### PR TITLE
Set custom temporary directory used by FF and delete it

### DIFF
--- a/openwpm/browser_manager.py
+++ b/openwpm/browser_manager.py
@@ -358,22 +358,6 @@ class BrowserManagerHandle:
                     )
                     return
 
-                # Delete the temporary directory used by geckodriver.
-                try:
-                    self.logger.debug(
-                        "BROWSER %i: deleting temp dir %s" %
-                        (self.browser_params.browser_id, 
-                            self.browser_params.tmpdir)
-                    )
-                    shutil.rmtree(self.browser_params.tmpdir)
-                    self.browser_params.tmpdir = None
-                except Exception as e:
-                    self.logger.warn(
-                        "BROWSER %i: failed to delete temp dir %s: %s" %
-                        (self.browser_params.browser_id, 
-                            self.browser_params.tmpdir,
-                            str(e))
-                )
                 self.logger.debug(
                     "BROWSER %i: Browser manager closed successfully." % self.browser_id
                 )
@@ -381,6 +365,23 @@ class BrowserManagerHandle:
         finally:
             if not shutdown_complete:
                 self.kill_browser_manager()
+
+            # Delete the temporary directory used by geckodriver.
+            try:
+                self.logger.debug(
+                    "BROWSER %i: deleting temp dir %s" %
+                    (self.browser_params.browser_id, 
+                        self.browser_params.tmpdir)
+                )
+                shutil.rmtree(self.browser_params.tmpdir)
+                self.browser_params.tmpdir = None
+            except Exception as e:
+                self.logger.warn(
+                    "BROWSER %i: failed to delete temp dir %s: %s" %
+                    (self.browser_params.browser_id, 
+                        self.browser_params.tmpdir,
+                        str(e))
+                )
 
     def execute_command_sequence(
         self,

--- a/openwpm/browser_manager.py
+++ b/openwpm/browser_manager.py
@@ -136,25 +136,26 @@ class BrowserManagerHandle:
         # use `tmpdir`, it just makes it available.
         if self.browser_params.tmpdir is not None:
             self.logger.debug(
-                "BROWSER %i: leftover temp directory %s?  Deleting it." %
-                (self.browser_params.browser_id, self.browser_params.tmpdir)
+                "BROWSER %i: leftover temp directory %s?  Deleting it."
+                % (self.browser_params.browser_id, self.browser_params.tmpdir)
             )
             try:
                 shutil.rmtree(self.browser_params.tmpdir)
             except Exception as e:
                 self.logger.debug(
-                    "BROWSER %i: error deleting %s: %s." %
-                    (self.browser_params.browser_id,
+                    "BROWSER %i: error deleting %s: %s."
+                    % (
+                        self.browser_params.browser_id,
                         self.browser_params.tmpdir,
-                        str(e))
+                        str(e),
+                    )
                 )
-        self.browser_params.tmpdir = Path(tempfile.mkdtemp(
-            prefix="openwpm_", 
-            dir=os.getenv('TMPDIR', default='/tmp')
-        ))
+        self.browser_params.tmpdir = Path(
+            tempfile.mkdtemp(prefix="openwpm_", dir=os.getenv("TMPDIR", default="/tmp"))
+        )
         self.logger.debug(
-            "BROWSER %i: Using temp dir %s" % 
-            (self.browser_params.browser_id, self.browser_params.tmpdir)
+            "BROWSER %i: Using temp dir %s"
+            % (self.browser_params.browser_id, self.browser_params.tmpdir)
         )
 
         self.logger.info("BROWSER %i: Launching browser..." % self.browser_id)
@@ -369,18 +370,19 @@ class BrowserManagerHandle:
             # Delete the temporary directory used by geckodriver.
             try:
                 self.logger.debug(
-                    "BROWSER %i: deleting temp dir %s" %
-                    (self.browser_params.browser_id, 
-                        self.browser_params.tmpdir)
+                    "BROWSER %i: deleting temp dir %s"
+                    % (self.browser_params.browser_id, self.browser_params.tmpdir)
                 )
                 shutil.rmtree(self.browser_params.tmpdir)
                 self.browser_params.tmpdir = None
             except Exception as e:
                 self.logger.warn(
-                    "BROWSER %i: failed to delete temp dir %s: %s" %
-                    (self.browser_params.browser_id, 
+                    "BROWSER %i: failed to delete temp dir %s: %s"
+                    % (
+                        self.browser_params.browser_id,
                         self.browser_params.tmpdir,
-                        str(e))
+                        str(e),
+                    )
                 )
 
     def execute_command_sequence(

--- a/openwpm/browser_manager.py
+++ b/openwpm/browser_manager.py
@@ -764,6 +764,21 @@ class BrowserManager(Process):
 
                 if isinstance(command, ShutdownSignal):
                     driver.quit()
+                    # Delete the temporary directory used by this browser.
+                    try:
+                        self.logger.debug(
+                            "BROWSER %i: deleting temp dir %s" %
+                            (self.browser_params.browser_id, 
+                                self.browser_params.tmpdir)
+                        )
+                        shutil.rmtree(self.browser_params.tmpdir)
+                    except Exception as e:
+                        self.logger.warn(
+                            "BROWSER %i: failed to delete temp dir %s: %s" %
+                            (self.browser_params.browser_id, 
+                                self.browser_params.tmpdir,
+                                str(e))
+                    )
                     self.status_queue.put("OK")
                     return
 

--- a/openwpm/browser_manager.py
+++ b/openwpm/browser_manager.py
@@ -134,6 +134,20 @@ class BrowserManagerHandle:
         # Create a unique temporary directory that we can delete
         # when we shut down.  Note that this doesn't force anything to
         # use `tmpdir`, it just makes it available.
+        if self.browser_params.tmpdir is not None:
+            self.logger.debug(
+                "BROWSER %i: leftover temp directory %s?  Deleting it." %
+                (self.browser_params.browser_id, self.browser_params.tmpdir)
+            )
+            try:
+                shutil.rmtree(self.browser_params.tmpdir)
+            except Exception as e:
+                self.logger.debug(
+                    "BROWSER %i: error deleting %s: %s." %
+                    (self.browser_params.browser_id,
+                        self.browser_params.tmpdir,
+                        str(e))
+                )
         self.browser_params.tmpdir = Path(tempfile.mkdtemp(
             prefix="openwpm_", 
             dir=os.getenv('TMPDIR', default='/tmp')
@@ -352,6 +366,7 @@ class BrowserManagerHandle:
                             self.browser_params.tmpdir)
                     )
                     shutil.rmtree(self.browser_params.tmpdir)
+                    self.browser_params.tmpdir = None
                 except Exception as e:
                     self.logger.warn(
                         "BROWSER %i: failed to delete temp dir %s: %s" %

--- a/openwpm/browser_manager.py
+++ b/openwpm/browser_manager.py
@@ -344,9 +344,24 @@ class BrowserManagerHandle:
                     )
                     return
 
-            self.logger.debug(
-                "BROWSER %i: Browser manager closed successfully." % self.browser_id
-            )
+                # Delete the temporary directory used by geckodriver.
+                try:
+                    self.logger.debug(
+                        "BROWSER %i: deleting temp dir %s" %
+                        (self.browser_params.browser_id, 
+                            self.browser_params.tmpdir)
+                    )
+                    shutil.rmtree(self.browser_params.tmpdir)
+                except Exception as e:
+                    self.logger.warn(
+                        "BROWSER %i: failed to delete temp dir %s: %s" %
+                        (self.browser_params.browser_id, 
+                            self.browser_params.tmpdir,
+                            str(e))
+                )
+                self.logger.debug(
+                    "BROWSER %i: Browser manager closed successfully." % self.browser_id
+                )
             shutdown_complete = True
         finally:
             if not shutdown_complete:
@@ -651,22 +666,6 @@ class BrowserManagerHandle:
         # Clean up temporary files
         if self.current_profile_path is not None:
             shutil.rmtree(self.current_profile_path, ignore_errors=True)
-
-        # Delete the temporary directory used by geckodriver.
-        try:
-            self.logger.debug(
-                "BROWSER %i: deleting temp dir %s" %
-                (self.browser_params.browser_id, 
-                    self.browser_params.tmpdir)
-            )
-            shutil.rmtree(self.browser_params.tmpdir)
-        except Exception as e:
-            self.logger.warn(
-                "BROWSER %i: failed to delete temp dir %s: %s" %
-                (self.browser_params.browser_id, 
-                    self.browser_params.tmpdir,
-                    str(e))
-        )
 
 
 class BrowserManager(Process):

--- a/openwpm/config.py
+++ b/openwpm/config.py
@@ -104,6 +104,7 @@ class BrowserParams(DataClassJsonMixin):
         default=Path(tempfile.gettempdir()),
         metadata=DCJConfig(encoder=path_to_str, decoder=str_to_path),
     )
+
     """
     The tmp_profile_dir defaults to the OS's temporary file folder (typically /tmp) and is where the generated 
     browser profiles and residual files are stored.
@@ -138,6 +139,18 @@ class BrowserParams(DataClassJsonMixin):
     * 73400320:  70MB
     * 104857600: 100MB - IDEAL for 10+ browsers
 
+    """
+
+    tmpdir: Path = field(
+        default=Path(tempfile.gettempdir()),
+        metadata=DCJConfig(encoder=path_to_str, decoder=str_to_path),
+    )
+    """
+    The temporary directory used by `geckodriver`.  This is confiured when the
+    browser is deployed in deploy_browsers.deploy_firefox.  We need it in order
+    to delete it when the browser is closed down, because `geckodriver` doesn't
+    appear to delete temporary files that it creates, such as a copy of the
+    extension XPI file.
     """
 
     recovery_tar: Optional[Path] = None

--- a/openwpm/config.py
+++ b/openwpm/config.py
@@ -141,16 +141,16 @@ class BrowserParams(DataClassJsonMixin):
 
     """
 
-    tmpdir: Path = field(
-        default=Path(tempfile.gettempdir()),
+    tmpdir: Optional[Path] = field(
+        default=None,
         metadata=DCJConfig(encoder=path_to_str, decoder=str_to_path),
     )
     """
-    The temporary directory used by `geckodriver`.  This is confiured when the
-    browser is deployed in deploy_browsers.deploy_firefox.  We need it in order
-    to delete it when the browser is closed down, because `geckodriver` doesn't
-    appear to delete temporary files that it creates, such as a copy of the
-    extension XPI file.
+    The temporary directory used by `geckodriver`.  This is configured in
+    `BrowserManager.run` and then deleted when the browser is finished.  We do
+    this because it seems that `geckodriver` doesn't clean up its temporary
+    files (in particular, a copy of the extension XPI file), so we need to do
+    so ourselves.
     """
 
     recovery_tar: Optional[Path] = None

--- a/openwpm/deploy_browsers/deploy_firefox.py
+++ b/openwpm/deploy_browsers/deploy_firefox.py
@@ -138,6 +138,19 @@ def deploy_firefox(
         )
         fo.set_preference(name, value)
 
+    # Create a temporary directory for this instance of geckodriver that
+    # we can delete later.
+    env = os.environ
+    browser_params.tmpdir = tempfile.mkdtemp(
+        prefix="openwpm_", 
+        dir=os.getenv('TMPDIR', default='/tmp')
+    )
+    env['TMPDIR'] = browser_params.tmpdir
+    logger.debug(
+        "BROWSER %i: Using temp dir %s" % 
+        (browser_params.browser_id, browser_params.tmpdir)
+    )
+
     # Launch the webdriver
     status_queue.put(("STATUS", "Launch Attempted", None))
 
@@ -150,6 +163,7 @@ def deploy_firefox(
         service=Service(
             executable_path=geckodriver_path,
             log_output=open(webdriver_interceptor.fifo, "w"),
+            env=env
         ),
     )
 

--- a/openwpm/deploy_browsers/deploy_firefox.py
+++ b/openwpm/deploy_browsers/deploy_firefox.py
@@ -138,21 +138,14 @@ def deploy_firefox(
         )
         fo.set_preference(name, value)
 
-    # Create a temporary directory for this instance of geckodriver that
-    # we can delete later.
-    env = os.environ
-    browser_params.tmpdir = tempfile.mkdtemp(
-        prefix="openwpm_", 
-        dir=os.getenv('TMPDIR', default='/tmp')
-    )
-    env['TMPDIR'] = browser_params.tmpdir
-    logger.debug(
-        "BROWSER %i: Using temp dir %s" % 
-        (browser_params.browser_id, browser_params.tmpdir)
-    )
-
     # Launch the webdriver
     status_queue.put(("STATUS", "Launch Attempted", None))
+
+    # Use browser_params.tmpdir as the temporary directory.  This is so that
+    # geckodriver makes its copy of the extension XPI file in tmpdir, so
+    # we can delete it later and not have it left behind.
+    env = os.environ
+    env['TMPDIR'] = str(browser_params.tmpdir)
 
     fo.binary_location = firefox_binary_path
     geckodriver_path = subprocess.check_output(

--- a/openwpm/deploy_browsers/deploy_firefox.py
+++ b/openwpm/deploy_browsers/deploy_firefox.py
@@ -147,7 +147,7 @@ def deploy_firefox(
     # copy of `os.environ` because I'm a little nervous about modifying the
     # OpenWPM process' environment.
     env = os.environ.copy()
-    env['TMPDIR'] = str(browser_params.tmpdir)
+    env["TMPDIR"] = str(browser_params.tmpdir)
 
     fo.binary_location = firefox_binary_path
     geckodriver_path = subprocess.check_output(
@@ -158,7 +158,7 @@ def deploy_firefox(
         service=Service(
             executable_path=geckodriver_path,
             log_output=open(webdriver_interceptor.fifo, "w"),
-            env=env
+            env=env,
         ),
     )
 

--- a/openwpm/deploy_browsers/deploy_firefox.py
+++ b/openwpm/deploy_browsers/deploy_firefox.py
@@ -143,8 +143,10 @@ def deploy_firefox(
 
     # Use browser_params.tmpdir as the temporary directory.  This is so that
     # geckodriver makes its copy of the extension XPI file in tmpdir, so
-    # we can delete it later and not have it left behind.
-    env = os.environ
+    # we can delete it later and not have it left behind.  I make a shallow
+    # copy of `os.environ` because I'm a little nervous about modifying the
+    # OpenWPM process' environment.
+    env = os.environ.copy()
     env['TMPDIR'] = str(browser_params.tmpdir)
 
     fo.binary_location = firefox_binary_path

--- a/scripts/install-firefox.sh
+++ b/scripts/install-firefox.sh
@@ -9,8 +9,7 @@ set -e
 # Note this script is **destructive** and will
 # remove the existing Firefox in the OpenWPM directory
 
-# TAG='d3c71a6fc9a1aecf1fe04f8de2fc0b816588e677' # FIREFOX_123_0_RELEASE
-TAG='6c033deedc28e5dadb0b99de7336cb6ebb336631' # FIREFOX_126_0_1_RELEASE
+TAG='d3c71a6fc9a1aecf1fe04f8de2fc0b816588e677' # FIREFOX_123_0_RELEASE
 
 case "$(uname -s)" in
 Darwin)

--- a/scripts/install-firefox.sh
+++ b/scripts/install-firefox.sh
@@ -9,7 +9,8 @@ set -e
 # Note this script is **destructive** and will
 # remove the existing Firefox in the OpenWPM directory
 
-TAG='d3c71a6fc9a1aecf1fe04f8de2fc0b816588e677' # FIREFOX_123_0_RELEASE
+# TAG='d3c71a6fc9a1aecf1fe04f8de2fc0b816588e677' # FIREFOX_123_0_RELEASE
+TAG='6c033deedc28e5dadb0b99de7336cb6ebb336631' # FIREFOX_126_0_1_RELEASE
 
 case "$(uname -s)" in
 Darwin)


### PR DESCRIPTION
This pull request modifies OpenWPM as follows:
- When a browser is launched, a custom temporary directory is created.
- Before `geckodriver` is started, the TMPDIR environment variable is set in the environment used by `geckodriver`.
- When the browser terminates, the custom temporary directory is deleted.

The proximate rationale for doing this is that when `geckodriver` adds the OpenWPM extension to FF, it makes a copy of the XPI file in its temporary directory.  Unfortunately, it doesn't delete it.  That means one copy of the XPI file for each browser that is launched is left behind in `/tmp`.  On a big stateless crawl, that's a lot of copies.  We can't find out the name of the temporary file that `geckodriver` creates to delete it ourselves, and we don't want to just delete all XPI files in `/tmp` because we don't actually know to whom the all belong.  This approach seems to resolve these problems.

This patch is based on v.0.28.0.

See #1090.
