### PR TITLE
fix(coverage): collect coverage from multiprocess child processes

### DIFF
--- a/openwpm/browser_manager.py
+++ b/openwpm/browser_manager.py
@@ -15,7 +15,7 @@ from queue import Empty as EmptyQueue
 from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple, Type, Union
 
 import psutil
-from multiprocess import Process, Queue
+from multiprocess import Queue
 from selenium.common.exceptions import WebDriverException
 from tblib import Traceback, pickling_support
 
@@ -31,6 +31,7 @@ from .socket_interface import ClientSocket
 from .storage.storage_providers import TableName
 from .types import BrowserId, VisitId
 from .utilities.multiprocess_utils import (
+    Process,
     kill_process_and_children,
     parse_traceback_for_sentry,
 )
@@ -726,7 +727,7 @@ class BrowserManager(Process):
         success_filename.unlink()
         return extension_socket
 
-    def run(self) -> None:
+    def run_impl(self) -> None:
         assert self.browser_params.browser_id is not None
         display = None
 
@@ -821,4 +822,3 @@ class BrowserManager(Process):
         finally:
             if display is not None:
                 display.stop()
-            return

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -22,6 +22,23 @@ EXTENSION_DIR = os.path.join(
 pytest_plugins = "test.storage.fixtures"
 
 
+@pytest.fixture(scope="session", autouse=True)
+def enable_subprocess_coverage():
+    """Enable coverage collection in child processes when running under coverage."""
+    try:
+        import coverage
+
+        # Only set this if we're actually measuring coverage
+        if coverage.Coverage.current() is not None:
+            project_root = Path(__file__).parent.parent
+            os.environ["COVERAGE_PROCESS_START"] = str(project_root / "pyproject.toml")
+            # Ensure child processes write .coverage files to the project
+            # root where pytest-cov can find and combine them.
+            os.environ["COVERAGE_FILE"] = str(project_root / ".coverage")
+    except ImportError:
+        pass
+
+
 def xpi():
     # Creates a new xpi using npm run build.
     print("Building new xpi")


### PR DESCRIPTION
## Summary

- OpenWPM uses the third-party `multiprocess` library (a `dill`-based fork of stdlib `multiprocessing`), so coverage.py's built-in `concurrency` and `patch` settings don't instrument child processes
- Additionally, `multiprocess` uses `os._exit()` after `Process.run()`, which skips atexit handlers and prevents coverage from saving data
- Adds `coverage.process_startup()` and explicit `cov.stop()`/`cov.save()` in the `Process` wrapper, using a template method pattern (`run`/`run_impl`) so the logic lives in one place
- Adds a pytest fixture to set `COVERAGE_PROCESS_START` and `COVERAGE_FILE` env vars during coverage runs
- BrowserManager now uses the common `Process` wrapper and overrides `run_impl()` instead of `run()`

Fixes #1121