### PR TITLE
Revert workaround of manually creating user.js

### DIFF
--- a/docs/Release-Checklist.md
+++ b/docs/Release-Checklist.md
@@ -11,11 +11,10 @@ We aim to release a new version of OpenWPM with each new Firefox release (~1 rel
     2. Run `npm update` in `Extension/webext-instrumentation`.
     3. Run `npm update` in the base directory
 3. Update python and system dependencies by following the ["managing requirements" instructions](../CONTRIBUTING.md#managing-requirements).
-4. If a new version of geckodriver is used, check whether the default geckodriver browser preferences in [`openwpm/deploy_browsers/configure_firefox.py`](../openwpm/deploy_browsers/configure_firefox.py#L8L65) need to be updated.
-5. Increment the version number in [VERSION](../VERSION)
-6. Add a summary of changes since the last version to [CHANGELOG](../CHANGELOG.md)
-7. Squash and merge the release PR to master.
-8. Publish a new release from https://github.com/openwpm/OpenWPM/releases:
+4. Increment the version number in [VERSION](../VERSION)
+5. Add a summary of changes since the last version to [CHANGELOG](../CHANGELOG.md)
+6. Squash and merge the release PR to master.
+7. Publish a new release from https://github.com/openwpm/OpenWPM/releases:
     1. Click "Draft a new release".
     2. Enter the "Tag version" and "Release title" as `vX.X.X`.
     3. In the description:

--- a/openwpm/deploy_browsers/configure_firefox.py
+++ b/openwpm/deploy_browsers/configure_firefox.py
@@ -1,105 +1,10 @@
 """ Set prefs and load extensions in Firefox """
 
-import json
-import re
-from pathlib import Path
-from typing import Any, Dict
-
 from ..config import BrowserParams
-
-# TODO: Remove hardcoded geckodriver default preferences. See
-# https://github.com/openwpm/OpenWPM/issues/867
-# Source of preferences:
-# https://hg.mozilla.org/mozilla-central/file/tip/testing/geckodriver/src/prefs.rs
-# https://hg.mozilla.org/mozilla-central/file/tip/testing/geckodriver/src/marionette.rs
-DEFAULT_GECKODRIVER_PREFS = {
-    "app.normandy.api_url": "",
-    "app.update.checkInstallTime": False,
-    "app.update.disabledForTesting": True,
-    "app.update.auto": False,
-    "browser.dom.window.dump.enabled": True,
-    "devtools.console.stdout.chrome": True,
-    "browser.safebrowsing.blockedURIs.enabled": False,
-    "browser.safebrowsing.downloads.enabled": False,
-    "browser.safebrowsing.passwords.enabled": False,
-    "browser.safebrowsing.malware.enabled": False,
-    "browser.safebrowsing.phishing.enabled": False,
-    "browser.sessionstore.resume_from_crash": False,
-    "browser.shell.checkDefaultBrowser": False,
-    "browser.startup.homepage_override.mstone": "ignore",
-    "browser.startup.page": 0,
-    "browser.tabs.closeWindowWithLastTab": False,
-    "browser.tabs.warnOnClose": False,
-    "browser.uitour.enabled": False,
-    "browser.warnOnQuit": False,
-    "datareporting.healthreport.documentServerURI": "http://%(server)s/dummy/healthreport/",
-    "datareporting.healthreport.logging.consoleEnabled": False,
-    "datareporting.healthreport.service.enabled": False,
-    "datareporting.healthreport.service.firstRun": False,
-    "datareporting.healthreport.uploadEnabled": False,
-    "datareporting.policy.dataSubmissionEnabled": False,
-    "datareporting.policy.dataSubmissionPolicyBypassNotification": True,
-    "dom.ipc.reportProcessHangs": False,
-    "extensions.autoDisableScopes": 0,
-    "extensions.enabledScopes": 5,
-    "extensions.installDistroAddons": False,
-    "extensions.update.enabled": False,
-    "extensions.update.notifyUser": False,
-    "focusmanager.testmode": True,
-    "general.useragent.updates.enabled": False,
-    "geo.provider.testing": True,
-    "geo.wifi.scan": False,
-    "hangmonitor.timeout": 0,
-    "idle.lastDailyNotification": -1,
-    "javascript.options.showInConsole": True,
-    "media.gmp-manager.updateEnabled": False,
-    "media.sanity-test.disabled": True,
-    "network.http.phishy-userpass-length": 255,
-    "network.manage-offline-status": False,
-    "network.sntp.pools": "%(server)s",
-    "plugin.state.flash": 0,
-    "security.certerrors.mitm.priming.enabled": False,
-    "services.settings.server": "http://%(server)s/dummy/blocklist/",
-    "startup.homepage_welcome_url": "about:blank",
-    "startup.homepage_welcome_url.additional": "",
-    "toolkit.startup.max_resumed_crashes": -1,
-    "marionette.log.level": "Info",
-}
+from .selenium_firefox import Options
 
 
-def load_existing_prefs(browser_profile_path: Path) -> Dict[str, Any]:
-    """Load existing user preferences.
-
-    If the browser profile contains a user.js file, load the preferences
-    specified inside it into a dictionary.
-    """
-    prefs: Dict[str, Any] = {}
-    prefs_path = browser_profile_path / "user.js"
-    if not prefs_path.is_file():
-        return prefs
-    # Regular expression from https://stackoverflow.com/a/24563687
-    r = re.compile(r"\s*user_pref\(([\"'])(.+?)\1,\s*(.+?)\);")
-    with open(prefs_path, "r") as f:
-        for line in f:
-            m = r.match(line)
-            if m:
-                key, value = m.group(2), m.group(3)
-                prefs[key] = json.loads(value)
-    return prefs
-
-
-def save_prefs_to_profile(prefs: Dict[str, Any], browser_profile_path: Path) -> None:
-    """Save all preferences to the browser profile.
-
-    Write preferences from the prefs dictionary to a user.js file in the
-    profile directory.
-    """
-    with open(browser_profile_path / "user.js", "w") as f:
-        for key, value in prefs.items():
-            f.write('user_pref("%s", %s);\n' % (key, json.dumps(value)))
-
-
-def privacy(browser_params: BrowserParams, prefs: Dict[str, Any]) -> None:
+def privacy(browser_params: BrowserParams, fo: Options) -> None:
     """
     Configure the privacy settings in Firefox. This includes:
     * DNT
@@ -110,15 +15,15 @@ def privacy(browser_params: BrowserParams, prefs: Dict[str, Any]) -> None:
 
     # Turns on Do Not Track
     if browser_params.donottrack:
-        prefs["privacy.donottrackheader.enabled"] = True
+        fo.set_preference("privacy.donottrackheader.enabled", True)
 
     # Sets the third party cookie setting
     if browser_params.tp_cookies.lower() == "never":
-        prefs["network.cookie.cookieBehavior"] = 1
+        fo.set_preference("network.cookie.cookieBehavior", 1)
     elif browser_params.tp_cookies.lower() == "from_visited":
-        prefs["network.cookie.cookieBehavior"] = 3
+        fo.set_preference("network.cookie.cookieBehavior", 3)
     else:  # always allow third party cookies
-        prefs["network.cookie.cookieBehavior"] = 0
+        fo.set_preference("network.cookie.cookieBehavior", 0)
 
     # Tracking Protection
     if browser_params.tracking_protection:
@@ -129,7 +34,7 @@ def privacy(browser_params: BrowserParams, prefs: Dict[str, Any]) -> None:
         )
 
 
-def optimize_prefs(prefs: Dict[str, Any]) -> None:
+def optimize_prefs(fo: Options) -> None:
     """
     Disable various features and checks the browser will do on startup.
     Some of these (e.g. disabling the newtab page) are required to prevent
@@ -140,113 +45,113 @@ def optimize_prefs(prefs: Dict[str, Any]) -> None:
     * https://github.com/pyllyukko/user.js/blob/master/user.js
     """  # noqa
     # Startup / Speed
-    prefs["browser.shell.checkDefaultBrowser"] = False
-    prefs["browser.slowStartup.notificationDisabled"] = True
-    prefs["browser.slowStartup.maxSamples"] = 0
-    prefs["browser.slowStartup.samples"] = 0
-    prefs["extensions.checkCompatibility.nightly"] = False
-    prefs["browser.rights.3.shown"] = True
-    prefs["reader.parse-on-load.enabled"] = False
-    prefs["browser.pagethumbnails.capturing_disabled"] = True
-    prefs["browser.uitour.enabled"] = False
-    prefs["dom.flyweb.enabled"] = False
+    fo.set_preference("browser.shell.checkDefaultBrowser", False)
+    fo.set_preference("browser.slowStartup.notificationDisabled", True)
+    fo.set_preference("browser.slowStartup.maxSamples", 0)
+    fo.set_preference("browser.slowStartup.samples", 0)
+    fo.set_preference("extensions.checkCompatibility.nightly", False)
+    fo.set_preference("browser.rights.3.shown", True)
+    fo.set_preference("reader.parse-on-load.enabled", False)
+    fo.set_preference("browser.pagethumbnails.capturing_disabled", True)
+    fo.set_preference("browser.uitour.enabled", False)
+    fo.set_preference("dom.flyweb.enabled", False)
 
     # Disable health reports / telemetry / crash reports
-    prefs["datareporting.policy.dataSubmissionEnabled"] = False
-    prefs["datareporting.healthreport.uploadEnabled"] = False
-    prefs["datareporting.healthreport.service.enabled"] = False
-    prefs["toolkit.telemetry.archive.enabled"] = False
-    prefs["toolkit.telemetry.enabled"] = False
-    prefs["toolkit.telemetry.unified"] = False
-    prefs["breakpad.reportURL"] = ""
-    prefs["dom.ipc.plugins.reportCrashURL"] = False
-    prefs["browser.selfsupport.url"] = ""
-    prefs["browser.tabs.crashReporting.sendReport"] = False
-    prefs["browser.crashReports.unsubmittedCheck.enabled"] = False
-    prefs["dom.ipc.plugins.flash.subprocess.crashreporter.enabled"] = False
+    fo.set_preference("datareporting.policy.dataSubmissionEnabled", False)
+    fo.set_preference("datareporting.healthreport.uploadEnabled", False)
+    fo.set_preference("datareporting.healthreport.service.enabled", False)
+    fo.set_preference("toolkit.telemetry.archive.enabled", False)
+    fo.set_preference("toolkit.telemetry.enabled", False)
+    fo.set_preference("toolkit.telemetry.unified", False)
+    fo.set_preference("breakpad.reportURL", "")
+    fo.set_preference("dom.ipc.plugins.reportCrashURL", False)
+    fo.set_preference("browser.selfsupport.url", "")
+    fo.set_preference("browser.tabs.crashReporting.sendReport", False)
+    fo.set_preference("browser.crashReports.unsubmittedCheck.enabled", False)
+    fo.set_preference("dom.ipc.plugins.flash.subprocess.crashreporter.enabled", False)
 
     # Predictive Actions / Prefetch
-    prefs["network.predictor.enabled"] = False
-    prefs["network.dns.disablePrefetch"] = True
-    prefs["network.prefetch-next"] = False
-    prefs["browser.search.suggest.enabled"] = False
-    prefs["network.http.speculative-parallel-limit"] = 0
-    prefs["keyword.enabled"] = False  # location bar using search
-    prefs["browser.urlbar.userMadeSearchSuggestionsChoice"] = True
-    prefs["browser.casting.enabled"] = False
+    fo.set_preference("network.predictor.enabled", False)
+    fo.set_preference("network.dns.disablePrefetch", True)
+    fo.set_preference("network.prefetch-next", False)
+    fo.set_preference("browser.search.suggest.enabled", False)
+    fo.set_preference("network.http.speculative-parallel-limit", 0)
+    fo.set_preference("keyword.enabled", False)  # location bar using search
+    fo.set_preference("browser.urlbar.userMadeSearchSuggestionsChoice", True)
+    fo.set_preference("browser.casting.enabled", False)
 
     # Disable pinging Mozilla for geoip
-    prefs["browser.search.geoip.url"] = ""
-    prefs["browser.search.countryCode"] = "US"
-    prefs["browser.search.region"] = "US"
+    fo.set_preference("browser.search.geoip.url", "")
+    fo.set_preference("browser.search.countryCode", "US")
+    fo.set_preference("browser.search.region", "US")
 
     # Disable pinging Mozilla for geo-specific search
-    prefs["browser.search.geoSpecificDefaults"] = False
-    prefs["browser.search.geoSpecificDefaults.url"] = ""
+    fo.set_preference("browser.search.geoSpecificDefaults", False)
+    fo.set_preference("browser.search.geoSpecificDefaults.url", "")
 
     # Disable auto-updating
-    prefs["app.update.enabled"] = False  # browser
-    prefs["app.update.url"] = ""  # browser
-    prefs["browser.search.update"] = False  # search
-    prefs["extensions.update.enabled"] = False  # extensions
-    prefs["extensions.update.autoUpdateDefault"] = False
-    prefs["extensions.getAddons.cache.enabled"] = False
-    prefs["lightweightThemes.update.enabled"] = False  # Personas
+    fo.set_preference("app.update.enabled", False)  # browser
+    fo.set_preference("app.update.url", "")  # browser
+    fo.set_preference("browser.search.update", False)  # search
+    fo.set_preference("extensions.update.enabled", False)  # extensions
+    fo.set_preference("extensions.update.autoUpdateDefault", False)
+    fo.set_preference("extensions.getAddons.cache.enabled", False)
+    fo.set_preference("lightweightThemes.update.enabled", False)  # Personas
 
     # Disable Safebrowsing and other security features
     # that require on remote content
-    prefs["browser.safebrowsing.phising.enabled"] = False
-    prefs["browser.safebrowsing.malware.enabled"] = False
-    prefs["browser.safebrowsing.downloads.enabled"] = False
-    prefs["browser.safebrowsing.downloads.remote.enabled"] = False
-    prefs["browser.safebrowsing.blockedURIs.enabled"] = False
-    prefs["browser.safebrowsing.provider.mozilla.gethashURL"] = ""
-    prefs["browser.safebrowsing.provider.google.gethashURL"] = ""
-    prefs["browser.safebrowsing.provider.google4.gethashURL"] = ""
-    prefs["browser.safebrowsing.provider.mozilla.updateURL"] = ""
-    prefs["browser.safebrowsing.provider.google.updateURL"] = ""
-    prefs["browser.safebrowsing.provider.google4.updateURL"] = ""
-    prefs["browser.safebrowsing.provider.mozilla.lists"] = ""  # TP
-    prefs["browser.safebrowsing.provider.google.lists"] = ""  # TP
-    prefs["browser.safebrowsing.provider.google4.lists"] = ""  # TP
-    prefs["extensions.blocklist.enabled"] = False  # extensions
-    prefs["security.OCSP.enabled"] = 0
+    fo.set_preference("browser.safebrowsing.phising.enabled", False)
+    fo.set_preference("browser.safebrowsing.malware.enabled", False)
+    fo.set_preference("browser.safebrowsing.downloads.enabled", False)
+    fo.set_preference("browser.safebrowsing.downloads.remote.enabled", False)
+    fo.set_preference("browser.safebrowsing.blockedURIs.enabled", False)
+    fo.set_preference("browser.safebrowsing.provider.mozilla.gethashURL", "")
+    fo.set_preference("browser.safebrowsing.provider.google.gethashURL", "")
+    fo.set_preference("browser.safebrowsing.provider.google4.gethashURL", "")
+    fo.set_preference("browser.safebrowsing.provider.mozilla.updateURL", "")
+    fo.set_preference("browser.safebrowsing.provider.google.updateURL", "")
+    fo.set_preference("browser.safebrowsing.provider.google4.updateURL", "")
+    fo.set_preference("browser.safebrowsing.provider.mozilla.lists", "")  # TP
+    fo.set_preference("browser.safebrowsing.provider.google.lists", "")  # TP
+    fo.set_preference("browser.safebrowsing.provider.google4.lists", "")  # TP
+    fo.set_preference("extensions.blocklist.enabled", False)  # extensions
+    fo.set_preference("security.OCSP.enabled", 0)
 
     # Disable Content Decryption Module and OpenH264 related downloads
-    prefs["media.gmp-manager.url"] = ""
-    prefs["media.gmp-provider.enabled"] = False
-    prefs["media.gmp-widevinecdm.enabled"] = False
-    prefs["media.gmp-widevinecdm.visible"] = False
-    prefs["media.gmp-gmpopenh264.enabled"] = False
+    fo.set_preference("media.gmp-manager.url", "")
+    fo.set_preference("media.gmp-provider.enabled", False)
+    fo.set_preference("media.gmp-widevinecdm.enabled", False)
+    fo.set_preference("media.gmp-widevinecdm.visible", False)
+    fo.set_preference("media.gmp-gmpopenh264.enabled", False)
 
     # Disable Experiments
-    prefs["experiments.enabled"] = False
-    prefs["experiments.manifest.uri"] = ""
-    prefs["experiments.supported"] = False
-    prefs["experiments.activeExperiment"] = False
-    prefs["network.allow-experiments"] = False
+    fo.set_preference("experiments.enabled", False)
+    fo.set_preference("experiments.manifest.uri", "")
+    fo.set_preference("experiments.supported", False)
+    fo.set_preference("experiments.activeExperiment", False)
+    fo.set_preference("network.allow-experiments", False)
 
     # Disable pinging Mozilla for newtab
-    prefs["browser.newtabpage.directory.ping"] = ""
-    prefs["browser.newtabpage.directory.source"] = ""
-    prefs["browser.newtabpage.enabled"] = False
-    prefs["browser.newtabpage.enhanced"] = False
-    prefs["browser.newtabpage.introShown"] = True
-    prefs["browser.aboutHomeSnippets.updateUrl"] = ""
+    fo.set_preference("browser.newtabpage.directory.ping", "")
+    fo.set_preference("browser.newtabpage.directory.source", "")
+    fo.set_preference("browser.newtabpage.enabled", False)
+    fo.set_preference("browser.newtabpage.enhanced", False)
+    fo.set_preference("browser.newtabpage.introShown", True)
+    fo.set_preference("browser.aboutHomeSnippets.updateUrl", "")
 
     # Disable Pocket
-    prefs["extensions.pocket.enabled"] = False
+    fo.set_preference("extensions.pocket.enabled", False)
 
     # Disable Shield
-    prefs["app.shield.optoutstudies.enabled"] = False
-    prefs["extensions.shield-recipe-client.enabled"] = False
+    fo.set_preference("app.shield.optoutstudies.enabled", False)
+    fo.set_preference("extensions.shield-recipe-client.enabled", False)
 
     # Disable Source Pragmas
     # As per https://bugzilla.mozilla.org/show_bug.cgi?id=1628853
     # sourceURL can be used to obfuscate the original origin of
     # a script, we disable it.
-    prefs["javascript.options.source_pragmas"] = False
+    fo.set_preference("javascript.options.source_pragmas", False)
 
     # Enable extensions and disable extension signing
-    prefs["extensions.experiments.enabled"] = True
-    prefs["xpinstall.signatures.required"] = False
+    fo.set_preference("extensions.experiments.enabled", True)
+    fo.set_preference("xpinstall.signatures.required", False)

--- a/test/manual_test.py
+++ b/test/manual_test.py
@@ -29,7 +29,7 @@ from selenium.webdriver.common.keys import Keys  # noqa isort:skip
 OPENWPM_LOG_PREFIX = "console.log: openwpm: "
 INSERT_PREFIX = "Array"
 BASE_DIR = dirname(dirname(realpath(__file__)))
-EXT_PATH = join(BASE_DIR, "openwpm", "Extension", "firefox")
+EXT_PATH = join(BASE_DIR, "Extension", "firefox")
 
 
 class Logger:

--- a/test/manual_test.py
+++ b/test/manual_test.py
@@ -124,25 +124,13 @@ def start_webdriver(
     fo = Options()
     fo.add_argument("-profile")
     fo.add_argument(str(browser_profile_path))
-    # TODO: See https://github.com/openwpm/OpenWPM/issues/867 for when
-    # to remove manually creating user.js
-    prefs = configure_firefox.load_existing_prefs(browser_profile_path)
-    prefs.update(configure_firefox.DEFAULT_GECKODRIVER_PREFS)
 
     if with_extension:
         # TODO: Restore preference for log level in a way that works in Fx 57+
         # fp.set_preference("extensions.@openwpm.sdk.console.logLevel", "all")
-        configure_firefox.optimize_prefs(prefs)
+        configure_firefox.optimize_prefs(fo)
 
-    configure_firefox.save_prefs_to_profile(prefs, browser_profile_path)
-    driver = webdriver.Firefox(
-        firefox_binary=fb,
-        options=fo,
-        # Use the default Marionette port.
-        # TODO: See https://github.com/openwpm/OpenWPM/issues/867 for
-        # when to remove this
-        service_args=["--marionette-port", "2828"],
-    )
+    driver = webdriver.Firefox(firefox_binary=fb, options=fo)
     if load_browser_params is True:
         # There's probably more we could do here
         # to set more preferences and better emulate


### PR DESCRIPTION
Hi all! This PR reverts the workaround of manually creating the `user.js` file now that https://github.com/mozilla/geckodriver/issues/1844 has been fixed and the fix has been included in geckodriver v0.30.0.

Closes #867