### PR TITLE
chore(selenium): upgrade to selenium 4.1

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -29,7 +29,7 @@ dependencies:
 - recommonmark=0.7.1
 - redis-py=4.0.2
 - s3fs=2021.11.1
-- selenium=3.141.0
+- selenium=4.1.0
 - sentry-sdk=1.5.0
 - sphinx-markdown-tables=0.0.15
 - sphinx=4.3.1


### PR DESCRIPTION
Since `self.log_file` is not used in the constructor, it's okay to let Selenium open the file first, close it and then reopen it ourselves.
This way we don't have to maintain a full clone of the class in our repo, instead only modifying the behaviour we need.