### PR TITLE
refactor: extract CommandExecutionContext to decouple BrowserManagerHandle from TaskManager

### DIFF
--- a/openwpm/browser_manager.py
+++ b/openwpm/browser_manager.py
@@ -12,13 +12,14 @@ import time
 import traceback
 from pathlib import Path
 from queue import Empty as EmptyQueue
-from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple, Type, Union
+from typing import Any, Dict, Optional, Tuple, Type, Union
 
 import psutil
 from multiprocess import Queue
 from selenium.common.exceptions import WebDriverException
 from tblib import Traceback, pickling_support
 
+from .command_execution_context import CommandExecutionContext
 from .command_sequence import CommandSequence
 from .commands.browser_commands import FinalizeCommand
 from .commands.profile_commands import dump_profile
@@ -31,6 +32,7 @@ from .errors import (
     BrowserCrashError,
     ProfileLoadError,
 )
+from .failure_tracker import CommandFailure
 from .socket_interface import ClientSocket
 from .storage.storage_providers import TableName
 from .types import BrowserId, VisitId
@@ -42,9 +44,6 @@ from .utilities.multiprocess_utils import (
 from .utilities.storage_watchdog import profile_size_exceeds_max_size
 
 pickling_support.install()
-
-if TYPE_CHECKING:
-    from .task_manager import TaskManager
 
 
 def is_dns_error(command_status: str, error_text: Optional[str]) -> bool:
@@ -362,16 +361,23 @@ class BrowserManagerHandle:
 
     def execute_command_sequence(
         self,
-        # Quoting to break cyclic import, see https://stackoverflow.com/a/39757388
-        task_manager: "TaskManager",
+        context: CommandExecutionContext,
         command_sequence: CommandSequence,
     ) -> None:
         """
-        Sends CommandSequence to the BrowserManager one command at a time
+        Sends CommandSequence to the BrowserManager one command at a time.
+
+        Parameters
+        ----------
+        context : CommandExecutionContext
+            Provides storage and failure tracking without requiring a
+            direct reference to TaskManager.
+        command_sequence : CommandSequence
+            The sequence of commands to execute.
         """
         assert self.browser_id is not None
         assert self.curr_visit_id is not None
-        task_manager.sock.store_record(
+        context.store_record(
             TableName("site_visits"),
             self.curr_visit_id,
             {
@@ -431,11 +437,9 @@ class BrowserManagerHandle:
                     "process while executing command %s. Setting failure "
                     "status." % (self.browser_id, str(command))
                 )
-                task_manager.failure_status = {
-                    "ErrorType": "CriticalChildException",
-                    "CommandSequence": command_sequence,
-                    "Exception": status[1],
-                }
+                context.failure_tracker.set_critical_failure(
+                    "CriticalChildException", command_sequence, exception=status[1]
+                )
                 error_text, tb = self._unpack_pickled_error(status[1])
             elif status[0] == "FAILED":
                 command_status = "error"
@@ -455,7 +459,7 @@ class BrowserManagerHandle:
             else:
                 raise ValueError("Unknown browser status message %s" % status)
 
-            task_manager.sock.store_record(
+            context.store_record(
                 TableName("crawl_history"),
                 self.curr_visit_id,
                 {
@@ -474,29 +478,32 @@ class BrowserManagerHandle:
             )
 
             if command_status == "critical":
-                task_manager.sock.finalize_visit_id(
-                    success=False,
+                context.finalize_visit_id(
                     visit_id=self.curr_visit_id,
+                    success=False,
                 )
                 return
 
             if command_status != "ok":
                 if not is_dns_error(command_status, error_text):
-                    with task_manager.threadlock:
-                        task_manager.failure_count += 1
-                        exceeded_limit = (
-                            task_manager.failure_count > task_manager.failure_limit
+                    over_limit = context.failure_tracker.record_failure(
+                        CommandFailure(
+                            browser_id=self.browser_id,
+                            command=repr(command),
+                            command_status=command_status,
+                            error=error_text,
+                            traceback=tb,
                         )
-                    if exceeded_limit:
+                    )
+                    if over_limit:
                         self.logger.critical(
                             "BROWSER %i: Command execution failure pushes failure "
                             "count above the allowable limit. Setting "
                             "failure_status." % self.browser_id
                         )
-                        task_manager.failure_status = {
-                            "ErrorType": "ExceedCommandFailureLimit",
-                            "CommandSequence": command_sequence,
-                        }
+                        context.failure_tracker.set_critical_failure(
+                            "ExceedCommandFailureLimit", command_sequence
+                        )
                         return
                 self.restart_required = True
                 self.logger.debug(
@@ -504,13 +511,10 @@ class BrowserManagerHandle:
                 )
             # Reset failure_count at the end of each successful command sequence
             elif type(command) is FinalizeCommand:
-                with task_manager.threadlock:
-                    task_manager.failure_count = 0
+                context.failure_tracker.reset()
 
             if self.restart_required:
-                task_manager.sock.finalize_visit_id(
-                    success=False, visit_id=self.curr_visit_id
-                )
+                context.finalize_visit_id(visit_id=self.curr_visit_id, success=False)
                 break
 
         self.logger.info(
@@ -523,7 +527,7 @@ class BrowserManagerHandle:
         # internal buffers to drain. Stopgap in support of #135
         time.sleep(2)
 
-        if task_manager.closing:
+        if context.closing:
             return
 
         # Allow StorageWatchdog to utilize built-in browser reset functionality
@@ -543,10 +547,9 @@ class BrowserManagerHandle:
                     "BROWSER %i: Exceeded the maximum allowable consecutive "
                     "browser launch failures. Setting failure_status." % self.browser_id
                 )
-                task_manager.failure_status = {
-                    "ErrorType": "ExceedLaunchFailureLimit",
-                    "CommandSequence": command_sequence,
-                }
+                context.failure_tracker.set_critical_failure(
+                    "ExceedLaunchFailureLimit", command_sequence
+                )
                 return
             self.restart_required = False
 

--- a/openwpm/command_execution_context.py
+++ b/openwpm/command_execution_context.py
@@ -1,0 +1,32 @@
+"""Protocol for the context needed by BrowserManagerHandle to execute commands.
+
+This decouples BrowserManagerHandle from the concrete TaskManager class,
+allowing tests to provide lightweight mock implementations.
+"""
+
+from typing import Any, Dict, Protocol
+
+from .failure_tracker import FailureTracker
+from .storage.storage_providers import TableName
+from .types import VisitId
+
+
+class CommandExecutionContext(Protocol):
+    """Interface that BrowserManagerHandle needs from the TaskManager.
+
+    TaskManager implements this protocol. Tests can provide a lightweight
+    mock with a real FailureTracker but no storage/browser infrastructure.
+    """
+
+    closing: bool
+    failure_tracker: FailureTracker
+
+    def store_record(
+        self, table: TableName, visit_id: VisitId, data: Dict[str, Any]
+    ) -> None:
+        """Send a record to the StorageController."""
+        ...
+
+    def finalize_visit_id(self, visit_id: VisitId, success: bool) -> None:
+        """Signal that all data for a visit_id has been sent."""
+        ...

--- a/openwpm/failure_tracker.py
+++ b/openwpm/failure_tracker.py
@@ -1,0 +1,114 @@
+"""Tracks command execution failures and determines when to halt crawling.
+
+There are two failure mechanisms:
+
+1. **Consecutive failure tracking** — Each non-ok command status is recorded
+   via ``record_failure``.  After a successful command sequence the list is
+   cleared.  When the number of recorded failures exceeds ``failure_limit``
+   the tracker escalates to a critical failure.
+
+2. **Critical failure** — An immediate halt signal set by
+   ``set_critical_failure``.  Three situations trigger this:
+   - A browser process sends a CRITICAL status (``CriticalChildException``).
+   - The consecutive failure limit is exceeded (``ExceedCommandFailureLimit``).
+   - A browser fails to relaunch (``ExceedLaunchFailureLimit``).
+"""
+
+import threading
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+from .command_sequence import CommandSequence
+from .types import BrowserId
+
+
+@dataclass(frozen=True)
+class CommandFailure:
+    """A single command execution failure.
+
+    Attributes
+    ----------
+    browser_id
+        The browser that experienced the failure.
+    command
+        Human-readable representation of the command that failed.
+    command_status
+        The status string reported by the browser process
+        (e.g. ``"timeout"``, ``"error"``, ``"neterror"``).
+    error
+        Optional error message extracted from the browser process.
+    traceback
+        Optional JSON-encoded traceback from the browser process.
+    """
+
+    browser_id: BrowserId
+    command: str
+    command_status: str
+    error: Optional[str] = None
+    traceback: Optional[str] = None
+
+
+class FailureTracker:
+    """Thread-safe tracker for command execution failures.
+
+    Used by ``BrowserManagerHandle`` to report failures without needing a
+    direct reference to ``TaskManager``.  The ``TaskManager`` checks
+    ``has_critical_failure`` periodically and shuts down if it is set.
+
+    The recorded ``failures`` list preserves context across consecutive
+    failures so that common causes can be identified (e.g. all failures
+    from the same browser, or all the same error type).
+    """
+
+    def __init__(self, failure_limit: int) -> None:
+        self.failure_limit = failure_limit
+        self.failures: List[CommandFailure] = []
+        self.critical_failure: Optional[Dict[str, Any]] = None
+        self.lock = threading.Lock()
+
+    def record_failure(self, failure: CommandFailure) -> bool:
+        """Record a command failure.
+
+        Returns ``True`` when the number of consecutive failures exceeds
+        ``failure_limit``, indicating that the crawl should be halted.
+        """
+        with self.lock:
+            self.failures.append(failure)
+            return len(self.failures) > self.failure_limit
+
+    def reset(self) -> None:
+        """Clear recorded failures after a successful command sequence."""
+        with self.lock:
+            self.failures.clear()
+
+    def set_critical_failure(
+        self,
+        error_type: str,
+        command_sequence: CommandSequence,
+        exception: Optional[bytes] = None,
+    ) -> None:
+        """Record a critical failure that should halt crawling immediately.
+
+        Parameters
+        ----------
+        error_type
+            One of ``"CriticalChildException"``,
+            ``"ExceedCommandFailureLimit"``, or
+            ``"ExceedLaunchFailureLimit"``.
+        command_sequence
+            The command sequence that triggered the failure.
+        exception
+            Pickled exception info for ``CriticalChildException``.
+        """
+        status: Dict[str, Any] = {
+            "ErrorType": error_type,
+            "CommandSequence": command_sequence,
+        }
+        if exception is not None:
+            status["Exception"] = exception
+        self.critical_failure = status
+
+    @property
+    def has_critical_failure(self) -> bool:
+        """Check if a critical failure has been recorded."""
+        return self.critical_failure is not None

--- a/openwpm/failure_tracker.py
+++ b/openwpm/failure_tracker.py
@@ -16,7 +16,7 @@ There are two failure mechanisms:
 
 import threading
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional
+from typing import List, Optional
 
 from .command_sequence import CommandSequence
 from .types import BrowserId
@@ -48,6 +48,26 @@ class CommandFailure:
     traceback: Optional[str] = None
 
 
+@dataclass(frozen=True)
+class CriticalFailure:
+    """A failure that should halt the entire crawl immediately.
+
+    Attributes
+    ----------
+    error_type
+        One of ``"CriticalChildException"``,
+        ``"ExceedCommandFailureLimit"``, or ``"ExceedLaunchFailureLimit"``.
+    command_sequence
+        The command sequence that triggered the failure.
+    exception
+        Pickled exception info, only set for ``"CriticalChildException"``.
+    """
+
+    error_type: str
+    command_sequence: CommandSequence
+    exception: Optional[bytes] = None
+
+
 class FailureTracker:
     """Thread-safe tracker for command execution failures.
 
@@ -63,7 +83,7 @@ class FailureTracker:
     def __init__(self, failure_limit: int) -> None:
         self.failure_limit = failure_limit
         self.failures: List[CommandFailure] = []
-        self.critical_failure: Optional[Dict[str, Any]] = None
+        self.critical_failure: Optional[CriticalFailure] = None
         self.lock = threading.Lock()
 
     def record_failure(self, failure: CommandFailure) -> bool:
@@ -100,15 +120,18 @@ class FailureTracker:
         exception
             Pickled exception info for ``CriticalChildException``.
         """
-        status: Dict[str, Any] = {
-            "ErrorType": error_type,
-            "CommandSequence": command_sequence,
-        }
-        if exception is not None:
-            status["Exception"] = exception
-        self.critical_failure = status
+        with self.lock:
+            self.critical_failure = CriticalFailure(
+                error_type=error_type,
+                command_sequence=command_sequence,
+                exception=exception,
+            )
 
-    @property
-    def has_critical_failure(self) -> bool:
-        """Check if a critical failure has been recorded."""
-        return self.critical_failure is not None
+    def get_critical_failure(self) -> Optional[CriticalFailure]:
+        """Return the recorded critical failure, if any.
+
+        Reads the critical failure under the lock so callers observe a
+        consistent snapshot in a single atomic step.
+        """
+        with self.lock:
+            return self.critical_failure

--- a/openwpm/task_manager.py
+++ b/openwpm/task_manager.py
@@ -351,27 +351,27 @@ class TaskManager:
         appropriate steps are taken to gracefully close the infrastructure
         """
         self.logger.debug("Checking command failure status indicator...")
-        if not self.failure_tracker.has_critical_failure:
+        failure_status = self.failure_tracker.get_critical_failure()
+        if failure_status is None:
             return
 
-        failure_status = self.failure_tracker.critical_failure
-        assert failure_status is not None
         self.logger.debug("TaskManager failure status set, halting command execution.")
         self._shutdown_manager()
-        if failure_status["ErrorType"] == "ExceedCommandFailureLimit":
+        if failure_status.error_type == "ExceedCommandFailureLimit":
             raise CommandExecutionError(
                 "TaskManager exceeded maximum consecutive command "
                 "execution failures.",
-                failure_status["CommandSequence"],
+                failure_status.command_sequence,
             )
-        elif failure_status["ErrorType"] == "ExceedLaunchFailureLimit":
+        elif failure_status.error_type == "ExceedLaunchFailureLimit":
             raise CommandExecutionError(
                 "TaskManager failed to launch browser within allowable "
                 "failure limit.",
-                failure_status["CommandSequence"],
+                failure_status.command_sequence,
             )
-        if failure_status["ErrorType"] == "CriticalChildException":
-            _, exc, tb = pickle.loads(failure_status["Exception"])
+        if failure_status.error_type == "CriticalChildException":
+            assert failure_status.exception is not None
+            _, exc, tb = pickle.loads(failure_status.exception)
             raise exc.with_traceback(tb)
 
     # CRAWLER COMMAND CODE


### PR DESCRIPTION
## Summary
- Extract `FailureTracker` class from TaskManager's inline failure tracking fields
- Define `CommandExecutionContext` protocol that BrowserManagerHandle depends on instead of TaskManager directly
- Update BrowserManagerHandle to use the protocol, breaking the circular dependency
- TaskManager implements the protocol via `store_record()` and `finalize_visit_id()` methods

This enables mock-based unit testing of BrowserManagerHandle without needing a full TaskManager.

Stacked on #1124.