### PR TITLE
chore(conda): remove main channel

### DIFF
--- a/docs/Release-Checklist.md
+++ b/docs/Release-Checklist.md
@@ -6,11 +6,12 @@ We aim to release a new version of OpenWPM with each new Firefox release (~1 rel
     1. Go to: <https://hg.mozilla.org/releases/mozilla-release/tags>.
     2. Find the commit hash for the Firefox release version you'd like to upgrade to.
     3. Update the `TAG` variable in [`scripts/install-firefox.sh`](../scripts/install-firefox.sh#L12) to that hash and the comment to the new tag name.
-2. Run `./scripts/update.sh`
-3. Increment the version number in [VERSION](../VERSION)
-4. Add a summary of changes since the last version to [CHANGELOG](../CHANGELOG.md)
-5. Squash and merge the release PR to master.
-6. Publish a new release from <https://github.com/openwpm/OpenWPM/releases>:
+2. Check if we can unpin our python version (this requires Linux to test) See <https://github.com/openwpm/OpenWPM/issues/1111>
+3. Run `./scripts/update.sh`
+4. Increment the version number in [VERSION](../VERSION)
+5. Add a summary of changes since the last version to [CHANGELOG](../CHANGELOG.md)
+6. Squash and merge the release PR to master.
+7. Publish a new release from <https://github.com/openwpm/OpenWPM/releases>:
     1. Click "Draft a new release".
     2. Enter the "Tag version" and "Release title" as `vX.X.X`.
     3. In the description:

--- a/environment.yaml
+++ b/environment.yaml
@@ -1,6 +1,5 @@
 channels:
 - conda-forge
-- main
 dependencies:
 - beautifulsoup4=4.12.3
 - black=24.10.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -4976,9 +4976,9 @@
       "license": "MIT"
     },
     "node_modules/undici": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.0.tgz",
-      "integrity": "sha512-BUgJXc752Kou3oOIuU1i+yZZypyZRqNPW0vqoMPl8VaoalSfeR0D8/t4iAS3yirs79SSMTxTag+ZC86uswv+Cw==",
+      "version": "6.21.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.1.tgz",
+      "integrity": "sha512-q/1rj5D0/zayJB2FraXdaWxbhWiNKDvu8naDT2dl1yTlvJp4BLtOcp2a5BvgGNQpYYJzau7tf1WgKv3b+7mqpQ==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/scripts/environment-unpinned.yaml
+++ b/scripts/environment-unpinned.yaml
@@ -1,7 +1,6 @@
 name: openwpm
 channels:
     - conda-forge
-    - main
 dependencies:
     - beautifulsoup4
     - click

--- a/scripts/environment-unpinned.yaml
+++ b/scripts/environment-unpinned.yaml
@@ -18,7 +18,8 @@ dependencies:
     - plyvel
     - psutil
     - pyarrow
-    - python
+    # See https://github.com/openwpm/OpenWPM/issues/1111
+    - python=3.12
     - pyvirtualdisplay
     - redis-py
     - s3fs
@@ -28,7 +29,7 @@ dependencies:
     - tblib
     - wget
     - pip:
-        - jsonschema
-        - domain-utils
         - dataclasses-json
+        - domain-utils
+        - jsonschema
         - tranco

--- a/scripts/repin.sh
+++ b/scripts/repin.sh
@@ -38,7 +38,7 @@ esac
 
 
 # Export the environment including manually specify channels
-conda env export --no-builds --override-channels -c conda-forge -c main -f ../environment.yaml
+conda env export --no-builds --override-channels -c conda-forge -f ../environment.yaml
 
 # Prune environment file to only things we want to pin
 python prune-environment.py


### PR DESCRIPTION
By using the conda-forge channel exclusively we should get the most up-to-date software

See https://github.com/openwpm/OpenWPM/issues/1111 for the second commit