### PR TITLE
ci: replace codecov package with codecov-action and add actionlint

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -53,3 +53,26 @@ jobs:
           name: ${{matrix.test-groups}} # Name of the check run which will be created
           path: junit-report.xml # Path to test results
           reporter: java-junit # Format of test results
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: coverage-${{ strategy.job-index }}
+          path: coverage.xml
+
+  upload-coverage:
+    runs-on: ubuntu-latest
+    needs: tests
+    if: always()
+    steps:
+      - uses: actions/checkout@v4
+      - name: Download all coverage artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: coverage-*
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          directory: .
+          fail_ci_if_error: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,6 +16,10 @@ repos:
           [pytest, types-tabulate, types-PyYAML, types-redis]
         # We may need to add more and more dependencies here, as pre-commit
         # runs in an environment without our dependencies
+  - repo: https://github.com/rhysd/actionlint
+    rev: v1.7.11
+    hooks:
+      - id: actionlint
   - repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook
     rev: v9.11.0
     hooks:

--- a/environment.yaml
+++ b/environment.yaml
@@ -4,7 +4,6 @@ dependencies:
 - beautifulsoup4=4.12.3
 - black=24.10.0
 - click=8.1.8
-- codecov=2.1.13
 - dill=0.3.9
 - easyprocess=1.1
 - gcsfs=2024.12.0

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -1,9 +1,3 @@
 #!/bin/bash
 
 python -m pytest --cov=openwpm --junit-xml=junit-report.xml --cov-report=xml $TESTS -s -v --durations=10;
-exit_code=$?;
-if [[ "$exit_code" -ne 0 ]]; then
-    exit $exit_code;
-fi
-codecov -f coverage.xml;
-

--- a/scripts/environment-unpinned-dev.yaml
+++ b/scripts/environment-unpinned-dev.yaml
@@ -2,7 +2,6 @@ channels:
     - conda-forge
 dependencies:
     - black
-    - codecov
     - pytest-cov
     - ipython
     - isort


### PR DESCRIPTION
## Summary
- Remove the unmaintained Python `codecov` package from conda dependencies and `scripts/ci.sh`
- Upload coverage as artifacts from each test matrix job, then aggregate and upload once via `codecov/codecov-action@v5` in a new `upload-coverage` job — avoids Codecov rate limiting from 7 parallel uploads
- Add `actionlint` pre-commit hook to lint GitHub Actions workflow files

Closes #1133

## Test plan
- [ ] Verify CI workflow runs successfully with the new `upload-coverage` job
- [ ] Confirm Codecov receives a single aggregated coverage upload
- [ ] Verify `actionlint` pre-commit hook catches workflow syntax issues