### PR TITLE
feat: add extension-to-BrowserManager finalize ack

### DIFF
--- a/Extension/bundled/privileged/sockets/schema.json
+++ b/Extension/bundled/privileged/sockets/schema.json
@@ -73,6 +73,25 @@
             "name": "id"
           }
         ]
+      },
+      {
+        "name": "sendResponse",
+        "type": "function",
+        "async": false,
+        "parameters": [
+          {
+            "type": "number",
+            "name": "connectionId"
+          },
+          {
+            "type": "string",
+            "name": "data"
+          },
+          {
+            "type": "boolean",
+            "name": "json"
+          }
+        ]
       }
     ],
     "events": [
@@ -91,6 +110,10 @@
           {
             "type": "boolean",
             "name": "json"
+          },
+          {
+            "type": "number",
+            "name": "connectionId"
           }
         ]
       }

--- a/Extension/src/loggingdb.ts
+++ b/Extension/src/loggingdb.ts
@@ -1,4 +1,5 @@
 import * as socket from "./socket";
+import { RespondFn } from "./socket";
 
 let crawlID = null;
 let visitID = null;
@@ -7,7 +8,7 @@ let storageController = null;
 let logAggregator = null;
 let listeningSocket = null;
 
-const listeningSocketCallback = async (data) => {
+const listeningSocketCallback = async (data, respond: RespondFn) => {
   // This works even if data is an int
   const action = data.action;
   let newVisitID = data.visit_id;
@@ -34,6 +35,11 @@ const listeningSocketCallback = async (data) => {
       data.success = true;
       storageController.send(JSON.stringify(["meta_information", data]));
       visitID = null;
+      respond({
+        action: "FinalizeAck",
+        visit_id: newVisitID,
+        success: true,
+      });
       break;
     default:
       // Just making sure that it's a valid number before logging

--- a/Extension/src/socket.ts
+++ b/Extension/src/socket.ts
@@ -1,15 +1,25 @@
 /* eslint-disable max-classes-per-file */
 
+export type RespondFn = (msg: any) => void;
+
 const DataReceiver = {
   callbacks: new Map(),
-  onDataReceived: (aSocketId: number, aData: string, aJSON: boolean): void => {
+  onDataReceived: (
+    aSocketId: number,
+    aData: string,
+    aJSON: boolean,
+    aConnectionId: number,
+  ): void => {
     if (!DataReceiver.callbacks.has(aSocketId)) {
       return;
     }
     if (aJSON) {
       aData = JSON.parse(aData);
     }
-    DataReceiver.callbacks.get(aSocketId)(aData);
+    const respond: RespondFn = (msg: any) => {
+      browser.sockets.sendResponse(aConnectionId, JSON.stringify(msg), true);
+    };
+    DataReceiver.callbacks.get(aSocketId)(aData, respond);
   },
 };
 

--- a/Extension/src/types/browser.d.ts
+++ b/Extension/src/types/browser.d.ts
@@ -4,9 +4,15 @@ declare namespace browser.profileDirIO {
 }
 
 declare namespace browser.sockets {
+  export type ConnectionId = number;
   export const onDataReceived: {
     addListener(
-      receiver: (socketId: number, data: string, isJson: boolean) => void,
+      receiver: (
+        socketId: number,
+        data: string,
+        isJson: boolean,
+        connectionId: ConnectionId,
+      ) => void,
     ): void;
   };
   export type ServerSocketId = number;
@@ -24,5 +30,10 @@ declare namespace browser.sockets {
     data: string,
     json: boolean,
   ): void;
+  export function sendResponse(
+    connectionId: ConnectionId,
+    data: string,
+    json: boolean,
+  ): boolean;
   export function close(id: SendingSocketId | ServerSocketId): void;
 }

--- a/openwpm/commands/browser_commands.py
+++ b/openwpm/commands/browser_commands.py
@@ -488,12 +488,23 @@ class FinalizeCommand(BaseCommand):
     ):
         """Informs the extension that a visit is done"""
         tab_restart_browser(webdriver)
-        # This doesn't immediately stop data saving from the current
-        # visit so we sleep briefly before unsetting the visit_id.
-        sleep = 0.1 if manager_params.testing else self.sleep
-        time.sleep(sleep)
         msg = {"action": "Finalize", "visit_id": self.visit_id}
         extension_socket.send(msg)
+        # Wait for the extension to acknowledge it has flushed all events
+        # for this visit. Falls back to a timeout if the ack is not received.
+        timeout = 0.5 if manager_params.testing else self.sleep
+        try:
+            ack = extension_socket.receive(timeout=timeout)
+            logger.debug(
+                "Received finalize ack for visit_id %s: %s",
+                self.visit_id,
+                ack,
+            )
+        except Exception:
+            logger.warning(
+                "Timed out waiting for finalize ack for visit_id %s",
+                self.visit_id,
+            )
 
 
 class InitializeCommand(BaseCommand):


### PR DESCRIPTION
## Summary

Replaces the fixed sleep in `FinalizeCommand` with a bidirectional ack from the WebExtension. When the extension finishes processing a Finalize message (forwarding to StorageController, clearing visitID), it sends a `FinalizeAck` response back on the same TCP connection. Python reads this ack instead of sleeping.

- Make the privileged sockets API bidirectional: open `outputStream` on accepted connections, add `sendResponse()` API, pass `connectionId` through `onDataReceived`
- Extension sends `FinalizeAck` after processing Finalize in `loggingdb.ts`
- Add `receive()` method to `ClientSocket` in `socket_interface.py`
- `FinalizeCommand` waits for ack with timeout fallback (0.5s test / 5s prod)

Stacked on #1128.