### PR TITLE
perf: reduce fixed sleeps in test mode

### DIFF
--- a/openwpm/browser_manager.py
+++ b/openwpm/browser_manager.py
@@ -504,7 +504,8 @@ class BrowserManagerHandle:
         )
         # Sleep after executing CommandSequence to provide extra time for
         # internal buffers to drain. Stopgap in support of #135
-        time.sleep(2)
+        drain_sleep = 0.1 if self.manager_params.testing else 2
+        time.sleep(drain_sleep)
 
         if context.closing:
             return

--- a/openwpm/commands/browser_commands.py
+++ b/openwpm/commands/browser_commands.py
@@ -484,7 +484,8 @@ class FinalizeCommand(BaseCommand):
         tab_restart_browser(webdriver)
         # This doesn't immediately stop data saving from the current
         # visit so we sleep briefly before unsetting the visit_id.
-        time.sleep(self.sleep)
+        sleep = 0.1 if manager_params.testing else self.sleep
+        time.sleep(sleep)
         msg = {"action": "Finalize", "visit_id": self.visit_id}
         extension_socket.send(msg)
 


### PR DESCRIPTION
## Summary
- Reduce the 2s post-CommandSequence drain sleep to 0.1s when `manager_params.testing` is True
- Reduce the 5s FinalizeCommand sleep to 0.1s when `manager_params.testing` is True
- Production behavior unchanged

These are stopgap sleeps (documented as support for #135) that add ~7s per visit in tests.

Stacked on #1126.