### PR TITLE
Remove stability warning from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,6 @@ of websites. OpenWPM is built on top of Firefox, with automation provided
 by Selenium. It includes several hooks for data collection. Check out
 the instrumentation section below for more details.
 
-**Note**: The master branch OpenWPM is currently unstable while we push to
-complete the upgrade to WebExtensions. If you're running crawls we recommend
-using the `firefox-52-archive` branch, noting that it is running an outdated
-version of Firefox.
-
-
 Installation
 ------------
 


### PR DESCRIPTION
With the recent changes I think it's safe to say we no longer need to recommend folks to use the add-on sdk version of OpenWPM.