### PR TITLE
refactor(test): use dynamic ports and fixture injection for test parallelization

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -13,6 +13,7 @@ from openwpm.task_manager import TaskManager
 
 from . import utilities
 from .openwpmtest import NUM_BROWSERS
+from .utilities import ServerUrls
 
 EXTENSION_DIR = os.path.join(
     os.path.dirname(os.path.realpath(__file__)),
@@ -52,10 +53,10 @@ def xpi_fixture():
 
 @pytest.fixture(scope="session")
 def server():
-    """Run an HTTP server during the tests."""
+    """Run an HTTP server during the tests and yield its URLs."""
     print("Starting local_http_server")
-    server, server_thread = utilities.start_server()
-    yield
+    server, server_thread, urls = utilities.start_server()
+    yield urls
     print("\nClosing server thread...")
     server.shutdown()
     server_thread.join()
@@ -85,7 +86,7 @@ TaskManagerCreator: TypeAlias = Callable[[FullConfig], Tuple[TaskManager, Path]]
 
 
 @pytest.fixture()
-def task_manager_creator(server: None, xpi: None) -> TaskManagerCreator:
+def task_manager_creator(server: ServerUrls, xpi: None) -> TaskManagerCreator:
     """We create a callable that returns a TaskManager that has
     been configured with the Manager and BrowserParams"""
 

--- a/test/manual_test.py
+++ b/test/manual_test.py
@@ -17,7 +17,7 @@ from openwpm.deploy_browsers import configure_firefox
 from openwpm.utilities.platform_utils import get_firefox_binary_path
 
 from .conftest import xpi
-from .utilities import BASE_TEST_URL, start_server
+from .utilities import start_server
 
 # import commonly used modules and utilities so they can be easily accessed
 # in the interactive session
@@ -103,10 +103,10 @@ def start_webdriver(
     firefox_binary_path = get_firefox_binary_path()
 
     fb = FirefoxBinary(firefox_path=firefox_binary_path)
-    server, thread = start_server()
+    server, thread, urls = start_server()
 
     def register_cleanup(driver):
-        driver.get(BASE_TEST_URL)
+        driver.get(urls.base)
 
         def cleanup_server():
             print("Cleanup before shutdown...")
@@ -160,12 +160,12 @@ def start_webdriver(
 
 def start_webext():
     firefox_binary_path = get_firefox_binary_path()
+    server, thread, urls = start_server()
     cmd_webext_run = f"""
     npm start -- \
-            --start-url '{BASE_TEST_URL}' \
+            --start-url '{urls.base}' \
             --firefox '{firefox_binary_path}'
     """
-    server, thread = start_server()
     try:
         # http://stackoverflow.com/a/4417735/3104416
         for line in get_command_output(cmd_webext_run, cwd=EXT_PATH):

--- a/test/openwpmtest.py
+++ b/test/openwpmtest.py
@@ -8,7 +8,7 @@ from openwpm import task_manager
 from openwpm.config import BrowserParams, ManagerParams
 from openwpm.storage.sql_provider import SQLiteStorageProvider
 
-from . import utilities
+from .utilities import ServerUrls
 
 NUM_BROWSERS = 2
 
@@ -23,6 +23,11 @@ class OpenWPMTest:
         https://mail.python.org/pipermail/pytest-dev/2014-April/002484.html
         """
         self.tmpdir = Path(tmpdir)
+
+    @pytest.fixture(autouse=True)
+    def set_server(self, server: ServerUrls) -> None:
+        """Inject server URLs for use in test methods."""
+        self.server = server
 
     def get_config(
         self, data_dir: Optional[Path]
@@ -46,7 +51,7 @@ class OpenWPMTest:
             None,
         )
         if not page_url.startswith("http"):
-            page_url = utilities.BASE_TEST_URL + page_url
+            page_url = self.server.base + page_url
         manager.get(url=page_url, sleep=sleep_after)
         manager.close()
         return db_path

--- a/test/test_callback.py
+++ b/test/test_callback.py
@@ -4,16 +4,18 @@ from typing import List
 from openwpm.command_sequence import CommandSequence
 
 from .conftest import FullConfig, TaskManagerCreator
-from .utilities import BASE_TEST_URL
+from .utilities import ServerUrls
 
 
 def test_local_callbacks(
-    default_params: FullConfig, task_manager_creator: TaskManagerCreator
+    default_params: FullConfig,
+    task_manager_creator: TaskManagerCreator,
+    server: ServerUrls,
 ) -> None:
     """Test the storage controller as well as the entire callback machinery
     to see if all callbacks get correctly called"""
     manager, _ = task_manager_creator(default_params)
-    TEST_SITE = BASE_TEST_URL + "/test_pages/simple_a.html"
+    TEST_SITE = server.base + "/simple_a.html"
 
     def callback(argument: List[int], success: bool) -> None:
         argument.extend([1, 2, 3])

--- a/test/test_callstack_instrument.py
+++ b/test/test_callstack_instrument.py
@@ -2,39 +2,38 @@ import pytest
 
 from openwpm.utilities import db_utils
 
-from . import utilities
-
-# HTTP request call stack instrumentation
-# Expected stack frames
-HTTP_STACKTRACE_TEST_URL = utilities.BASE_TEST_URL + "/http_stacktrace.html"
-STACK_TRACE_INJECT_IMAGE = (
-    "inject_image@" + HTTP_STACKTRACE_TEST_URL + ":18:7;null\n"
-    "inject_all@" + HTTP_STACKTRACE_TEST_URL + ":22:7;null\n"
-    "onload@" + HTTP_STACKTRACE_TEST_URL + ":1:1;null"
-)
+from .conftest import FullConfig, TaskManagerCreator
+from .utilities import ServerUrls
 
 RAWGIT_HTTP_STACKTRACE_TEST_URL = "https://gist.githack.com/gunesacar/b927d3fe69f3e7bf456da5192f74beea/raw/8d3e490b5988c633101ec45ef1443e61b1fd495e/inject_pixel.js"  # noqa
-# https://gist.github.com/gunesacar/b927d3fe69f3e7bf456da5192f74beea
-STACK_TRACE_INJECT_PIXEL = (
-    "inject_pixel@" + RAWGIT_HTTP_STACKTRACE_TEST_URL + ":4:3;null\n"
-    "null@" + RAWGIT_HTTP_STACKTRACE_TEST_URL + ":6:1;null"
-)
 
-STACK_TRACE_INJECT_JS = (
-    "inject_js@" + HTTP_STACKTRACE_TEST_URL + ":13:28;null\n"
-    "inject_all@" + HTTP_STACKTRACE_TEST_URL + ":21:7;null\n"
-    "onload@" + HTTP_STACKTRACE_TEST_URL + ":1:1;null"
-)
 
-HTTP_STACKTRACES = {
-    STACK_TRACE_INJECT_IMAGE,
-    STACK_TRACE_INJECT_PIXEL,
-    STACK_TRACE_INJECT_JS,
-}
+def _http_stacktraces(base_url: str) -> set[str]:
+    """Build expected stack traces (needs dynamic base_url)."""
+    url = base_url + "/http_stacktrace.html"
+    inject_image = (
+        f"inject_image@{url}:18:7;null\n"
+        f"inject_all@{url}:22:7;null\n"
+        f"onload@{url}:1:1;null"
+    )
+    inject_pixel = (
+        f"inject_pixel@{RAWGIT_HTTP_STACKTRACE_TEST_URL}:4:3;null\n"
+        f"null@{RAWGIT_HTTP_STACKTRACE_TEST_URL}:6:1;null"
+    )
+    inject_js = (
+        f"inject_js@{url}:13:28;null\n"
+        f"inject_all@{url}:21:7;null\n"
+        f"onload@{url}:1:1;null"
+    )
+    return {inject_image, inject_pixel, inject_js}
 
 
 @pytest.mark.skip("We don't have the resources to fix this")
-def test_http_stacktrace(default_params, task_manager_creator):
+def test_http_stacktrace(
+    default_params: FullConfig,
+    task_manager_creator: TaskManagerCreator,
+    server: ServerUrls,
+) -> None:
     manager_params, browser_params = default_params
     for browser_param in browser_params:
         # Record HTTP Requests and Responses
@@ -43,7 +42,7 @@ def test_http_stacktrace(default_params, task_manager_creator):
         browser_param.js_instrument = True
         # Record the callstack of all WebRequests made
         browser_param.callstack_instrument = True
-    test_url = utilities.BASE_TEST_URL + "/http_stacktrace.html"
+    test_url = server.base + "/http_stacktrace.html"
     manager, db = task_manager_creator((manager_params, browser_params))
     manager.get(test_url, sleep=10)
     manager.close()
@@ -59,10 +58,11 @@ def test_http_stacktrace(default_params, task_manager_creator):
         ),
     )
     print("Printing callstacks contents")
-    observed_records = set()
+    observed_records: set[str] = set()
     for row in rows:
+        assert not isinstance(row, tuple)
         print(row["call_stack"])
-        url, call_stack = row
+        url, call_stack = row["url"], row["call_stack"]
         test_urls = (
             "inject_pixel.js",
             "test_image.png",
@@ -70,4 +70,4 @@ def test_http_stacktrace(default_params, task_manager_creator):
         )
         if url.endswith(test_urls):
             observed_records.add(call_stack)
-    assert HTTP_STACKTRACES == observed_records
+    assert _http_stacktraces(server.base) == observed_records

--- a/test/test_custom_function_command.py
+++ b/test/test_custom_function_command.py
@@ -12,24 +12,25 @@ from openwpm.storage.storage_providers import TableName
 from openwpm.task_manager import TaskManager
 from openwpm.utilities import db_utils
 
-from . import utilities
+from .conftest import FullConfig
+from .utilities import ServerUrls
 
-url_a = utilities.BASE_TEST_URL + "/simple_a.html"
 
-PAGE_LINKS = {
-    (
-        f"{utilities.BASE_TEST_URL}/simple_a.html",
-        f"{utilities.BASE_TEST_URL}/simple_c.html",
-    ),
-    (
-        f"{utilities.BASE_TEST_URL}/simple_a.html",
-        f"{utilities.BASE_TEST_URL}/simple_d.html",
-    ),
-    (
-        f"{utilities.BASE_TEST_URL}/simple_a.html",
-        "http://example.com/test.html?localhost",
-    ),
-}
+def _page_links(base: str) -> set:
+    return {
+        (
+            f"{base}/simple_a.html",
+            f"{base}/simple_c.html",
+        ),
+        (
+            f"{base}/simple_a.html",
+            f"{base}/simple_d.html",
+        ),
+        (
+            f"{base}/simple_a.html",
+            "http://example.com/test.html?localhost",
+        ),
+    }
 
 
 class CollectLinksCommand(BaseCommand):
@@ -77,9 +78,12 @@ class CollectLinksCommand(BaseCommand):
         sock.close()
 
 
-def test_custom_function(default_params, xpi, server):
+def test_custom_function(
+    default_params: FullConfig, xpi: None, server: ServerUrls
+) -> None:
     """Test `custom_function` with an inline func that collects links"""
     table_name = TableName("page_links")
+    url_a = server.base + "/simple_a.html"
 
     manager_params, browser_params = default_params
     path = manager_params.data_directory / "crawl-data.sqlite"
@@ -104,4 +108,4 @@ def test_custom_function(default_params, xpi, server):
         "SELECT top_url, link FROM page_links;",
         as_tuple=True,
     )
-    assert PAGE_LINKS == set(query_result)
+    assert _page_links(server.base) == set(query_result)

--- a/test/test_dns_instrument.py
+++ b/test/test_dns_instrument.py
@@ -1,21 +1,27 @@
 from sqlite3 import Row
+from typing import cast
 from urllib.parse import urlparse
 
 from openwpm.utilities import db_utils
 
-from . import utilities
+from .conftest import FullConfig, TaskManagerCreator
+from .utilities import ServerUrls
 
 
-def test_name_resolution(default_params, task_manager_creator):
+def test_name_resolution(
+    default_params: FullConfig,
+    task_manager_creator: TaskManagerCreator,
+    server: ServerUrls,
+) -> None:
     manager_params, browser_params = default_params
     for browser_param in browser_params:
         browser_param.dns_instrument = True
 
     manager, db = task_manager_creator((manager_params, browser_params))
-    manager.get("http://test.localhost:8000")
+    manager.get(f"http://test.localhost:{server.port}")
     manager.close()
 
-    results = db_utils.query_db(db, "SELECT * FROM dns_responses")
+    results = cast("list[Row]", db_utils.query_db(db, "SELECT * FROM dns_responses"))
     result = results[0]
     assert isinstance(result, Row)
     assert result["used_address"] == "127.0.0.1"
@@ -23,14 +29,18 @@ def test_name_resolution(default_params, task_manager_creator):
     assert result["hostname"] == "test.localhost"
     assert result["canonical_name"] == "test.localhost"
     assert result["redirect_url"] is not None
-    assert "test.localhost:8000" in result["redirect_url"]
+    assert f"test.localhost:{server.port}" in result["redirect_url"]
 
     # Each redirect hop should record the URL it was associated with
     redirect_urls = [r["redirect_url"] for r in results]
     assert all(url is not None for url in redirect_urls)
 
 
-def test_dns_captured_on_connection_abort(default_params, task_manager_creator):
+def test_dns_captured_on_connection_abort(
+    default_params: FullConfig,
+    task_manager_creator: TaskManagerCreator,
+    server: ServerUrls,
+) -> None:
     """Regression test: DNS data must be captured even when the connection
     aborts before completion. This verifies that the extension uses
     onHeadersReceived (not onCompleted) to record DNS responses."""
@@ -39,7 +49,7 @@ def test_dns_captured_on_connection_abort(default_params, task_manager_creator):
         browser_param.dns_instrument = True
 
     manager, db = task_manager_creator((manager_params, browser_params))
-    manager.get("http://localhost:8000/CONNECTION_ABORT/")
+    manager.get(f"http://localhost:{server.port}/CONNECTION_ABORT/")
     manager.close()
 
     results = db_utils.query_db(db, "SELECT * FROM dns_responses")
@@ -51,7 +61,10 @@ def test_dns_captured_on_connection_abort(default_params, task_manager_creator):
     assert result["hostname"] == "localhost"
 
 
-def test_dns_failure_captured(default_params, task_manager_creator):
+def test_dns_failure_captured(
+    default_params: FullConfig,
+    task_manager_creator: TaskManagerCreator,
+) -> None:
     """DNS failures (NXDOMAIN) should be captured via onErrorOccurred
     with error details and null addresses."""
     manager_params, browser_params = default_params
@@ -63,7 +76,7 @@ def test_dns_failure_captured(default_params, task_manager_creator):
     manager.get("http://example.invalid/")
     manager.close()
 
-    results = db_utils.query_db(db, "SELECT * FROM dns_responses")
+    results = cast("list[Row]", db_utils.query_db(db, "SELECT * FROM dns_responses"))
     assert len(results) > 0, "No DNS responses captured for failed resolution"
     # Find the row for example.invalid
     dns_failure = [r for r in results if "example.invalid" in (r["hostname"] or "")]
@@ -75,7 +88,11 @@ def test_dns_failure_captured(default_params, task_manager_creator):
     assert result["error"] is not None
 
 
-def test_redirect_chain_dns(default_params, task_manager_creator):
+def test_redirect_chain_dns(
+    default_params: FullConfig,
+    task_manager_creator: TaskManagerCreator,
+    server: ServerUrls,
+) -> None:
     """A 2-hop redirect chain (hop1 -> hop2 -> simple_b.html) should produce
     exactly three dns_responses rows that, ordered by time_stamp, reconstruct
     the original chain — one row per redirect step, all sharing the same
@@ -88,7 +105,7 @@ def test_redirect_chain_dns(default_params, task_manager_creator):
     manager, db = task_manager_creator((manager_params, browser_params))
 
     chain_url = (
-        f"http://test.localhost:{utilities.LOCAL_WEBSERVER_PORT}"
+        f"http://test.localhost:{server.port}"
         f"/MAGIC_REDIRECT/hop1"
         f"?dst=/MAGIC_REDIRECT/hop2"
         f"&dst=/test_pages/simple_b.html"
@@ -101,10 +118,13 @@ def test_redirect_chain_dns(default_params, task_manager_creator):
         "/MAGIC_REDIRECT/hop2",
         "/test_pages/simple_b.html",
     ]
-    rows = db_utils.query_db(
-        db,
-        "SELECT * FROM dns_responses WHERE hostname = 'test.localhost' "
-        "ORDER BY time_stamp",
+    rows = cast(
+        "list[Row]",
+        db_utils.query_db(
+            db,
+            "SELECT * FROM dns_responses WHERE hostname = 'test.localhost' "
+            "ORDER BY time_stamp",
+        ),
     )
     chain_rows = [r for r in rows if urlparse(r["redirect_url"]).path in expected_paths]
 

--- a/test/test_extension.py
+++ b/test/test_extension.py
@@ -16,7 +16,6 @@ from openwpm.config import BrowserParams, ManagerParams
 from openwpm.socket_interface import ClientSocket
 from openwpm.utilities import db_utils
 
-from . import utilities
 from .openwpmtest import OpenWPMTest
 
 # Expected Navigator and Screen properties
@@ -43,72 +42,80 @@ PROPERTIES = {
 }
 
 # Canvas Fingerprinting DB calls and property sets
-CANVAS_TEST_URL = "%s/canvas_fingerprinting.html" % utilities.BASE_TEST_URL
 
-CANVAS_CALLS = {
-    (CANVAS_TEST_URL, "CanvasRenderingContext2D.fillStyle", "set", "#f60", None),
-    (
-        CANVAS_TEST_URL,
-        "CanvasRenderingContext2D.textBaseline",
-        "set",
-        "alphabetic",
-        None,
-    ),
-    (CANVAS_TEST_URL, "CanvasRenderingContext2D.textBaseline", "set", "top", None),
-    (CANVAS_TEST_URL, "CanvasRenderingContext2D.font", "set", "14px 'Arial'", None),
-    (CANVAS_TEST_URL, "CanvasRenderingContext2D.fillStyle", "set", "#069", None),
-    (
-        CANVAS_TEST_URL,
-        "CanvasRenderingContext2D.fillStyle",
-        "set",
-        "rgba(102, 204, 0, 0.7)",
-        None,
-    ),
-    (CANVAS_TEST_URL, "HTMLCanvasElement.getContext", "call", "", '["2d"]'),
-    (
-        CANVAS_TEST_URL,
-        "CanvasRenderingContext2D.fillRect",
-        "call",
-        "",
-        "[125,1,62,20]",
-    ),
-    (CANVAS_TEST_URL, "HTMLCanvasElement.toDataURL", "call", "", None),
-    (
-        CANVAS_TEST_URL,
-        "CanvasRenderingContext2D.fillText",
-        "call",
-        "",
-        '["BrowserLeaks,com <canvas> 1.0",4,17]',
-    ),
-    (
-        CANVAS_TEST_URL,
-        "CanvasRenderingContext2D.fillText",
-        "call",
-        "",
-        '["BrowserLeaks,com <canvas> 1.0",2,15]',
-    ),
-}
 
-WEBRTC_TEST_URL = "%s/webrtc_localip.html" % utilities.BASE_TEST_URL
+def expected_canvas_calls(canvas_test_url: str) -> set:
+    return {
+        (canvas_test_url, "CanvasRenderingContext2D.fillStyle", "set", "#f60", None),
+        (
+            canvas_test_url,
+            "CanvasRenderingContext2D.textBaseline",
+            "set",
+            "alphabetic",
+            None,
+        ),
+        (canvas_test_url, "CanvasRenderingContext2D.textBaseline", "set", "top", None),
+        (
+            canvas_test_url,
+            "CanvasRenderingContext2D.font",
+            "set",
+            "14px 'Arial'",
+            None,
+        ),
+        (canvas_test_url, "CanvasRenderingContext2D.fillStyle", "set", "#069", None),
+        (
+            canvas_test_url,
+            "CanvasRenderingContext2D.fillStyle",
+            "set",
+            "rgba(102, 204, 0, 0.7)",
+            None,
+        ),
+        (canvas_test_url, "HTMLCanvasElement.getContext", "call", "", '["2d"]'),
+        (
+            canvas_test_url,
+            "CanvasRenderingContext2D.fillRect",
+            "call",
+            "",
+            "[125,1,62,20]",
+        ),
+        (canvas_test_url, "HTMLCanvasElement.toDataURL", "call", "", None),
+        (
+            canvas_test_url,
+            "CanvasRenderingContext2D.fillText",
+            "call",
+            "",
+            '["BrowserLeaks,com <canvas> 1.0",4,17]',
+        ),
+        (
+            canvas_test_url,
+            "CanvasRenderingContext2D.fillText",
+            "call",
+            "",
+            '["BrowserLeaks,com <canvas> 1.0",2,15]',
+        ),
+    }
 
-WEBRTC_CALLS = {
-    (
-        WEBRTC_TEST_URL,
-        "RTCPeerConnection.createOffer",
-        "call",
-        "",
-        '["FUNCTION","FUNCTION"]',
-    ),
-    (WEBRTC_TEST_URL, "RTCPeerConnection.createDataChannel", "call", "", '[""]'),
-    (
-        WEBRTC_TEST_URL,
-        "RTCPeerConnection.createDataChannel",
-        "call",
-        "",
-        '["","{\\"reliable\\":false}"]',
-    ),
-    (WEBRTC_TEST_URL, "RTCPeerConnection.onicecandidate", "set", "FUNCTION", None),
-}
+
+def expected_webrtc_calls(webrtc_test_url: str) -> set:
+    return {
+        (
+            webrtc_test_url,
+            "RTCPeerConnection.createOffer",
+            "call",
+            "",
+            '["FUNCTION","FUNCTION"]',
+        ),
+        (webrtc_test_url, "RTCPeerConnection.createDataChannel", "call", "", '[""]'),
+        (
+            webrtc_test_url,
+            "RTCPeerConnection.createDataChannel",
+            "call",
+            "",
+            '["","{\\"reliable\\":false}"]',
+        ),
+        (webrtc_test_url, "RTCPeerConnection.onicecandidate", "set", "FUNCTION", None),
+    }
+
 
 # we expect these strings to be present in the WebRTC SDP
 WEBRTC_SDP_OFFER_STRINGS = (
@@ -150,111 +157,111 @@ AUDIO_SYMBOLS = {
     "OscillatorNode.stop",
 }
 
-JS_STACK_TEST_URL = "%s/js_call_stack.html" % utilities.BASE_TEST_URL
-JS_STACK_TEST_SCRIPT_URL = "%s/stack.js" % utilities.BASE_TEST_URL
 
-JS_STACK_CALLS = {
-    (
-        JS_STACK_TEST_URL,
-        "1",
-        "1",
-        "",
-        "line 10 > eval",
-        "",
-        "window.navigator.appName",
-        "get",
-    ),
-    (
-        JS_STACK_TEST_SCRIPT_URL,
-        "3",
-        "17",
-        "js_check_navigator",
-        "",
-        "",
-        "window.navigator.userAgent",
-        "get",
-    ),
-    (
-        JS_STACK_TEST_SCRIPT_URL,
-        "1",
-        "1",
-        "",
-        "line 4 > eval",
-        "",
-        "window.navigator.platform",
-        "get",
-    ),
-    (
-        JS_STACK_TEST_SCRIPT_URL,
-        "1",
-        "1",
-        "",
-        "line 11 > eval",
-        "",
-        "window.navigator.buildID",
-        "get",
-    ),
-    (
-        JS_STACK_TEST_SCRIPT_URL,
-        "3",
-        "1",
-        "anonymous",
-        "line 14 > Function",
-        "",
-        "window.navigator.appVersion",
-        "get",
-    ),
-    (
-        JS_STACK_TEST_URL,
-        "7",
+def expected_js_stack_calls(base_url: str) -> set:
+    js_stack_test_url = base_url + "/js_call_stack.html"
+    js_stack_test_script_url = base_url + "/stack.js"
+    return {
+        (
+            js_stack_test_url,
+            "1",
+            "1",
+            "",
+            "line 10 > eval",
+            "",
+            "window.navigator.appName",
+            "get",
+        ),
+        (
+            js_stack_test_script_url,
+            "3",
+            "17",
+            "js_check_navigator",
+            "",
+            "",
+            "window.navigator.userAgent",
+            "get",
+        ),
+        (
+            js_stack_test_script_url,
+            "1",
+            "1",
+            "",
+            "line 4 > eval",
+            "",
+            "window.navigator.platform",
+            "get",
+        ),
+        (
+            js_stack_test_script_url,
+            "1",
+            "1",
+            "",
+            "line 11 > eval",
+            "",
+            "window.navigator.buildID",
+            "get",
+        ),
+        (
+            js_stack_test_script_url,
+            "3",
+            "1",
+            "anonymous",
+            "line 14 > Function",
+            "",
+            "window.navigator.appVersion",
+            "get",
+        ),
+        (
+            js_stack_test_url,
+            "7",
+            "21",
+            "check_navigator",
+            "",
+            "",
+            "window.navigator.userAgent",
+            "get",
+        ),
+        (
+            js_stack_test_url,
+            "1",
+            "1",
+            "",
+            "line 8 > eval",
+            "",
+            "window.navigator.appCodeName",
+            "get",
+        ),
+    }
+
+
+def expected_document_cookie_read_write(base_url: str) -> set:
+    js_cookie_test_url = base_url + "/js_cookie.html"
+    document_cookie_read = (
+        js_cookie_test_url,
+        "8",
         "21",
-        "check_navigator",
+        "set_cookie",
         "",
-        "",
-        "window.navigator.userAgent",
+        "set_cookie@" + js_cookie_test_url + ":8:21"
+        "\nonload@" + js_cookie_test_url + ":1:1",
+        "window.document.cookie",
         "get",
-    ),
-    (
-        JS_STACK_TEST_URL,
-        "1",
-        "1",
+        "test_cookie=Test-0123456789",
+    )
+    document_cookie_write = (
+        js_cookie_test_url,
+        "7",
+        "9",
+        "set_cookie",
         "",
-        "line 8 > eval",
-        "",
-        "window.navigator.appCodeName",
-        "get",
-    ),
-}
-
-JS_COOKIE_TEST_URL = "%s/js_cookie.html" % utilities.BASE_TEST_URL
-
-DOCUMENT_COOKIE_READ = (
-    JS_COOKIE_TEST_URL,
-    "8",
-    "21",
-    "set_cookie",
-    "",
-    "set_cookie@" + JS_COOKIE_TEST_URL + ":8:21"
-    "\nonload@" + JS_COOKIE_TEST_URL + ":1:1",
-    "window.document.cookie",
-    "get",
-    "test_cookie=Test-0123456789",
-)
-
-DOCUMENT_COOKIE_WRITE = (
-    JS_COOKIE_TEST_URL,
-    "7",
-    "9",
-    "set_cookie",
-    "",
-    "set_cookie@" + JS_COOKIE_TEST_URL + ":7:9"
-    "\nonload@" + JS_COOKIE_TEST_URL + ":1:1",
-    "window.document.cookie",
-    "set",
-    "test_cookie=Test-0123456789; " "expires=Tue, 31 Dec 2030 00:00:00 UTC; path=/",
-)
-
-DOCUMENT_COOKIE_READ_WRITE = {DOCUMENT_COOKIE_READ, DOCUMENT_COOKIE_WRITE}
+        "set_cookie@" + js_cookie_test_url + ":7:9"
+        "\nonload@" + js_cookie_test_url + ":1:1",
+        "window.document.cookie",
+        "set",
+        "test_cookie=Test-0123456789; " "expires=Tue, 31 Dec 2030 00:00:00 UTC; path=/",
+    )
+    return {document_cookie_read, document_cookie_write}
 
 
 class TestExtension(OpenWPMTest):
@@ -266,7 +273,7 @@ class TestExtension(OpenWPMTest):
         return manager_params, browser_params
 
     def test_property_enumeration(self) -> None:
-        test_url = utilities.BASE_TEST_URL + "/property_enumeration.html"
+        test_url = self.server.base + "/property_enumeration.html"
         db = self.visit(test_url)
         rows = db_utils.query_db(db, "SELECT script_url, symbol FROM javascript")
         observed_symbols = set()
@@ -290,11 +297,12 @@ class TestExtension(OpenWPMTest):
                 row["arguments"],
             )
             observed_rows.add(item)
-        assert CANVAS_CALLS == observed_rows
+        canvas_test_url = self.server.base + "/canvas_fingerprinting.html"
+        assert expected_canvas_calls(canvas_test_url) == observed_rows
 
     def test_extension_gets_correct_visit_id(self) -> None:
-        url_a = utilities.BASE_TEST_URL + "/simple_a.html"
-        url_b = utilities.BASE_TEST_URL + "/simple_b.html"
+        url_a = self.server.base + "/simple_a.html"
+        url_b = self.server.base + "/simple_b.html"
         self.visit(url_a)
         db = self.visit(url_b)
 
@@ -351,7 +359,8 @@ class TestExtension(OpenWPMTest):
                     row["arguments"],
                 )
                 observed_rows.add(item)
-        assert WEBRTC_CALLS == observed_rows
+        webrtc_test_url = self.server.base + "/webrtc_localip.html"
+        assert expected_webrtc_calls(webrtc_test_url) == observed_rows
 
     def test_js_call_stack(self):
         db = self.visit("/js_call_stack.html")
@@ -370,7 +379,7 @@ class TestExtension(OpenWPMTest):
                 row["operation"],
             )
             observed_rows.add(item)
-        assert JS_STACK_CALLS == observed_rows
+        assert expected_js_stack_calls(self.server.base) == observed_rows
 
     def test_js_time_stamp(self):
         # Check that timestamp is recorded correctly for the javascript table
@@ -386,7 +395,7 @@ class TestExtension(OpenWPMTest):
         assert not db_utils.any_command_failed(db)
 
     def test_document_cookie_instrumentation(self):
-        db = self.visit(utilities.BASE_TEST_URL + "/js_cookie.html")
+        db = self.visit(self.server.base + "/js_cookie.html")
         rows = db_utils.get_javascript_entries(db, all_columns=True)
         captured_cookie_calls = set()
         for row in rows:
@@ -402,7 +411,9 @@ class TestExtension(OpenWPMTest):
                 row["value"],
             )
             captured_cookie_calls.add(item)
-        assert captured_cookie_calls == DOCUMENT_COOKIE_READ_WRITE
+        assert captured_cookie_calls == expected_document_cookie_read_write(
+            self.server.base
+        )
 
 
 class ClickButtonCommand(BaseCommand):
@@ -422,15 +433,13 @@ class ClickButtonCommand(BaseCommand):
     "CI" in os.environ and os.environ["CI"] == "true",
     reason="Flaky on CI",
 )
-def test_audio_fingerprinting(default_params, task_manager_creator):
+def test_audio_fingerprinting(default_params, task_manager_creator, server):
     for browser_params in default_params[1]:
         browser_params.js_instrument = True
 
     tm, db = task_manager_creator(default_params)
     cs = CommandSequence("/audio_fingerprinting.html")
-    cs.append_command(
-        GetCommand(utilities.BASE_TEST_URL + "/audio_fingerprinting.html", 0)
-    )
+    cs.append_command(GetCommand(server.base + "/audio_fingerprinting.html", 0))
     cs.append_command(ClickButtonCommand())
     tm.execute_command_sequence(cs)
 

--- a/test/test_http_instrumentation.py
+++ b/test/test_http_instrumentation.py
@@ -21,9 +21,10 @@ from openwpm.storage.leveldb import LevelDbProvider
 from openwpm.storage.sql_provider import SQLiteStorageProvider
 from openwpm.utilities import db_utils
 
-from . import utilities
 from .conftest import FullConfig, HttpParams, TaskManagerCreator
 from .openwpmtest import OpenWPMTest
+from .utilities import ServerUrls
+
 
 # Data for test_page_visit
 # format: (
@@ -34,592 +35,606 @@ from .openwpmtest import OpenWPMTest
 # loading_href,
 # is_XHR, is_tp_content, is_tp_window,
 #   resource_type
-HTTP_REQUESTS: set[tuple[Union[str, None, int], ...]] = {
-    (
-        f"{utilities.BASE_TEST_URL}/http_test_page.html",
-        f"{utilities.BASE_TEST_URL}/http_test_page.html",
-        "undefined",
-        "undefined",
-        "undefined",
-        0,
-        None,
-        None,
-        "main_frame",
-    ),
-    (
-        f"{utilities.BASE_TEST_URL}/shared/test_favicon.ico",
-        f"{utilities.BASE_TEST_URL}/http_test_page.html",
-        f"{utilities.BASE_TEST_URL_NOPATH}",
-        f"{utilities.BASE_TEST_URL_NOPATH}",
-        f"{utilities.BASE_TEST_URL}/http_test_page.html",
-        0,
-        None,
-        None,
-        "image",
-    ),
-    (
-        f"{utilities.BASE_TEST_URL}/shared/test_image_2.png",
-        f"{utilities.BASE_TEST_URL}/http_test_page.html",
-        f"{utilities.BASE_TEST_URL_NOPATH}",
-        f"{utilities.BASE_TEST_URL_NOPATH}",
-        f"{utilities.BASE_TEST_URL}/http_test_page_2.html",
-        0,
-        None,
-        None,
-        "image",
-    ),
-    (
-        f"{utilities.BASE_TEST_URL}/shared/test_script_2.js",
-        f"{utilities.BASE_TEST_URL}/http_test_page.html",
-        f"{utilities.BASE_TEST_URL_NOPATH}",
-        f"{utilities.BASE_TEST_URL_NOPATH}",
-        f"{utilities.BASE_TEST_URL}/http_test_page_2.html",
-        0,
-        None,
-        None,
-        "script",
-    ),
-    (
-        f"{utilities.BASE_TEST_URL}/shared/test_script.js",
-        f"{utilities.BASE_TEST_URL}/http_test_page.html",
-        f"{utilities.BASE_TEST_URL_NOPATH}",
-        f"{utilities.BASE_TEST_URL_NOPATH}",
-        f"{utilities.BASE_TEST_URL}/http_test_page.html",
-        0,
-        None,
-        None,
-        "script",
-    ),
-    (
-        f"{utilities.BASE_TEST_URL}/shared/test_image.png",
-        f"{utilities.BASE_TEST_URL}/http_test_page.html",
-        f"{utilities.BASE_TEST_URL_NOPATH}",
-        f"{utilities.BASE_TEST_URL_NOPATH}",
-        f"{utilities.BASE_TEST_URL}/http_test_page.html",
-        0,
-        None,
-        None,
-        "image",
-    ),
-    (
-        f"{utilities.BASE_TEST_URL}/http_test_page_2.html",
-        f"{utilities.BASE_TEST_URL}/http_test_page.html",
-        f"{utilities.BASE_TEST_URL_NOPATH}",
-        f"{utilities.BASE_TEST_URL_NOPATH}",
-        f"{utilities.BASE_TEST_URL}/http_test_page.html",
-        0,
-        None,
-        None,
-        "sub_frame",
-    ),
-    (
-        f"{utilities.BASE_TEST_URL}/shared/test_style.css",
-        f"{utilities.BASE_TEST_URL}/http_test_page.html",
-        f"{utilities.BASE_TEST_URL_NOPATH}",
-        f"{utilities.BASE_TEST_URL_NOPATH}",
-        f"{utilities.BASE_TEST_URL}/http_test_page.html",
-        0,
-        None,
-        None,
-        "stylesheet",
-    ),
-    (
-        f"{utilities.BASE_TEST_URL_NOPATH}/404.png",
-        f"{utilities.BASE_TEST_URL}/http_test_page.html",
-        f"{utilities.BASE_TEST_URL_NOPATH}",
-        f"{utilities.BASE_TEST_URL_NOPATH}",
-        f"{utilities.BASE_TEST_URL}/http_test_page_2.html",
-        0,
-        None,
-        None,
-        "image",
-    ),
-    (
-        f"{utilities.BASE_TEST_URL_NOPATH}/MAGIC_REDIRECT/frame1.png",
-        f"{utilities.BASE_TEST_URL}/http_test_page.html",
-        f"{utilities.BASE_TEST_URL_NOPATH}",
-        f"{utilities.BASE_TEST_URL_NOPATH}",
-        f"{utilities.BASE_TEST_URL}/http_test_page_2.html",
-        0,
-        None,
-        None,
-        "image",
-    ),
-    (
-        f"{utilities.BASE_TEST_URL_NOPATH}/MAGIC_REDIRECT/frame2.png",
-        f"{utilities.BASE_TEST_URL}/http_test_page.html",
-        f"{utilities.BASE_TEST_URL_NOPATH}",
-        f"{utilities.BASE_TEST_URL_NOPATH}",
-        f"{utilities.BASE_TEST_URL}/http_test_page_2.html",
-        0,
-        None,
-        None,
-        "image",
-    ),
-    (
-        f"{utilities.BASE_TEST_URL_NOPATH}/MAGIC_REDIRECT/req1.png",
-        f"{utilities.BASE_TEST_URL}/http_test_page.html",
-        f"{utilities.BASE_TEST_URL_NOPATH}",
-        f"{utilities.BASE_TEST_URL_NOPATH}",
-        f"{utilities.BASE_TEST_URL}/http_test_page.html",
-        0,
-        None,
-        None,
-        "image",
-    ),
-    (
-        f"{utilities.BASE_TEST_URL_NOPATH}/MAGIC_REDIRECT/req2.png",
-        f"{utilities.BASE_TEST_URL}/http_test_page.html",
-        f"{utilities.BASE_TEST_URL_NOPATH}",
-        f"{utilities.BASE_TEST_URL_NOPATH}",
-        f"{utilities.BASE_TEST_URL}/http_test_page.html",
-        0,
-        None,
-        None,
-        "image",
-    ),
-    (
-        f"{utilities.BASE_TEST_URL_NOPATH}/MAGIC_REDIRECT/req3.png",
-        f"{utilities.BASE_TEST_URL}/http_test_page.html",
-        f"{utilities.BASE_TEST_URL_NOPATH}",
-        f"{utilities.BASE_TEST_URL_NOPATH}",
-        f"{utilities.BASE_TEST_URL}/http_test_page.html",
-        0,
-        None,
-        None,
-        "image",
-    ),
-    (
-        f"{utilities.BASE_TEST_URL}/shared/test_image_2.png",
-        f"{utilities.BASE_TEST_URL}/http_test_page.html",
-        f"{utilities.BASE_TEST_URL_NOPATH}",
-        f"{utilities.BASE_TEST_URL_NOPATH}",
-        f"{utilities.BASE_TEST_URL}/http_test_page.html",
-        0,
-        None,
-        None,
-        "image",
-    ),
-}
+def _http_requests(server: ServerUrls) -> set[tuple[Union[str, None, int], ...]]:
+    return {
+        (
+            f"{server.base}/http_test_page.html",
+            f"{server.base}/http_test_page.html",
+            "undefined",
+            "undefined",
+            "undefined",
+            0,
+            None,
+            None,
+            "main_frame",
+        ),
+        (
+            f"{server.base}/shared/test_favicon.ico",
+            f"{server.base}/http_test_page.html",
+            f"{server.base_nopath}",
+            f"{server.base_nopath}",
+            f"{server.base}/http_test_page.html",
+            0,
+            None,
+            None,
+            "image",
+        ),
+        (
+            f"{server.base}/shared/test_image_2.png",
+            f"{server.base}/http_test_page.html",
+            f"{server.base_nopath}",
+            f"{server.base_nopath}",
+            f"{server.base}/http_test_page_2.html",
+            0,
+            None,
+            None,
+            "image",
+        ),
+        (
+            f"{server.base}/shared/test_script_2.js",
+            f"{server.base}/http_test_page.html",
+            f"{server.base_nopath}",
+            f"{server.base_nopath}",
+            f"{server.base}/http_test_page_2.html",
+            0,
+            None,
+            None,
+            "script",
+        ),
+        (
+            f"{server.base}/shared/test_script.js",
+            f"{server.base}/http_test_page.html",
+            f"{server.base_nopath}",
+            f"{server.base_nopath}",
+            f"{server.base}/http_test_page.html",
+            0,
+            None,
+            None,
+            "script",
+        ),
+        (
+            f"{server.base}/shared/test_image.png",
+            f"{server.base}/http_test_page.html",
+            f"{server.base_nopath}",
+            f"{server.base_nopath}",
+            f"{server.base}/http_test_page.html",
+            0,
+            None,
+            None,
+            "image",
+        ),
+        (
+            f"{server.base}/http_test_page_2.html",
+            f"{server.base}/http_test_page.html",
+            f"{server.base_nopath}",
+            f"{server.base_nopath}",
+            f"{server.base}/http_test_page.html",
+            0,
+            None,
+            None,
+            "sub_frame",
+        ),
+        (
+            f"{server.base}/shared/test_style.css",
+            f"{server.base}/http_test_page.html",
+            f"{server.base_nopath}",
+            f"{server.base_nopath}",
+            f"{server.base}/http_test_page.html",
+            0,
+            None,
+            None,
+            "stylesheet",
+        ),
+        (
+            f"{server.base_nopath}/404.png",
+            f"{server.base}/http_test_page.html",
+            f"{server.base_nopath}",
+            f"{server.base_nopath}",
+            f"{server.base}/http_test_page_2.html",
+            0,
+            None,
+            None,
+            "image",
+        ),
+        (
+            f"{server.base_nopath}/MAGIC_REDIRECT/frame1.png",
+            f"{server.base}/http_test_page.html",
+            f"{server.base_nopath}",
+            f"{server.base_nopath}",
+            f"{server.base}/http_test_page_2.html",
+            0,
+            None,
+            None,
+            "image",
+        ),
+        (
+            f"{server.base_nopath}/MAGIC_REDIRECT/frame2.png",
+            f"{server.base}/http_test_page.html",
+            f"{server.base_nopath}",
+            f"{server.base_nopath}",
+            f"{server.base}/http_test_page_2.html",
+            0,
+            None,
+            None,
+            "image",
+        ),
+        (
+            f"{server.base_nopath}/MAGIC_REDIRECT/req1.png",
+            f"{server.base}/http_test_page.html",
+            f"{server.base_nopath}",
+            f"{server.base_nopath}",
+            f"{server.base}/http_test_page.html",
+            0,
+            None,
+            None,
+            "image",
+        ),
+        (
+            f"{server.base_nopath}/MAGIC_REDIRECT/req2.png",
+            f"{server.base}/http_test_page.html",
+            f"{server.base_nopath}",
+            f"{server.base_nopath}",
+            f"{server.base}/http_test_page.html",
+            0,
+            None,
+            None,
+            "image",
+        ),
+        (
+            f"{server.base_nopath}/MAGIC_REDIRECT/req3.png",
+            f"{server.base}/http_test_page.html",
+            f"{server.base_nopath}",
+            f"{server.base_nopath}",
+            f"{server.base}/http_test_page.html",
+            0,
+            None,
+            None,
+            "image",
+        ),
+        (
+            f"{server.base}/shared/test_image_2.png",
+            f"{server.base}/http_test_page.html",
+            f"{server.base_nopath}",
+            f"{server.base_nopath}",
+            f"{server.base}/http_test_page.html",
+            0,
+            None,
+            None,
+            "image",
+        ),
+    }
+
 
 # format: (request_url, referrer, location)
 # TODO: webext instrumentation doesn't support referrer yet
-HTTP_RESPONSES: set[tuple[str, str]] = {
-    (
-        f"{utilities.BASE_TEST_URL}/http_test_page.html",
-        # u'',
-        "",
-    ),
-    (
-        f"{utilities.BASE_TEST_URL}/shared/test_favicon.ico",
-        # u'',
-        "",
-    ),
-    (
-        f"{utilities.BASE_TEST_URL}/shared/test_style.css",
-        # u'http://localhost:8000/test_pages/http_test_page.html',
-        "",
-    ),
-    (
-        f"{utilities.BASE_TEST_URL}/shared/test_script.js",
-        # u'http://localhost:8000/test_pages/http_test_page.html',
-        "",
-    ),
-    (
-        f"{utilities.BASE_TEST_URL}/shared/test_image.png",
-        # u'http://localhost:8000/test_pages/http_test_page.html',
-        "",
-    ),
-    (
-        f"{utilities.BASE_TEST_URL}/http_test_page_2.html",
-        # u'http://localhost:8000/test_pages/http_test_page.html',
-        "",
-    ),
-    (
-        f"{utilities.BASE_TEST_URL}/shared/test_image_2.png",
-        # u'http://localhost:8000/test_pages/http_test_page_2.html',
-        "",
-    ),
-    (
-        f"{utilities.BASE_TEST_URL}/shared/test_script_2.js",
-        # u'http://localhost:8000/test_pages/http_test_page_2.html',
-        "",
-    ),
-    (
-        f"{utilities.BASE_TEST_URL_NOPATH}/404.png",
-        # u'http://localhost:8000/test_pages/http_test_page_2.html',
-        "",
-    ),
-    (
-        f"{utilities.BASE_TEST_URL}/shared/test_image_2.png",
-        # u'http://localhost:8000/test_pages/http_test_page.html',
-        "",
-    ),
-}
+def _http_responses(server: ServerUrls) -> set[tuple[str, str]]:
+    return {
+        (
+            f"{server.base}/http_test_page.html",
+            # u'',
+            "",
+        ),
+        (
+            f"{server.base}/shared/test_favicon.ico",
+            # u'',
+            "",
+        ),
+        (
+            f"{server.base}/shared/test_style.css",
+            # u'http://localhost:8000/test_pages/http_test_page.html',
+            "",
+        ),
+        (
+            f"{server.base}/shared/test_script.js",
+            # u'http://localhost:8000/test_pages/http_test_page.html',
+            "",
+        ),
+        (
+            f"{server.base}/shared/test_image.png",
+            # u'http://localhost:8000/test_pages/http_test_page.html',
+            "",
+        ),
+        (
+            f"{server.base}/http_test_page_2.html",
+            # u'http://localhost:8000/test_pages/http_test_page.html',
+            "",
+        ),
+        (
+            f"{server.base}/shared/test_image_2.png",
+            # u'http://localhost:8000/test_pages/http_test_page_2.html',
+            "",
+        ),
+        (
+            f"{server.base}/shared/test_script_2.js",
+            # u'http://localhost:8000/test_pages/http_test_page_2.html',
+            "",
+        ),
+        (
+            f"{server.base_nopath}/404.png",
+            # u'http://localhost:8000/test_pages/http_test_page_2.html',
+            "",
+        ),
+        (
+            f"{server.base}/shared/test_image_2.png",
+            # u'http://localhost:8000/test_pages/http_test_page.html',
+            "",
+        ),
+    }
+
 
 # format: (source_url, destination_url, location header)
-HTTP_REDIRECTS: set[tuple[str, str, str | None]] = {
-    (
-        f"{utilities.BASE_TEST_URL_NOPATH}/MAGIC_REDIRECT/req1.png",
-        f"{utilities.BASE_TEST_URL_NOPATH}/MAGIC_REDIRECT/req2.png",
-        "req2.png?dst=req3.png&dst=/test_pages/shared/test_image_2.png",
-    ),
-    (
-        f"{utilities.BASE_TEST_URL_NOPATH}/MAGIC_REDIRECT/req2.png",
-        f"{utilities.BASE_TEST_URL_NOPATH}/MAGIC_REDIRECT/req3.png",
-        "req3.png?dst=/test_pages/shared/test_image_2.png",
-    ),
-    (
-        f"{utilities.BASE_TEST_URL_NOPATH}/MAGIC_REDIRECT/req3.png",
-        f"{utilities.BASE_TEST_URL}/shared/test_image_2.png",
-        "/test_pages/shared/test_image_2.png",
-    ),
-    (
-        f"{utilities.BASE_TEST_URL_NOPATH}/MAGIC_REDIRECT/frame1.png",
-        f"{utilities.BASE_TEST_URL_NOPATH}/MAGIC_REDIRECT/frame2.png",
-        "frame2.png?dst=/404.png",
-    ),
-    (
-        f"{utilities.BASE_TEST_URL_NOPATH}/MAGIC_REDIRECT/frame2.png",
-        f"{utilities.BASE_TEST_URL_NOPATH}/404.png",
-        "/404.png",
-    ),
-}
+def _http_redirects(server: ServerUrls) -> set[tuple[str, str, str | None]]:
+    return {
+        (
+            f"{server.base_nopath}/MAGIC_REDIRECT/req1.png",
+            f"{server.base_nopath}/MAGIC_REDIRECT/req2.png",
+            "req2.png?dst=req3.png&dst=/test_pages/shared/test_image_2.png",
+        ),
+        (
+            f"{server.base_nopath}/MAGIC_REDIRECT/req2.png",
+            f"{server.base_nopath}/MAGIC_REDIRECT/req3.png",
+            "req3.png?dst=/test_pages/shared/test_image_2.png",
+        ),
+        (
+            f"{server.base_nopath}/MAGIC_REDIRECT/req3.png",
+            f"{server.base}/shared/test_image_2.png",
+            "/test_pages/shared/test_image_2.png",
+        ),
+        (
+            f"{server.base_nopath}/MAGIC_REDIRECT/frame1.png",
+            f"{server.base_nopath}/MAGIC_REDIRECT/frame2.png",
+            "frame2.png?dst=/404.png",
+        ),
+        (
+            f"{server.base_nopath}/MAGIC_REDIRECT/frame2.png",
+            f"{server.base_nopath}/404.png",
+            "/404.png",
+        ),
+    }
+
 
 # Data for test_cache_hits_recorded
-HTTP_CACHED_REQUESTS: set[tuple[Union[str, None, int], ...]] = {
-    (
-        f"{utilities.BASE_TEST_URL}/http_test_page.html",
-        f"{utilities.BASE_TEST_URL}/http_test_page.html",
-        "undefined",
-        "undefined",
-        "undefined",
-        0,
-        None,
-        None,
-        "main_frame",
-    ),
-    (
-        f"{utilities.BASE_TEST_URL}/shared/test_script_2.js",
-        f"{utilities.BASE_TEST_URL}/http_test_page.html",
-        f"{utilities.BASE_TEST_URL_NOPATH}",
-        f"{utilities.BASE_TEST_URL_NOPATH}",
-        f"{utilities.BASE_TEST_URL}/http_test_page_2.html",
-        0,
-        None,
-        None,
-        "script",
-    ),
-    (
-        f"{utilities.BASE_TEST_URL}/shared/test_script.js",
-        f"{utilities.BASE_TEST_URL}/http_test_page.html",
-        f"{utilities.BASE_TEST_URL_NOPATH}",
-        f"{utilities.BASE_TEST_URL_NOPATH}",
-        f"{utilities.BASE_TEST_URL}/http_test_page.html",
-        0,
-        None,
-        None,
-        "script",
-    ),
-    (
-        f"{utilities.BASE_TEST_URL}/http_test_page_2.html",
-        f"{utilities.BASE_TEST_URL}/http_test_page.html",
-        f"{utilities.BASE_TEST_URL_NOPATH}",
-        f"{utilities.BASE_TEST_URL_NOPATH}",
-        f"{utilities.BASE_TEST_URL}/http_test_page.html",
-        0,
-        None,
-        None,
-        "sub_frame",
-    ),
-    (
-        f"{utilities.BASE_TEST_URL_NOPATH}/404.png",
-        f"{utilities.BASE_TEST_URL}/http_test_page.html",
-        f"{utilities.BASE_TEST_URL_NOPATH}",
-        f"{utilities.BASE_TEST_URL_NOPATH}",
-        f"{utilities.BASE_TEST_URL}/http_test_page_2.html",
-        0,
-        None,
-        None,
-        "image",
-    ),
-    (
-        f"{utilities.BASE_TEST_URL_NOPATH}/MAGIC_REDIRECT/frame1.png",
-        f"{utilities.BASE_TEST_URL}/http_test_page.html",
-        f"{utilities.BASE_TEST_URL_NOPATH}",
-        f"{utilities.BASE_TEST_URL_NOPATH}",
-        f"{utilities.BASE_TEST_URL}/http_test_page_2.html",
-        0,
-        None,
-        None,
-        "image",
-    ),
-    (
-        f"{utilities.BASE_TEST_URL_NOPATH}/MAGIC_REDIRECT/frame2.png",
-        f"{utilities.BASE_TEST_URL}/http_test_page.html",
-        f"{utilities.BASE_TEST_URL_NOPATH}",
-        f"{utilities.BASE_TEST_URL_NOPATH}",
-        f"{utilities.BASE_TEST_URL}/http_test_page_2.html",
-        0,
-        None,
-        None,
-        "image",
-    ),
-    (
-        f"{utilities.BASE_TEST_URL_NOPATH}/MAGIC_REDIRECT/req1.png",
-        f"{utilities.BASE_TEST_URL}/http_test_page.html",
-        f"{utilities.BASE_TEST_URL_NOPATH}",
-        f"{utilities.BASE_TEST_URL_NOPATH}",
-        f"{utilities.BASE_TEST_URL}/http_test_page.html",
-        0,
-        None,
-        None,
-        "image",
-    ),
-    (
-        f"{utilities.BASE_TEST_URL_NOPATH}/MAGIC_REDIRECT/req2.png",
-        f"{utilities.BASE_TEST_URL}/http_test_page.html",
-        f"{utilities.BASE_TEST_URL_NOPATH}",
-        f"{utilities.BASE_TEST_URL_NOPATH}",
-        f"{utilities.BASE_TEST_URL}/http_test_page.html",
-        0,
-        None,
-        None,
-        "image",
-    ),
-    (
-        f"{utilities.BASE_TEST_URL_NOPATH}/MAGIC_REDIRECT/req3.png",
-        f"{utilities.BASE_TEST_URL}/http_test_page.html",
-        f"{utilities.BASE_TEST_URL_NOPATH}",
-        f"{utilities.BASE_TEST_URL_NOPATH}",
-        f"{utilities.BASE_TEST_URL}/http_test_page.html",
-        0,
-        None,
-        None,
-        "image",
-    ),
-    (
-        f"{utilities.BASE_TEST_URL}/shared/test_image_2.png",
-        f"{utilities.BASE_TEST_URL}/http_test_page.html",
-        f"{utilities.BASE_TEST_URL_NOPATH}",
-        f"{utilities.BASE_TEST_URL_NOPATH}",
-        f"{utilities.BASE_TEST_URL}/http_test_page.html",
-        0,
-        None,
-        None,
-        "image",
-    ),
-    # Resources re-requested when the tab restart opens a new tab; served from
-    # the shared HTTP cache (is_cached=1 in HTTP_CACHED_RESPONSES).
-    (
-        f"{utilities.BASE_TEST_URL}/shared/test_style.css",
-        f"{utilities.BASE_TEST_URL}/http_test_page.html",
-        f"{utilities.BASE_TEST_URL_NOPATH}",
-        f"{utilities.BASE_TEST_URL_NOPATH}",
-        f"{utilities.BASE_TEST_URL}/http_test_page.html",
-        0,
-        None,
-        None,
-        "stylesheet",
-    ),
-    (
-        f"{utilities.BASE_TEST_URL}/shared/test_image.png",
-        f"{utilities.BASE_TEST_URL}/http_test_page.html",
-        f"{utilities.BASE_TEST_URL_NOPATH}",
-        f"{utilities.BASE_TEST_URL_NOPATH}",
-        f"{utilities.BASE_TEST_URL}/http_test_page.html",
-        0,
-        None,
-        None,
-        "image",
-    ),
-    (
-        f"{utilities.BASE_TEST_URL}/shared/test_image_2.png",
-        f"{utilities.BASE_TEST_URL}/http_test_page.html",
-        f"{utilities.BASE_TEST_URL_NOPATH}",
-        f"{utilities.BASE_TEST_URL_NOPATH}",
-        f"{utilities.BASE_TEST_URL}/http_test_page_2.html",
-        0,
-        None,
-        None,
-        "image",
-    ),
-}
+def _http_cached_requests(server: ServerUrls) -> set[tuple[Union[str, None, int], ...]]:
+    return {
+        (
+            f"{server.base}/http_test_page.html",
+            f"{server.base}/http_test_page.html",
+            "undefined",
+            "undefined",
+            "undefined",
+            0,
+            None,
+            None,
+            "main_frame",
+        ),
+        (
+            f"{server.base}/shared/test_script_2.js",
+            f"{server.base}/http_test_page.html",
+            f"{server.base_nopath}",
+            f"{server.base_nopath}",
+            f"{server.base}/http_test_page_2.html",
+            0,
+            None,
+            None,
+            "script",
+        ),
+        (
+            f"{server.base}/shared/test_script.js",
+            f"{server.base}/http_test_page.html",
+            f"{server.base_nopath}",
+            f"{server.base_nopath}",
+            f"{server.base}/http_test_page.html",
+            0,
+            None,
+            None,
+            "script",
+        ),
+        (
+            f"{server.base}/http_test_page_2.html",
+            f"{server.base}/http_test_page.html",
+            f"{server.base_nopath}",
+            f"{server.base_nopath}",
+            f"{server.base}/http_test_page.html",
+            0,
+            None,
+            None,
+            "sub_frame",
+        ),
+        (
+            f"{server.base_nopath}/404.png",
+            f"{server.base}/http_test_page.html",
+            f"{server.base_nopath}",
+            f"{server.base_nopath}",
+            f"{server.base}/http_test_page_2.html",
+            0,
+            None,
+            None,
+            "image",
+        ),
+        (
+            f"{server.base_nopath}/MAGIC_REDIRECT/frame1.png",
+            f"{server.base}/http_test_page.html",
+            f"{server.base_nopath}",
+            f"{server.base_nopath}",
+            f"{server.base}/http_test_page_2.html",
+            0,
+            None,
+            None,
+            "image",
+        ),
+        (
+            f"{server.base_nopath}/MAGIC_REDIRECT/frame2.png",
+            f"{server.base}/http_test_page.html",
+            f"{server.base_nopath}",
+            f"{server.base_nopath}",
+            f"{server.base}/http_test_page_2.html",
+            0,
+            None,
+            None,
+            "image",
+        ),
+        (
+            f"{server.base_nopath}/MAGIC_REDIRECT/req1.png",
+            f"{server.base}/http_test_page.html",
+            f"{server.base_nopath}",
+            f"{server.base_nopath}",
+            f"{server.base}/http_test_page.html",
+            0,
+            None,
+            None,
+            "image",
+        ),
+        (
+            f"{server.base_nopath}/MAGIC_REDIRECT/req2.png",
+            f"{server.base}/http_test_page.html",
+            f"{server.base_nopath}",
+            f"{server.base_nopath}",
+            f"{server.base}/http_test_page.html",
+            0,
+            None,
+            None,
+            "image",
+        ),
+        (
+            f"{server.base_nopath}/MAGIC_REDIRECT/req3.png",
+            f"{server.base}/http_test_page.html",
+            f"{server.base_nopath}",
+            f"{server.base_nopath}",
+            f"{server.base}/http_test_page.html",
+            0,
+            None,
+            None,
+            "image",
+        ),
+        (
+            f"{server.base}/shared/test_image_2.png",
+            f"{server.base}/http_test_page.html",
+            f"{server.base_nopath}",
+            f"{server.base_nopath}",
+            f"{server.base}/http_test_page.html",
+            0,
+            None,
+            None,
+            "image",
+        ),
+        # Resources re-requested when the tab restart opens a new tab; served from
+        # the shared HTTP cache (is_cached=1 in HTTP_CACHED_RESPONSES).
+        (
+            f"{server.base}/shared/test_style.css",
+            f"{server.base}/http_test_page.html",
+            f"{server.base_nopath}",
+            f"{server.base_nopath}",
+            f"{server.base}/http_test_page.html",
+            0,
+            None,
+            None,
+            "stylesheet",
+        ),
+        (
+            f"{server.base}/shared/test_image.png",
+            f"{server.base}/http_test_page.html",
+            f"{server.base_nopath}",
+            f"{server.base_nopath}",
+            f"{server.base}/http_test_page.html",
+            0,
+            None,
+            None,
+            "image",
+        ),
+        (
+            f"{server.base}/shared/test_image_2.png",
+            f"{server.base}/http_test_page.html",
+            f"{server.base_nopath}",
+            f"{server.base_nopath}",
+            f"{server.base}/http_test_page_2.html",
+            0,
+            None,
+            None,
+            "image",
+        ),
+    }
+
 
 # format: (request_url, referrer, is_cached)
 # TODO: referrer isn't recorded by webext instrumentation yet.
-HTTP_CACHED_RESPONSES: set[tuple[str, int]] = {
-    (
-        f"{utilities.BASE_TEST_URL}/http_test_page.html",
-        # u'',
-        1,
-    ),
-    (
-        f"{utilities.BASE_TEST_URL}/shared/test_script.js",
-        # u'http://localhost:8000/test_pages/http_test_page.html',
-        1,
-    ),
-    (
-        f"{utilities.BASE_TEST_URL}/http_test_page_2.html",
-        # u'http://localhost:8000/test_pages/http_test_page.html',
-        1,
-    ),
-    (
-        f"{utilities.BASE_TEST_URL}/shared/test_script_2.js",
-        # u'http://localhost:8000/test_pages/http_test_page_2.html',
-        1,
-    ),
-    (
-        f"{utilities.BASE_TEST_URL_NOPATH}/404.png",
-        # u'http://localhost:8000/test_pages/http_test_page_2.html',
-        0,
-    ),
-    (f"{utilities.BASE_TEST_URL}/shared/test_image_2.png", 1),
-    (f"{utilities.BASE_TEST_URL}/shared/test_style.css", 1),
-    (f"{utilities.BASE_TEST_URL}/shared/test_image.png", 1),
-}
+def _http_cached_responses(server: ServerUrls) -> set[tuple[str, int]]:
+    return {
+        (
+            f"{server.base}/http_test_page.html",
+            # u'',
+            1,
+        ),
+        (
+            f"{server.base}/shared/test_script.js",
+            # u'http://localhost:8000/test_pages/http_test_page.html',
+            1,
+        ),
+        (
+            f"{server.base}/http_test_page_2.html",
+            # u'http://localhost:8000/test_pages/http_test_page.html',
+            1,
+        ),
+        (
+            f"{server.base}/shared/test_script_2.js",
+            # u'http://localhost:8000/test_pages/http_test_page_2.html',
+            1,
+        ),
+        (
+            f"{server.base_nopath}/404.png",
+            # u'http://localhost:8000/test_pages/http_test_page_2.html',
+            0,
+        ),
+        (f"{server.base}/shared/test_image_2.png", 1),
+        (f"{server.base}/shared/test_style.css", 1),
+        (f"{server.base}/shared/test_image.png", 1),
+    }
+
 
 # format: (source_url, destination_url)
-HTTP_CACHED_REDIRECTS: set[tuple[str, str]] = {
-    (
-        f"{utilities.BASE_TEST_URL_NOPATH}/MAGIC_REDIRECT/frame1.png",
-        f"{utilities.BASE_TEST_URL_NOPATH}/MAGIC_REDIRECT/frame2.png",
-    ),
-    (
-        f"{utilities.BASE_TEST_URL_NOPATH}/MAGIC_REDIRECT/frame2.png",
-        f"{utilities.BASE_TEST_URL_NOPATH}/404.png",
-    ),
-    (
-        f"{utilities.BASE_TEST_URL_NOPATH}/MAGIC_REDIRECT/req1.png",
-        f"{utilities.BASE_TEST_URL_NOPATH}/MAGIC_REDIRECT/req2.png",
-    ),
-    (
-        f"{utilities.BASE_TEST_URL_NOPATH}/MAGIC_REDIRECT/req2.png",
-        f"{utilities.BASE_TEST_URL_NOPATH}/MAGIC_REDIRECT/req3.png",
-    ),
-    (
-        f"{utilities.BASE_TEST_URL_NOPATH}/MAGIC_REDIRECT/req3.png",
-        f"{utilities.BASE_TEST_URL}/shared/test_image_2.png",
-    ),
-}
+def _http_cached_redirects(server: ServerUrls) -> set[tuple[str, str]]:
+    return {
+        (
+            f"{server.base_nopath}/MAGIC_REDIRECT/frame1.png",
+            f"{server.base_nopath}/MAGIC_REDIRECT/frame2.png",
+        ),
+        (
+            f"{server.base_nopath}/MAGIC_REDIRECT/frame2.png",
+            f"{server.base_nopath}/404.png",
+        ),
+        (
+            f"{server.base_nopath}/MAGIC_REDIRECT/req1.png",
+            f"{server.base_nopath}/MAGIC_REDIRECT/req2.png",
+        ),
+        (
+            f"{server.base_nopath}/MAGIC_REDIRECT/req2.png",
+            f"{server.base_nopath}/MAGIC_REDIRECT/req3.png",
+        ),
+        (
+            f"{server.base_nopath}/MAGIC_REDIRECT/req3.png",
+            f"{server.base}/shared/test_image_2.png",
+        ),
+    }
+
 
 # Test URL attribution for worker script requests
-HTTP_WORKER_SCRIPT_REQUESTS: set[tuple[Union[str, None, int], ...]] = {
-    (
-        f"{utilities.BASE_TEST_URL}/http_worker_page.html",
-        f"{utilities.BASE_TEST_URL}/http_worker_page.html",
-        "undefined",
-        "undefined",
-        "undefined",
-        0,
-        None,
-        None,
-        "main_frame",
-    ),
-    (
-        f"{utilities.BASE_TEST_URL}/shared/test_favicon.ico",
-        f"{utilities.BASE_TEST_URL}/http_worker_page.html",
-        f"{utilities.BASE_TEST_URL_NOPATH}",
-        f"{utilities.BASE_TEST_URL_NOPATH}",
-        f"{utilities.BASE_TEST_URL}/http_worker_page.html",
-        0,
-        None,
-        None,
-        "image",
-    ),
-    (
-        f"{utilities.BASE_TEST_URL}/shared/worker.js",
-        f"{utilities.BASE_TEST_URL}/http_worker_page.html",
-        f"{utilities.BASE_TEST_URL_NOPATH}",
-        f"{utilities.BASE_TEST_URL_NOPATH}",
-        f"{utilities.BASE_TEST_URL}/http_worker_page.html",
-        0,
-        None,
-        None,
-        "script",
-    ),
-    (
-        f"{utilities.BASE_TEST_URL}/shared/test_image.png",
-        f"{utilities.BASE_TEST_URL}/http_worker_page.html",
-        f"{utilities.BASE_TEST_URL_NOPATH}",
-        f"{utilities.BASE_TEST_URL_NOPATH}",
-        f"{utilities.BASE_TEST_URL}/http_worker_page.html",
-        1,
-        None,
-        None,
-        "xmlhttprequest",
-    ),
-    (
-        f"{utilities.BASE_TEST_URL}/shared/test_image.png",
-        f"{utilities.BASE_TEST_URL}/shared/worker.js",
-        f"{utilities.BASE_TEST_URL_NOPATH}",
-        f"{utilities.BASE_TEST_URL_NOPATH}",
-        f"{utilities.BASE_TEST_URL}/shared/worker.js",
-        1,
-        None,
-        None,
-        "xmlhttprequest",
-    ),
-}
+def _http_worker_script_requests(
+    server: ServerUrls,
+) -> set[tuple[Union[str, None, int], ...]]:
+    return {
+        (
+            f"{server.base}/http_worker_page.html",
+            f"{server.base}/http_worker_page.html",
+            "undefined",
+            "undefined",
+            "undefined",
+            0,
+            None,
+            None,
+            "main_frame",
+        ),
+        (
+            f"{server.base}/shared/test_favicon.ico",
+            f"{server.base}/http_worker_page.html",
+            f"{server.base_nopath}",
+            f"{server.base_nopath}",
+            f"{server.base}/http_worker_page.html",
+            0,
+            None,
+            None,
+            "image",
+        ),
+        (
+            f"{server.base}/shared/worker.js",
+            f"{server.base}/http_worker_page.html",
+            f"{server.base_nopath}",
+            f"{server.base_nopath}",
+            f"{server.base}/http_worker_page.html",
+            0,
+            None,
+            None,
+            "script",
+        ),
+        (
+            f"{server.base}/shared/test_image.png",
+            f"{server.base}/http_worker_page.html",
+            f"{server.base_nopath}",
+            f"{server.base_nopath}",
+            f"{server.base}/http_worker_page.html",
+            1,
+            None,
+            None,
+            "xmlhttprequest",
+        ),
+        (
+            f"{server.base}/shared/test_image.png",
+            f"{server.base}/shared/worker.js",
+            f"{server.base_nopath}",
+            f"{server.base_nopath}",
+            f"{server.base}/shared/worker.js",
+            1,
+            None,
+            None,
+            "xmlhttprequest",
+        ),
+    }
 
-# Test URL-attribution for Service Worker requests.
-HTTP_SERVICE_WORKER_REQUESTS: set[tuple[Union[str, None, int], ...]] = {
-    (
-        "http://localhost:8000/test_pages/http_service_worker_page.html",
-        "http://localhost:8000/test_pages/http_service_worker_page.html",
-        "undefined",
-        "undefined",
-        "undefined",
-        0,
-        None,
-        None,
-        "main_frame",
-    ),
-    (
-        "http://localhost:8000/test_pages/shared/test_favicon.ico",
-        "http://localhost:8000/test_pages/http_service_worker_page.html",
-        "http://localhost:8000",
-        "http://localhost:8000",
-        "http://localhost:8000/test_pages/http_service_worker_page.html",
-        0,
-        None,
-        None,
-        "image",
-    ),
-    (
-        "http://localhost:8000/test_pages/shared/service_worker.js",
-        "http://localhost:8000/test_pages/http_service_worker_page.html",
-        "http://localhost:8000",
-        "http://localhost:8000",
-        "http://localhost:8000/test_pages/http_service_worker_page.html",
-        0,
-        None,
-        None,
-        "script",
-    ),
-    (
-        "http://localhost:8000/test_pages/shared/test_image.png",
-        "http://localhost:8000/test_pages/http_service_worker_page.html",
-        "http://localhost:8000",
-        "http://localhost:8000",
-        "http://localhost:8000/test_pages/http_service_worker_page.html",
-        1,
-        None,
-        None,
-        "xmlhttprequest",
-    ),
-    (
-        "http://localhost:8000/test_pages/shared/test_image_2.png",
-        "http://localhost:8000/test_pages/shared/service_worker.js",
-        "http://localhost:8000",
-        "http://localhost:8000",
-        "http://localhost:8000/test_pages/shared/service_worker.js",
-        1,
-        None,
-        None,
-        "xmlhttprequest",
-    ),
-}
+
+def _http_service_worker_requests(
+    server: ServerUrls,
+) -> set[tuple[Union[str, None, int], ...]]:
+    """Build expected service worker requests (needs dynamic BASE_TEST_URL)."""
+    base = server.base
+    origin = server.base_nopath
+    page = f"{base}/http_service_worker_page.html"
+    sw = f"{base}/shared/service_worker.js"
+    return {
+        (
+            page,
+            page,
+            "undefined",
+            "undefined",
+            "undefined",
+            0,
+            None,
+            None,
+            "main_frame",
+        ),
+        (
+            f"{base}/shared/test_favicon.ico",
+            page,
+            origin,
+            origin,
+            page,
+            0,
+            None,
+            None,
+            "image",
+        ),
+        (sw, page, origin, origin, page, 0, None, None, "script"),
+        (
+            f"{base}/shared/test_image.png",
+            page,
+            origin,
+            origin,
+            page,
+            1,
+            None,
+            None,
+            "xmlhttprequest",
+        ),
+        (
+            f"{base}/shared/test_image_2.png",
+            sw,
+            origin,
+            origin,
+            sw,
+            1,
+            None,
+            None,
+            "xmlhttprequest",
+        ),
+    }
+
 
 BASE_PATH = os.path.dirname(os.path.realpath(__file__))
 
@@ -632,7 +647,7 @@ class TestHTTPInstrument(OpenWPMTest):
 
     def test_worker_script_requests(self):
         """Check correct URL attribution for requests made by worker script"""
-        test_url = utilities.BASE_TEST_URL + "/http_worker_page.html"
+        test_url = self.server.base + "/http_worker_page.html"
         db = self.visit(test_url)
 
         request_id_to_url = dict()
@@ -656,11 +671,11 @@ class TestHTTPInstrument(OpenWPMTest):
             )
             request_id_to_url[row["request_id"]] = row["url"]
 
-        assert HTTP_WORKER_SCRIPT_REQUESTS == observed_records
+        assert _http_worker_script_requests(self.server) == observed_records
 
     def test_service_worker_requests(self):
         """Check correct URL attribution for requests made by service worker"""
-        test_url = utilities.BASE_TEST_URL + "/http_service_worker_page.html"
+        test_url = self.server.base + "/http_service_worker_page.html"
         # sleep_after gives the webRequest pipeline (extension → socket → StorageController)
         # time to flush the SW's fetch before manager.close() shuts down the browser.
         # The SW uses event.waitUntil() so the fetch itself completes, but the async
@@ -689,7 +704,7 @@ class TestHTTPInstrument(OpenWPMTest):
             )
             request_id_to_url[row["request_id"]] = row["url"]
 
-        assert HTTP_SERVICE_WORKER_REQUESTS == observed_records
+        assert _http_service_worker_requests(self.server) == observed_records
 
 
 class TestPOSTInstrument(OpenWPMTest):
@@ -832,7 +847,7 @@ class TestPOSTInstrument(OpenWPMTest):
 
         manager_params, browser_params = self.get_config()
         manager, db_path = task_manager_creator((manager_params, browser_params))
-        test_url = utilities.BASE_TEST_URL + "/post_file_upload.html"
+        test_url = self.server.base + "/post_file_upload.html"
         cs = command_sequence.CommandSequence(test_url)
         cs.get(sleep=0, timeout=60)
         cs.append_command(FilenamesIntoFormCommand(img_file_path, css_file_path))
@@ -857,9 +872,12 @@ class TestPOSTInstrument(OpenWPMTest):
 
 @pytest.mark.parametrize("delayed", [True, False])
 def test_page_visit(
-    task_manager_creator: TaskManagerCreator, http_params: HttpParams, delayed: bool
+    task_manager_creator: TaskManagerCreator,
+    http_params: HttpParams,
+    delayed: bool,
+    server: ServerUrls,
 ) -> None:
-    test_url = utilities.BASE_TEST_URL + "/http_test_page.html"
+    test_url = server.base + "/http_test_page.html"
     manager_params, browser_params = http_params()
     if delayed:
         for browser_param in browser_params:
@@ -896,7 +914,7 @@ def test_page_visit(
         )
 
         request_id_to_url[row["request_id"]] = row["url"]
-    assert HTTP_REQUESTS == observed_requests
+    assert _http_requests(server) == observed_requests
 
     # HTTP Responses
     rows = db_utils.query_db(db, "SELECT * FROM http_responses")
@@ -913,7 +931,7 @@ def test_page_visit(
         )
         assert row["request_id"] in request_id_to_url
         assert request_id_to_url[row["request_id"]] == row["url"]
-    assert HTTP_RESPONSES == observed_responses
+    assert _http_responses(server) == observed_responses
 
     # HTTP Redirects
     rows = db_utils.query_db(db, "SELECT * FROM http_redirects")
@@ -932,12 +950,14 @@ def test_page_visit(
                 location = value
                 break
         observed_redirects.add((src, dst, location))
-    assert HTTP_REDIRECTS == observed_redirects
+    assert _http_redirects(server) == observed_redirects
 
 
-def test_javascript_saving(http_params, xpi, server):
+def test_javascript_saving(
+    http_params: HttpParams, xpi: None, server: ServerUrls
+) -> None:
     """check that javascript content is saved and hashed correctly"""
-    test_url = utilities.BASE_TEST_URL + "/http_test_page.html"
+    test_url = server.base + "/http_test_page.html"
     manager_params, browser_params = http_params()
 
     for browser_param in browser_params:
@@ -958,8 +978,10 @@ def test_javascript_saving(http_params, xpi, server):
         "0110c0521088c74f179615cd7c404816816126fa657550032f75ede67a66c7cc",
         "b34744034cd61e139f85f6c4c92464927bed8343a7ac08acf9fb3c6796f80f08",
     }
-    for chash, content in db_utils.get_content(ldb_path):
-        chash = chash.decode("ascii").lower()
+    for chash_raw, content in db_utils.get_content(ldb_path):
+        assert isinstance(chash_raw, bytes)
+        assert isinstance(content, bytes)
+        chash = chash_raw.decode("ascii").lower()
         pyhash = sha256(content).hexdigest().lower()
         assert pyhash == chash  # Verify expected key (sha256 of content)
         assert chash in expected_hashes
@@ -967,9 +989,11 @@ def test_javascript_saving(http_params, xpi, server):
     assert len(expected_hashes) == 0  # All expected hashes have been seen
 
 
-def test_document_saving(http_params, xpi, server):
+def test_document_saving(
+    http_params: HttpParams, xpi: None, server: ServerUrls
+) -> None:
     """check that document content is saved and hashed correctly"""
-    test_url = utilities.BASE_TEST_URL + "/http_test_page.html"
+    test_url = server.base + "/http_test_page.html"
     expected_hashes = {
         "2390eceab422db15bc45940b7e042e83e6cbd5f279f57e714bc4ad6cded7f966",
         "25343f42d9ffa5c082745f775b172db87d6e14dfbc3160b48669e06d727bfc8d",
@@ -990,8 +1014,10 @@ def test_document_saving(http_params, xpi, server):
 
     manager.get(url=test_url, sleep=1)
     manager.close()
-    for chash, content in db_utils.get_content(ldb_path):
-        chash = chash.decode("ascii").lower()
+    for chash_raw, content in db_utils.get_content(ldb_path):
+        assert isinstance(chash_raw, bytes)
+        assert isinstance(content, bytes)
+        chash = chash_raw.decode("ascii").lower()
         pyhash = sha256(content).hexdigest().lower()
         assert pyhash == chash  # Verify expected key (sha256 of content)
         assert chash in expected_hashes
@@ -999,9 +1025,9 @@ def test_document_saving(http_params, xpi, server):
     assert len(expected_hashes) == 0  # All expected hashes have been seen
 
 
-def test_content_saving(http_params, xpi, server):
+def test_content_saving(http_params: HttpParams, xpi: None, server: ServerUrls) -> None:
     """check that content is saved and hashed correctly"""
-    test_url = utilities.BASE_TEST_URL + "/http_test_page.html"
+    test_url = server.base + "/http_test_page.html"
     manager_params, browser_params = http_params()
     for browser_param in browser_params:
         browser_param.http_instrument = True
@@ -1017,8 +1043,9 @@ def test_content_saving(http_params, xpi, server):
     manager.close()
 
     rows = db_utils.query_db(db, "SELECT * FROM http_responses;")
-    disk_content = dict()
+    disk_content: dict[str, bytes] = dict()
     for row in rows:
+        assert not isinstance(row, tuple)
         if "MAGIC_REDIRECT" in row["url"] or "404" in row["url"]:
             continue
         path = urlparse(row["url"]).path
@@ -1028,16 +1055,21 @@ def test_content_saving(http_params, xpi, server):
         assert chash == row["content_hash"]
         disk_content[chash] = content
 
-    ldb_content = dict()
-    for chash, content in db_utils.get_content(ldb_path):
-        chash = chash.decode("ascii")
-        ldb_content[chash] = content
+    ldb_content: dict[str, bytes] = dict()
+    for chash_raw, content_raw in db_utils.get_content(ldb_path):
+        assert isinstance(chash_raw, bytes)
+        assert isinstance(content_raw, bytes)
+        ldb_content[chash_raw.decode("ascii")] = content_raw
 
     for k, v in disk_content.items():
         assert v == ldb_content[k]
 
 
-def test_cache_hits_recorded(http_params, task_manager_creator):
+def test_cache_hits_recorded(
+    http_params: HttpParams,
+    task_manager_creator: TaskManagerCreator,
+    server: ServerUrls,
+) -> None:
     """Verify all http responses are recorded, including cached responses
 
     Note that we expect to see all of the same requests and responses
@@ -1050,7 +1082,7 @@ def test_cache_hits_recorded(http_params, task_manager_creator):
     for this image when the page is reloaded. Additionally, the redirects
     should be cached.
     """
-    test_url = utilities.BASE_TEST_URL + "/http_test_page.html"
+    test_url = server.base + "/http_test_page.html"
     manager_params, browser_params = http_params()
     # ensuring that we only spawn one browser
     manager_params.num_browsers = 1
@@ -1062,7 +1094,7 @@ def test_cache_hits_recorded(http_params, task_manager_creator):
 
     manager.close()
 
-    request_id_to_url = dict()
+    request_id_to_url: dict[object, object] = dict()
 
     # HTTP Requests
     rows = db_utils.query_db(
@@ -1073,12 +1105,13 @@ def test_cache_hits_recorded(http_params, task_manager_creator):
         JOIN site_visits sv ON sv.visit_id = hr.visit_id and sv.browser_id = hr.browser_id
         WHERE sv.site_rank = 1""",
     )
-    observed_records = set()
+    observed_requests: set[tuple[object, ...]] = set()
     for row in rows:
+        assert not isinstance(row, tuple)
         # HACK: favicon caching is unpredictable, don't bother checking it
         if row["url"].split("?")[0].endswith("favicon.ico"):
             continue
-        observed_records.add(
+        observed_requests.add(
             (
                 row["url"].split("?")[0],
                 row["top_level_url"],
@@ -1092,7 +1125,7 @@ def test_cache_hits_recorded(http_params, task_manager_creator):
             )
         )
         request_id_to_url[row["request_id"]] = row["url"]
-    assert observed_records == HTTP_CACHED_REQUESTS
+    assert observed_requests == _http_cached_requests(server)
 
     # HTTP Responses
     rows = db_utils.query_db(
@@ -1103,12 +1136,13 @@ def test_cache_hits_recorded(http_params, task_manager_creator):
          JOIN site_visits sv ON sv.visit_id = hp.visit_id and sv.browser_id = hp.browser_id
          WHERE sv.site_rank = 1""",
     )
-    observed_records = set()
+    observed_responses: set[tuple[object, ...]] = set()
     for row in rows:
+        assert not isinstance(row, tuple)
         # HACK: favicon caching is unpredictable, don't bother checking it
         if row["url"].split("?")[0].endswith("favicon.ico"):
             continue
-        observed_records.add(
+        observed_responses.add(
             (
                 row["url"].split("?")[0],
                 # TODO: referrer isn't available yet in the
@@ -1118,7 +1152,7 @@ def test_cache_hits_recorded(http_params, task_manager_creator):
         )
         assert row["request_id"] in request_id_to_url
         assert request_id_to_url[row["request_id"]] == row["url"]
-    assert HTTP_CACHED_RESPONSES == observed_records
+    assert _http_cached_responses(server) == observed_responses
 
     # HTTP Redirects
     rows = db_utils.query_db(
@@ -1129,15 +1163,16 @@ def test_cache_hits_recorded(http_params, task_manager_creator):
          JOIN site_visits sv ON sv.visit_id = hr.visit_id and sv.browser_id = hr.browser_id
          WHERE sv.site_rank = 1""",
     )
-    observed_records = set()
+    observed_redirects: set[tuple[str, str]] = set()
     for row in rows:
+        assert not isinstance(row, tuple)
         # TODO: new_request_id isn't supported yet
         # src = request_id_to_url[row['old_request_id']].split('?')[0]
         # dst = request_id_to_url[row['new_request_id']].split('?')[0]
         src = row["old_request_url"].split("?")[0]
         dst = row["new_request_url"].split("?")[0]
-        observed_records.add((src, dst))
-    assert HTTP_CACHED_REDIRECTS == observed_records
+        observed_redirects.add((src, dst))
+    assert _http_cached_redirects(server) == observed_redirects
 
 
 class FilenamesIntoFormCommand(BaseCommand):

--- a/test/test_js_instrument.py
+++ b/test/test_js_instrument.py
@@ -4,7 +4,6 @@ from typing import List, Optional, Set, Tuple
 from openwpm.config import BrowserParams, ManagerParams
 from openwpm.utilities import db_utils
 
-from . import utilities as util
 from .openwpm_jstest import OpenWPMJSTest
 
 
@@ -28,16 +27,16 @@ class TestJSInstrumentNonExistingWindowProperty(OpenWPMJSTest):
     METHOD_CALLS: Set[Tuple[str, str, str]] = set()
 
     TEST_PAGE = "instrument_non_existing_window_property.html"
-    TOP_URL = "%s/js_instrument/%s" % (util.BASE_TEST_URL, TEST_PAGE)
 
     def test_instrument_object(self):
         """Ensure instrumentObject logs all property gets, sets, and calls"""
         db = self.visit("/js_instrument/%s" % self.TEST_PAGE)
+        top_url = f"{self.server.base}/js_instrument/{self.TEST_PAGE}"
         self._check_calls(
             db=db,
             symbol_prefix="",
-            doc_url=self.TOP_URL,
-            top_url=self.TOP_URL,
+            doc_url=top_url,
+            top_url=top_url,
             expected_method_calls=self.METHOD_CALLS,
             expected_gets_and_sets=self.GETS_AND_SETS,
         )
@@ -70,16 +69,16 @@ class TestJSInstrumentExistingWindowProperty(OpenWPMJSTest):
     METHOD_CALLS: Set[Tuple[str, str, str]] = set()  # Note 2
 
     TEST_PAGE = "instrument_existing_window_property.html"
-    TOP_URL = "%s/js_instrument/%s" % (util.BASE_TEST_URL, TEST_PAGE)
 
     def test_instrument_object(self):
         """Ensure instrumentObject logs all property gets, sets, and calls"""
         db = self.visit("/js_instrument/%s" % self.TEST_PAGE)
+        top_url = f"{self.server.base}/js_instrument/{self.TEST_PAGE}"
         self._check_calls(
             db=db,
             symbol_prefix="",
-            doc_url=self.TOP_URL,
-            top_url=self.TOP_URL,
+            doc_url=top_url,
+            top_url=top_url,
             expected_method_calls=self.METHOD_CALLS,
             expected_gets_and_sets=self.GETS_AND_SETS,
         )
@@ -89,7 +88,6 @@ class TestJSInstrumentByPython(OpenWPMJSTest):  # noqa
     # This test tests python side configuration. But we can only test
     # built in browser APIs, so we're not using html specced objects.
     TEST_PAGE = "instrument_pyside.html"
-    TOP_URL = "%s/js_instrument/%s" % (util.BASE_TEST_URL, TEST_PAGE)
 
     GETS_AND_SETS = {
         ("window.navigator.webdriver", "get", "true"),
@@ -132,11 +130,12 @@ class TestJSInstrumentByPython(OpenWPMJSTest):  # noqa
     def test_instrument_object(self):
         """Ensure instrumentObject logs all property gets, sets, and calls"""
         db = self.visit("/js_instrument/%s" % self.TEST_PAGE)
+        top_url = f"{self.server.base}/js_instrument/{self.TEST_PAGE}"
         self._check_calls(
             db=db,
             symbol_prefix="",
-            doc_url=self.TOP_URL,
-            top_url=self.TOP_URL,
+            doc_url=top_url,
+            top_url=top_url,
             expected_method_calls=self.METHOD_CALLS,
             expected_gets_and_sets=self.GETS_AND_SETS,
         )
@@ -196,17 +195,17 @@ class TestJSInstrumentMockWindowProperty(OpenWPMJSTest):
     }
 
     TEST_PAGE = "instrument_mock_window_property.html"
-    TOP_URL = "%s/js_instrument/%s" % (util.BASE_TEST_URL, TEST_PAGE)
 
     def test_instrument_object(self):
         """Ensure instrumentObject logs all property gets, sets, and calls"""
         db = self.visit("/js_instrument/%s" % self.TEST_PAGE)
+        top_url = f"{self.server.base}/js_instrument/{self.TEST_PAGE}"
 
         self._check_calls(
             db=db,
             symbol_prefix="",
-            doc_url=self.TOP_URL,
-            top_url=self.TOP_URL,
+            doc_url=top_url,
+            top_url=top_url,
             expected_method_calls=self.METHOD_CALLS,
             expected_gets_and_sets=self.GETS_AND_SETS,
         )
@@ -283,34 +282,34 @@ class TestJSInstrument(OpenWPMJSTest):
         ("window.test3.obj1.prop2", "get", "newprop2"),
     }
 
-    TOP_URL = "%s/js_instrument/instrument_object.html" % util.BASE_TEST_URL
-    FRAME1_URL = "%s/js_instrument/framed1.html" % util.BASE_TEST_URL
-    FRAME2_URL = "%s/js_instrument/framed2.html" % util.BASE_TEST_URL
-
     def test_instrument_object(self):
         """Ensure instrumentObject logs all property gets, sets, and calls"""
         db = self.visit("/js_instrument/instrument_object.html")
+        base = self.server.base
+        top_url = f"{base}/js_instrument/instrument_object.html"
+        frame1_url = f"{base}/js_instrument/framed1.html"
+        frame2_url = f"{base}/js_instrument/framed2.html"
         self._check_calls(
             db=db,
             symbol_prefix="window.test.",
-            doc_url=self.TOP_URL,
-            top_url=self.TOP_URL,
+            doc_url=top_url,
+            top_url=top_url,
             expected_method_calls=self.METHOD_CALLS,
             expected_gets_and_sets=self.GETS_AND_SETS,
         )
         self._check_calls(
             db=db,
             symbol_prefix="window.frame1Test.",
-            doc_url=self.FRAME1_URL,
-            top_url=self.TOP_URL,
+            doc_url=frame1_url,
+            top_url=top_url,
             expected_method_calls=self.METHOD_CALLS,
             expected_gets_and_sets=self.GETS_AND_SETS,
         )
         self._check_calls(
             db=db,
             symbol_prefix="window.frame2Test.",
-            doc_url=self.FRAME2_URL,
-            top_url=self.TOP_URL,
+            doc_url=frame2_url,
+            top_url=top_url,
             expected_method_calls=self.METHOD_CALLS,
             expected_gets_and_sets=self.GETS_AND_SETS,
         )
@@ -322,8 +321,8 @@ class TestJSInstrument(OpenWPMJSTest):
         for row in rows:
             if not row["symbol"].startswith("window.test2.nestedObj"):
                 continue
-            assert row["document_url"] == self.TOP_URL
-            assert row["top_level_url"] == self.TOP_URL
+            assert row["document_url"] == top_url
+            assert row["top_level_url"] == top_url
             if row["operation"] == "get" or row["operation"] == "set":
                 observed_gets_and_sets.add(
                     (row["symbol"], row["operation"], row["value"])
@@ -340,8 +339,8 @@ class TestJSInstrument(OpenWPMJSTest):
         for row in rows:
             if not row["symbol"].startswith("window.test2.l1"):
                 continue
-            assert row["document_url"] == self.TOP_URL
-            assert row["top_level_url"] == self.TOP_URL
+            assert row["document_url"] == top_url
+            assert row["top_level_url"] == top_url
             prop_access.add((row["symbol"], row["operation"], row["value"]))
         assert prop_access == self.RECURSIVE_PROP_SET
 
@@ -351,8 +350,8 @@ class TestJSInstrument(OpenWPMJSTest):
         for row in rows:
             if not row["symbol"].startswith("window.test3"):
                 continue
-            assert row["document_url"] == self.TOP_URL
-            assert row["top_level_url"] == self.TOP_URL
+            assert row["document_url"] == top_url
+            assert row["top_level_url"] == top_url
             if row["operation"] == "call":
                 observed_calls.add((row["symbol"], row["operation"], row["arguments"]))
             else:
@@ -382,16 +381,16 @@ class TestJSInstrumentRecursiveProperties(OpenWPMJSTest):
     METHOD_CALLS: Set[Tuple[str, str, str]] = set()
 
     TEST_PAGE = "instrument_do_not_recurse_properties_to_instrument.html"
-    TOP_URL = "%s/js_instrument/%s" % (util.BASE_TEST_URL, TEST_PAGE)
 
     def test_instrument_object(self):
         """Ensure instrumentObject logs all property gets, sets, and calls"""
         db = self.visit("/js_instrument/%s" % self.TEST_PAGE)
+        top_url = f"{self.server.base}/js_instrument/{self.TEST_PAGE}"
         self._check_calls(
             db=db,
             symbol_prefix="",
-            doc_url=self.TOP_URL,
-            top_url=self.TOP_URL,
+            doc_url=top_url,
+            top_url=top_url,
             expected_method_calls=self.METHOD_CALLS,
             expected_gets_and_sets=self.GETS_AND_SETS,
         )

--- a/test/test_pages/expected_source.html
+++ b/test/test_pages/expected_source.html
@@ -8,7 +8,7 @@
   </script>
  </head>
  <body onload="set_cookie()">
- <a href="http://localhost:8000/test_pages/simple_c.html">Click me!</a>
+ <a href="/test_pages/simple_c.html">Click me!</a>
  <a href="simple_d.html">Click me also!</a>
  <a href="javascript:alert(1)">Click me for a JS alert!</a>
  <a href="https://www.google.com">Go to google.com</a>

--- a/test/test_pages/http_service_worker_page.html
+++ b/test/test_pages/http_service_worker_page.html
@@ -21,7 +21,7 @@
     </script>
     <script>
       var request = new Request(
-        'http://localhost:8000/test_pages/shared/test_image.png'
+        '/test_pages/shared/test_image.png'
       );
       fetch(request);
     </script>

--- a/test/test_pages/recursive_iframes/child1a.html
+++ b/test/test_pages/recursive_iframes/child1a.html
@@ -5,7 +5,7 @@
   </head>
   <body>
     <h3>Depth 1 -- Child A</h3>
-    <iframe src="http://localhost:8000/test_pages/recursive_iframes/child2a.html"></iframe>
-    <iframe src="http://localhost:8000/test_pages/recursive_iframes/child2b.html"></iframe>
+    <iframe src="/test_pages/recursive_iframes/child2a.html"></iframe>
+    <iframe src="/test_pages/recursive_iframes/child2b.html"></iframe>
   </body>
 </html>

--- a/test/test_pages/recursive_iframes/child1c.html
+++ b/test/test_pages/recursive_iframes/child1c.html
@@ -5,6 +5,6 @@
   </head>
   <body>
     <h3>Depth 1 -- Child C</h3>
-    <iframe src="http://localhost:8000/test_pages/recursive_iframes/child2c.html"></iframe>
+    <iframe src="/test_pages/recursive_iframes/child2c.html"></iframe>
   </body>
 </html>

--- a/test/test_pages/recursive_iframes/child2a.html
+++ b/test/test_pages/recursive_iframes/child2a.html
@@ -5,6 +5,6 @@
   </head>
   <body>
     <h3>Depth 2 -- Child A</h3>
-    <iframe src="http://localhost:8000/test_pages/recursive_iframes/child3a.html"></iframe>
+    <iframe src="/test_pages/recursive_iframes/child3a.html"></iframe>
   </body>
 </html>

--- a/test/test_pages/recursive_iframes/child2c.html
+++ b/test/test_pages/recursive_iframes/child2c.html
@@ -5,8 +5,8 @@
   </head>
   <body>
     <h3>Depth 2 -- Child C</h3>
-    <iframe src="http://localhost:8000/test_pages/recursive_iframes/child3b.html"></iframe>
-    <iframe src="http://localhost:8000/test_pages/recursive_iframes/child3c.html"></iframe>
-    <iframe src="http://localhost:8000/test_pages/recursive_iframes/child3d.html"></iframe>
+    <iframe src="/test_pages/recursive_iframes/child3b.html"></iframe>
+    <iframe src="/test_pages/recursive_iframes/child3c.html"></iframe>
+    <iframe src="/test_pages/recursive_iframes/child3d.html"></iframe>
   </body>
 </html>

--- a/test/test_pages/recursive_iframes/child3a.html
+++ b/test/test_pages/recursive_iframes/child3a.html
@@ -5,6 +5,6 @@
   </head>
   <body>
     <h3>Depth 3 -- Child A</h3>
-    <iframe src="http://localhost:8000/test_pages/recursive_iframes/child4a.html"></iframe>
+    <iframe src="/test_pages/recursive_iframes/child4a.html"></iframe>
   </body>
 </html>

--- a/test/test_pages/recursive_iframes/child4a.html
+++ b/test/test_pages/recursive_iframes/child4a.html
@@ -5,6 +5,6 @@
   </head>
   <body>
     <h3>Depth 4 -- Child A</h3>
-    <iframe src="http://localhost:8000/test_pages/recursive_iframes/child5a.html"></iframe>
+    <iframe src="/test_pages/recursive_iframes/child5a.html"></iframe>
   </body>
 </html>

--- a/test/test_pages/recursive_iframes/child5a.html
+++ b/test/test_pages/recursive_iframes/child5a.html
@@ -5,6 +5,6 @@
   </head>
   <body>
     <h3>Depth 5 -- Child A</h3>
-    <iframe src="http://localhost:8000/test_pages/recursive_iframes/child6a.html"></iframe>
+    <iframe src="/test_pages/recursive_iframes/child6a.html"></iframe>
   </body>
 </html>

--- a/test/test_pages/recursive_iframes/parent.html
+++ b/test/test_pages/recursive_iframes/parent.html
@@ -7,8 +7,8 @@
     <h3> This is a test page to test the recursive iframe function.
     The test function grabs the page source of each frame, so any changes to
     the file will break the tests.</h3>
-    <iframe src="http://localhost:8000/test_pages/recursive_iframes/child1a.html"></iframe>
-    <iframe src="http://localhost:8000/test_pages/recursive_iframes/child1b.html"></iframe>
-    <iframe src="http://localhost:8000/test_pages/recursive_iframes/child1c.html"></iframe>
+    <iframe src="/test_pages/recursive_iframes/child1a.html"></iframe>
+    <iframe src="/test_pages/recursive_iframes/child1b.html"></iframe>
+    <iframe src="/test_pages/recursive_iframes/child1c.html"></iframe>
   </body>
 </html>

--- a/test/test_pages/shared/service_worker.js
+++ b/test/test_pages/shared/service_worker.js
@@ -1,4 +1,4 @@
-var IMAGE_URL = 'http://localhost:8000/test_pages/shared/test_image_2.png';
+var IMAGE_URL = '/test_pages/shared/test_image_2.png';
 
 self.addEventListener('install', function(event) {
   // Skip the waiting phase so this worker activates immediately after install.

--- a/test/test_pages/shared/worker.js
+++ b/test/test_pages/shared/worker.js
@@ -1,6 +1,6 @@
 
 const request = new Request(
-  'http://localhost:8000/test_pages/shared/test_image.png'
+  '/test_pages/shared/test_image.png'
 );
 
 fetch(request);

--- a/test/test_pages/simple_a.html
+++ b/test/test_pages/simple_a.html
@@ -10,7 +10,7 @@
   </script>
  </head>
  <body onload="set_cookie()">
- <a href="http://localhost:8000/test_pages/simple_c.html">Click me!</a>
+ <a href="/test_pages/simple_c.html">Click me!</a>
  <a href="simple_d.html">Click me also!</a>
  <a href="javascript:alert(1)">Click me for a JS alert!</a>
  <a href="https://www.google.com">Go to google.com</a>

--- a/test/test_profile.py
+++ b/test/test_profile.py
@@ -15,19 +15,19 @@ from openwpm.errors import CommandExecutionError, ProfileLoadError
 from openwpm.utilities import db_utils
 
 from . import openwpmtest
-from .utilities import BASE_TEST_URL
+from .utilities import ServerUrls
 
 # TODO update these tests to make use of blocking commands
 
 
-def test_saving(default_params, task_manager_creator):
+def test_saving(default_params, task_manager_creator, server):
     manager_params, browser_params = default_params
     manager_params.num_browsers = 1
     browser_params[0].profile_archive_dir = (
         manager_params.data_directory / "browser_profile"
     )
     manager, _ = task_manager_creator((manager_params, browser_params[:1]))
-    manager.get(BASE_TEST_URL)
+    manager.get(server.base)
     manager.close()
     tar_path = browser_params[0].profile_archive_dir / "profile.tar.gz"
     assert tar_path.is_file()
@@ -47,21 +47,21 @@ def test_saving(default_params, task_manager_creator):
         assert item in archive_items
 
 
-def test_save_incomplete_profile_error(default_params, task_manager_creator):
+def test_save_incomplete_profile_error(default_params, task_manager_creator, server):
     manager_params, browser_params = default_params
     manager_params.num_browsers = 1
     browser_params[0].profile_archive_dir = (
         manager_params.data_directory / "browser_profile"
     )
     manager, _ = task_manager_creator((manager_params, browser_params[:1]))
-    manager.get(BASE_TEST_URL)
+    manager.get(server.base)
     (manager.browsers[0].current_profile_path / "cookies.sqlite").unlink()
     with pytest.raises(RuntimeError) as error:
         manager.close()
     assert str(error.value) == "Profile dump not successful"
 
 
-def test_crash_profile(default_params, task_manager_creator):
+def test_crash_profile(default_params, task_manager_creator, server):
     manager_params, browser_params = default_params
     manager_params.num_browsers = 1
     manager_params.failure_limit = 2
@@ -70,7 +70,7 @@ def test_crash_profile(default_params, task_manager_creator):
     )
     manager, _ = task_manager_creator((manager_params, browser_params[:1]))
     try:
-        manager.get(BASE_TEST_URL)  # So we have a profile
+        manager.get(server.base)  # So we have a profile
         manager.get("example.com")  # Selenium requires scheme prefix
         manager.get("example.com")  # Selenium requires scheme prefix
         manager.get("example.com")  # Selenium requires scheme prefix
@@ -89,7 +89,7 @@ def test_profile_error(default_params, task_manager_creator):
 
 
 def test_profile_saved_when_launch_crashes(
-    monkeypatch, default_params, task_manager_creator
+    monkeypatch, default_params, task_manager_creator, server
 ):
     manager_params, browser_params = default_params
     manager_params.num_browsers = 1
@@ -97,7 +97,7 @@ def test_profile_saved_when_launch_crashes(
         manager_params.data_directory / "browser_profile"
     )
     manager, _ = task_manager_creator((manager_params, browser_params[:1]))
-    manager.get(BASE_TEST_URL)
+    manager.get(server.base)
 
     # This will cause browser restarts to fail
     monkeypatch.setenv("FIREFOX_BINARY", "/tmp/NOTREAL")
@@ -106,14 +106,14 @@ def test_profile_saved_when_launch_crashes(
     manager.get("example.com")  # Cause a selenium crash to force browser to restart
 
     try:
-        manager.get(BASE_TEST_URL)
+        manager.get(server.base)
     except CommandExecutionError:
         pass
     manager.close()
     assert (browser_params[0].profile_archive_dir / "profile.tar.gz").is_file()
 
 
-def test_seed_persistence(default_params, task_manager_creator):
+def test_seed_persistence(default_params, task_manager_creator, server):
     manager_params, browser_params = default_params
     p = Path("profile.tar.gz")
     for browser_param in browser_params:
@@ -122,7 +122,7 @@ def test_seed_persistence(default_params, task_manager_creator):
     with manager:
         command_sequences = []
         for _ in range(openwpmtest.NUM_BROWSERS):
-            cs = CommandSequence(url=BASE_TEST_URL)
+            cs = CommandSequence(url=server.base)
             cs.get()
             cs.append_command(AssertConfigSetCommand("test_pref", True))
             command_sequences.append(cs)
@@ -166,12 +166,12 @@ class AssertConfigSetCommand(BaseCommand):
         assert result == self.expected_value
 
 
-def test_dump_profile_command(default_params, task_manager_creator):
+def test_dump_profile_command(default_params, task_manager_creator, server):
     """Test saving the browser profile using a command."""
     manager_params, browser_params = default_params
     manager_params.num_browsers = 1
     manager, _ = task_manager_creator((manager_params, browser_params[:1]))
-    cs = CommandSequence(url=BASE_TEST_URL)
+    cs = CommandSequence(url=server.base)
     cs.get()
     tar_path = manager_params.data_directory / "profile.tar.gz"
     cs.dump_profile(tar_path, True)
@@ -221,14 +221,20 @@ def test_crash_during_init(default_params, task_manager_creator):
 # Use -k to run this test for a specific set of parameters. For example:
 # pytest -vv test_profile.py::test_profile_recovery -k on_crash-stateful-with_seed_tar
 def test_profile_recovery(
-    monkeypatch, default_params, task_manager_creator, testcase, stateful, seed_tar
+    monkeypatch,
+    default_params,
+    task_manager_creator,
+    server,
+    testcase,
+    stateful,
+    seed_tar,
 ):
     """Test browser profile recovery in various scenarios."""
     manager_params, browser_params = default_params
     manager_params.num_browsers = 1
     browser_params[0].seed_tar = seed_tar
     manager, db = task_manager_creator((manager_params, browser_params[:1]))
-    manager.get(BASE_TEST_URL, reset=not stateful)
+    manager.get(server.base, reset=not stateful)
 
     if testcase == "normal_operation":
         pass
@@ -268,9 +274,9 @@ def test_profile_recovery(
     rows = db_utils.query_db(ff_db, "SELECT url FROM moz_places")
     places = [url for (url,) in rows]
     if stateful:
-        assert BASE_TEST_URL in places
+        assert server.base in places
     else:
-        assert BASE_TEST_URL not in places
+        assert server.base not in places
 
     # Check if seed_tar was loaded on restart
     rows = db_utils.query_db(

--- a/test/test_simple_commands.py
+++ b/test/test_simple_commands.py
@@ -11,6 +11,7 @@ import gzip
 import json
 import os
 import re
+from typing import Literal
 from urllib.parse import urlparse
 
 import pytest
@@ -19,73 +20,47 @@ from PIL import Image
 from openwpm import command_sequence
 from openwpm.utilities import db_utils
 
-from . import utilities
-
-url_a = utilities.BASE_TEST_URL + "/simple_a.html"
-url_b = utilities.BASE_TEST_URL + "/simple_b.html"
-url_c = utilities.BASE_TEST_URL + "/simple_c.html"
-url_d = utilities.BASE_TEST_URL + "/simple_d.html"
-
-rendered_js_url = utilities.BASE_TEST_URL + "/property_enumeration.html"
-
-# Expected nested page source
-# This needs to be changed back once #887 is addressed
+from .conftest import HttpParams, TaskManagerCreator
+from .utilities import ServerUrls
 
 NESTED_TEST_DIR = "/recursive_iframes/"
-NESTED_FRAMES_URL = utilities.BASE_TEST_URL + NESTED_TEST_DIR + "parent.html"
-D1_BASE = utilities.BASE_TEST_URL + NESTED_TEST_DIR
-D2_BASE = utilities.BASE_TEST_URL + NESTED_TEST_DIR
-D3_BASE = utilities.BASE_TEST_URL + NESTED_TEST_DIR
-D4_BASE = utilities.BASE_TEST_URL + NESTED_TEST_DIR
-D5_BASE = utilities.BASE_TEST_URL + NESTED_TEST_DIR
-EXPECTED_PARENTS = {
-    NESTED_FRAMES_URL: [],
-    D1_BASE + "child1a.html": [NESTED_FRAMES_URL],
-    D1_BASE + "child1b.html": [NESTED_FRAMES_URL],
-    D1_BASE + "child1c.html": [NESTED_FRAMES_URL],
-    D2_BASE + "child2a.html": [NESTED_FRAMES_URL, D1_BASE + "child1a.html"],
-    D2_BASE + "child2b.html": [NESTED_FRAMES_URL, D1_BASE + "child1a.html"],
-    D2_BASE + "child2c.html": [NESTED_FRAMES_URL, D1_BASE + "child1c.html"],
-    D3_BASE
-    + "child3a.html": [
-        NESTED_FRAMES_URL,
-        D1_BASE + "child1a.html",
-        D2_BASE + "child2a.html",
-    ],
-    D3_BASE
-    + "child3b.html": [
-        NESTED_FRAMES_URL,
-        D1_BASE + "child1c.html",
-        D2_BASE + "child2c.html",
-    ],
-    D3_BASE
-    + "child3c.html": [
-        NESTED_FRAMES_URL,
-        D1_BASE + "child1c.html",
-        D2_BASE + "child2c.html",
-    ],
-    D3_BASE
-    + "child3d.html": [
-        NESTED_FRAMES_URL,
-        D1_BASE + "child1c.html",
-        D2_BASE + "child2c.html",
-    ],
-    D4_BASE
-    + "child4a.html": [
-        NESTED_FRAMES_URL,
-        D1_BASE + "child1a.html",
-        D2_BASE + "child2a.html",
-        D3_BASE + "child3a.html",
-    ],
-    D5_BASE
-    + "child5a.html": [
-        NESTED_FRAMES_URL,
-        D1_BASE + "child1a.html",
-        D2_BASE + "child2a.html",
-        D3_BASE + "child3a.html",
-        D4_BASE + "child4a.html",
-    ],
-}
+
+
+def _url(base: str, page: str) -> str:
+    return base + page
+
+
+def _expected_parents(base: str) -> dict:
+    base = base + NESTED_TEST_DIR
+    frames = base + "parent.html"
+    return {
+        frames: [],
+        base + "child1a.html": [frames],
+        base + "child1b.html": [frames],
+        base + "child1c.html": [frames],
+        base + "child2a.html": [frames, base + "child1a.html"],
+        base + "child2b.html": [frames, base + "child1a.html"],
+        base + "child2c.html": [frames, base + "child1c.html"],
+        base + "child3a.html": [frames, base + "child1a.html", base + "child2a.html"],
+        base + "child3b.html": [frames, base + "child1c.html", base + "child2c.html"],
+        base + "child3c.html": [frames, base + "child1c.html", base + "child2c.html"],
+        base + "child3d.html": [frames, base + "child1c.html", base + "child2c.html"],
+        base
+        + "child4a.html": [
+            frames,
+            base + "child1a.html",
+            base + "child2a.html",
+            base + "child3a.html",
+        ],
+        base
+        + "child5a.html": [
+            frames,
+            base + "child1a.html",
+            base + "child2a.html",
+            base + "child3a.html",
+            base + "child4a.html",
+        ],
+    }
 
 
 scenarios = [
@@ -95,16 +70,21 @@ scenarios = [
 
 
 @pytest.mark.parametrize("display_mode", scenarios)
-def test_get_site_visits_table_valid(http_params, task_manager_creator, display_mode):
+def test_get_site_visits_table_valid(
+    http_params: HttpParams,
+    task_manager_creator: TaskManagerCreator,
+    display_mode: Literal["headless", "xvfb"],
+    server: ServerUrls,
+) -> None:
     """Check that get works and populates db correctly."""
     # Run the test crawl
     manager_params, browser_params = http_params(display_mode)
     manager, db = task_manager_creator((manager_params, browser_params))
 
     # Set up two sequential get commands to two URLS
-    cs_a = command_sequence.CommandSequence(url_a)
+    cs_a = command_sequence.CommandSequence(_url(server.base, "/simple_a.html"))
     cs_a.get(sleep=1)
-    cs_b = command_sequence.CommandSequence(url_b)
+    cs_b = command_sequence.CommandSequence(_url(server.base, "/simple_b.html"))
     cs_b.get(sleep=1)
 
     # Perform the get commands
@@ -120,8 +100,8 @@ def test_get_site_visits_table_valid(http_params, task_manager_creator, display_
     # We had two separate page visits
     assert len(qry_res) == 2
 
-    assert qry_res[0][0] == url_a
-    assert qry_res[1][0] == url_b
+    assert qry_res[0][0] == _url(server.base, "/simple_a.html")
+    assert qry_res[1][0] == _url(server.base, "/simple_b.html")
 
 
 def test_get_with_popup_blocking(default_params, task_manager_creator):
@@ -157,16 +137,21 @@ def test_get_with_popup_blocking(default_params, task_manager_creator):
 
 
 @pytest.mark.parametrize("display_mode", scenarios)
-def test_get_http_tables_valid(http_params, task_manager_creator, display_mode):
+def test_get_http_tables_valid(
+    http_params: HttpParams,
+    task_manager_creator: TaskManagerCreator,
+    display_mode: Literal["headless", "xvfb"],
+    server: ServerUrls,
+) -> None:
     """Check that get works and populates http tables correctly."""
     # Run the test crawl
     manager_params, browser_params = http_params(display_mode)
     manager, db = task_manager_creator((manager_params, browser_params))
 
     # Set up two sequential get commands to two URLS
-    cs_a = command_sequence.CommandSequence(url_a)
+    cs_a = command_sequence.CommandSequence(_url(server.base, "/simple_a.html"))
     cs_a.get(sleep=1)
-    cs_b = command_sequence.CommandSequence(url_b)
+    cs_b = command_sequence.CommandSequence(_url(server.base, "/simple_b.html"))
     cs_b.get(sleep=1)
 
     manager.execute_command_sequence(cs_a)
@@ -183,45 +168,52 @@ def test_get_http_tables_valid(http_params, task_manager_creator, display_mode):
     qry_res = db_utils.query_db(
         db,
         "SELECT visit_id FROM http_requests WHERE url = ?",
-        (url_a,),
+        (_url(server.base, "/simple_a.html"),),
     )
-    assert qry_res[0][0] == visit_ids[url_a]
+    assert qry_res[0][0] == visit_ids[_url(server.base, "/simple_a.html")]
 
     qry_res = db_utils.query_db(
         db,
         "SELECT visit_id FROM http_requests WHERE url = ?",
-        (url_b,),
+        (_url(server.base, "/simple_b.html"),),
     )
-    assert qry_res[0][0] == visit_ids[url_b]
+    assert qry_res[0][0] == visit_ids[_url(server.base, "/simple_b.html")]
 
     qry_res = db_utils.query_db(
         db,
         "SELECT visit_id FROM http_responses WHERE url = ?",
-        (url_a,),
+        (_url(server.base, "/simple_a.html"),),
     )
-    assert qry_res[0][0] == visit_ids[url_a]
+    assert qry_res[0][0] == visit_ids[_url(server.base, "/simple_a.html")]
 
     qry_res = db_utils.query_db(
         db,
         "SELECT visit_id FROM http_responses WHERE url = ?",
-        (url_b,),
+        (_url(server.base, "/simple_b.html"),),
     )
-    assert qry_res[0][0] == visit_ids[url_b]
+    assert qry_res[0][0] == visit_ids[_url(server.base, "/simple_b.html")]
 
 
 @pytest.mark.parametrize("display_mode", scenarios)
 def test_browse_site_visits_table_valid(
-    http_params, task_manager_creator, display_mode
-):
+    http_params: HttpParams,
+    task_manager_creator: TaskManagerCreator,
+    display_mode: Literal["headless", "xvfb"],
+    server: ServerUrls,
+) -> None:
     """Check that CommandSequence.browse() populates db correctly."""
     # Run the test crawl
     manager_params, browser_params = http_params(display_mode)
     manager, db = task_manager_creator((manager_params, browser_params))
 
     # Set up two sequential browse commands to two URLS
-    cs_a = command_sequence.CommandSequence(url_a, site_rank=0)
+    cs_a = command_sequence.CommandSequence(
+        _url(server.base, "/simple_a.html"), site_rank=0
+    )
     cs_a.browse(num_links=1, sleep=1)
-    cs_b = command_sequence.CommandSequence(url_b, site_rank=1)
+    cs_b = command_sequence.CommandSequence(
+        _url(server.base, "/simple_b.html"), site_rank=1
+    )
     cs_b.browse(num_links=1, sleep=1)
 
     manager.execute_command_sequence(cs_a)
@@ -236,14 +228,19 @@ def test_browse_site_visits_table_valid(
     # We had two separate page visits
     assert len(qry_res) == 2
 
-    assert qry_res[0][0] == url_a
+    assert qry_res[0][0] == _url(server.base, "/simple_a.html")
     assert qry_res[0][1] == 0
-    assert qry_res[1][0] == url_b
+    assert qry_res[1][0] == _url(server.base, "/simple_b.html")
     assert qry_res[1][1] == 1
 
 
 @pytest.mark.parametrize("display_mode", scenarios)
-def test_browse_http_table_valid(http_params, task_manager_creator, display_mode):
+def test_browse_http_table_valid(
+    http_params: HttpParams,
+    task_manager_creator: TaskManagerCreator,
+    display_mode: Literal["headless", "xvfb"],
+    server: ServerUrls,
+) -> None:
     """Check CommandSequence.browse() works and populates http tables correctly.
 
     NOTE: Since the browse command is choosing links randomly, there is a
@@ -255,9 +252,9 @@ def test_browse_http_table_valid(http_params, task_manager_creator, display_mode
     manager, db = task_manager_creator((manager_params, browser_params))
 
     # Set up two sequential browse commands to two URLS
-    cs_a = command_sequence.CommandSequence(url_a)
+    cs_a = command_sequence.CommandSequence(_url(server.base, "/simple_a.html"))
     cs_a.browse(num_links=20, sleep=1)
-    cs_b = command_sequence.CommandSequence(url_b)
+    cs_b = command_sequence.CommandSequence(_url(server.base, "/simple_b.html"))
     cs_b.browse(num_links=1, sleep=1)
 
     manager.execute_command_sequence(cs_a)
@@ -274,30 +271,30 @@ def test_browse_http_table_valid(http_params, task_manager_creator, display_mode
     qry_res = db_utils.query_db(
         db,
         "SELECT visit_id FROM http_requests WHERE url = ?",
-        (url_a,),
+        (_url(server.base, "/simple_a.html"),),
     )
-    assert qry_res[0][0] == visit_ids[url_a]
+    assert qry_res[0][0] == visit_ids[_url(server.base, "/simple_a.html")]
 
     qry_res = db_utils.query_db(
         db,
         "SELECT visit_id FROM http_requests WHERE url = ?",
-        (url_b,),
+        (_url(server.base, "/simple_b.html"),),
     )
-    assert qry_res[0][0] == visit_ids[url_b]
+    assert qry_res[0][0] == visit_ids[_url(server.base, "/simple_b.html")]
 
     qry_res = db_utils.query_db(
         db,
         "SELECT visit_id FROM http_responses WHERE url = ?",
-        (url_a,),
+        (_url(server.base, "/simple_a.html"),),
     )
-    assert qry_res[0][0] == visit_ids[url_a]
+    assert qry_res[0][0] == visit_ids[_url(server.base, "/simple_a.html")]
 
     qry_res = db_utils.query_db(
         db,
         "SELECT visit_id FROM http_responses WHERE url = ?",
-        (url_b,),
+        (_url(server.base, "/simple_b.html"),),
     )
-    assert qry_res[0][0] == visit_ids[url_b]
+    assert qry_res[0][0] == visit_ids[_url(server.base, "/simple_b.html")]
 
     # Page simple_a.html has three links:
     # 1) An absolute link to simple_c.html
@@ -309,29 +306,32 @@ def test_browse_http_table_valid(http_params, task_manager_creator, display_mode
     qry_res = db_utils.query_db(
         db,
         "SELECT visit_id FROM http_responses WHERE url = ?",
-        (url_c,),
+        (_url(server.base, "/simple_c.html"),),
     )
-    assert qry_res[0][0] == visit_ids[url_a]
+    assert qry_res[0][0] == visit_ids[_url(server.base, "/simple_a.html")]
     qry_res = db_utils.query_db(
         db,
         "SELECT visit_id FROM http_responses WHERE url = ?",
-        (url_d,),
+        (_url(server.base, "/simple_d.html"),),
     )
-    assert qry_res[0][0] == visit_ids[url_a]
+    assert qry_res[0][0] == visit_ids[_url(server.base, "/simple_a.html")]
 
     # We expect 4 urls: a,c,d and a favicon request
     qry_res = db_utils.query_db(
         db,
         "SELECT COUNT(DISTINCT url) FROM http_responses WHERE visit_id = ?",
-        (visit_ids[url_a],),
+        (visit_ids[_url(server.base, "/simple_a.html")],),
     )
     assert qry_res[0][0] == 4
 
 
 @pytest.mark.parametrize("display_mode", scenarios)
 def test_browse_wrapper_http_table_valid(
-    http_params, task_manager_creator, display_mode
-):
+    http_params: HttpParams,
+    task_manager_creator: TaskManagerCreator,
+    display_mode: Literal["headless", "xvfb"],
+    server: ServerUrls,
+) -> None:
     """Check that TaskManager.browse() wrapper works and populates
     http tables correctly.
 
@@ -344,8 +344,8 @@ def test_browse_wrapper_http_table_valid(
     manager, db = task_manager_creator((manager_params, browser_params))
 
     # Set up two sequential browse commands to two URLS
-    manager.browse(url_a, num_links=20, sleep=1)
-    manager.browse(url_b, num_links=1, sleep=1)
+    manager.browse(_url(server.base, "/simple_a.html"), num_links=20, sleep=1)
+    manager.browse(_url(server.base, "/simple_b.html"), num_links=1, sleep=1)
     manager.close()
 
     qry_res = db_utils.query_db(db, "SELECT visit_id, site_url FROM site_visits")
@@ -358,30 +358,30 @@ def test_browse_wrapper_http_table_valid(
     qry_res = db_utils.query_db(
         db,
         "SELECT visit_id FROM http_requests WHERE url = ?",
-        (url_a,),
+        (_url(server.base, "/simple_a.html"),),
     )
-    assert qry_res[0][0] == visit_ids[url_a]
+    assert qry_res[0][0] == visit_ids[_url(server.base, "/simple_a.html")]
 
     qry_res = db_utils.query_db(
         db,
         "SELECT visit_id FROM http_requests WHERE url = ?",
-        (url_b,),
+        (_url(server.base, "/simple_b.html"),),
     )
-    assert qry_res[0][0] == visit_ids[url_b]
+    assert qry_res[0][0] == visit_ids[_url(server.base, "/simple_b.html")]
 
     qry_res = db_utils.query_db(
         db,
         "SELECT visit_id FROM http_responses WHERE url = ?",
-        (url_a,),
+        (_url(server.base, "/simple_a.html"),),
     )
-    assert qry_res[0][0] == visit_ids[url_a]
+    assert qry_res[0][0] == visit_ids[_url(server.base, "/simple_a.html")]
 
     qry_res = db_utils.query_db(
         db,
         "SELECT visit_id FROM http_responses WHERE url = ?",
-        (url_b,),
+        (_url(server.base, "/simple_b.html"),),
     )
-    assert qry_res[0][0] == visit_ids[url_b]
+    assert qry_res[0][0] == visit_ids[_url(server.base, "/simple_b.html")]
 
     # Page simple_a.html has three links:
     # 1) An absolute link to simple_c.html
@@ -393,33 +393,38 @@ def test_browse_wrapper_http_table_valid(
     qry_res = db_utils.query_db(
         db,
         "SELECT visit_id FROM http_responses WHERE url = ?",
-        (url_c,),
+        (_url(server.base, "/simple_c.html"),),
     )
-    assert qry_res[0][0] == visit_ids[url_a]
+    assert qry_res[0][0] == visit_ids[_url(server.base, "/simple_a.html")]
     qry_res = db_utils.query_db(
         db,
         "SELECT visit_id FROM http_responses WHERE url = ?",
-        (url_d,),
+        (_url(server.base, "/simple_d.html"),),
     )
-    assert qry_res[0][0] == visit_ids[url_a]
+    assert qry_res[0][0] == visit_ids[_url(server.base, "/simple_a.html")]
 
     # We expect 4 urls: a,c,d and a favicon request
     qry_res = db_utils.query_db(
         db,
         "SELECT COUNT(DISTINCT url) FROM http_responses WHERE visit_id = ?",
-        (visit_ids[url_a],),
+        (visit_ids[_url(server.base, "/simple_a.html")],),
     )
     assert qry_res[0][0] == 4
 
 
 @pytest.mark.parametrize("display_mode", scenarios)
-def test_save_screenshot_valid(http_params, task_manager_creator, display_mode):
+def test_save_screenshot_valid(
+    http_params: HttpParams,
+    task_manager_creator: TaskManagerCreator,
+    display_mode: Literal["headless", "xvfb"],
+    server: ServerUrls,
+) -> None:
     """Check that 'save_screenshot' works"""
     # Run the test crawl
     manager_params, browser_params = http_params(display_mode)
     manager, _ = task_manager_creator((manager_params, browser_params))
 
-    cs = command_sequence.CommandSequence(url_a)
+    cs = command_sequence.CommandSequence(_url(server.base, "/simple_a.html"))
     cs.get(sleep=1)
     cs.save_screenshot("test")
     cs.screenshot_full_page("test_full")
@@ -446,13 +451,18 @@ def test_save_screenshot_valid(http_params, task_manager_creator, display_mode):
 
 
 @pytest.mark.parametrize("display_mode", scenarios)
-def test_dump_page_source_valid(http_params, task_manager_creator, display_mode):
+def test_dump_page_source_valid(
+    http_params: HttpParams,
+    task_manager_creator: TaskManagerCreator,
+    display_mode: Literal["headless", "xvfb"],
+    server: ServerUrls,
+) -> None:
     """Check that 'dump_page_source' works and source is saved properly."""
     # Run the test crawl
     manager_params, browser_params = http_params(display_mode)
     manager, db = task_manager_creator((manager_params, browser_params))
 
-    cs = command_sequence.CommandSequence(url_a)
+    cs = command_sequence.CommandSequence(_url(server.base, "/simple_a.html"))
     cs.get(sleep=1)
     cs.dump_page_source(suffix="test")
     manager.execute_command_sequence(cs)
@@ -473,13 +483,18 @@ def test_dump_page_source_valid(http_params, task_manager_creator, display_mode)
 
 @pytest.mark.parametrize("display_mode", scenarios)
 def test_recursive_dump_page_source_valid(
-    http_params, task_manager_creator, display_mode
-):
+    http_params: HttpParams,
+    task_manager_creator: TaskManagerCreator,
+    display_mode: Literal["headless", "xvfb"],
+    server: ServerUrls,
+) -> None:
     """Check that 'recursive_dump_page_source' works"""
     # Run the test crawl
     manager_params, browser_params = http_params(display_mode)
     manager, db = task_manager_creator((manager_params, browser_params))
-    cs = command_sequence.CommandSequence(NESTED_FRAMES_URL)
+    cs = command_sequence.CommandSequence(
+        _url(server.base, NESTED_TEST_DIR + "parent.html")
+    )
     cs.get(sleep=1)
     cs.recursive_dump_page_source()
     manager.execute_command_sequence(cs)
@@ -515,4 +530,4 @@ def test_recursive_dump_page_source_valid(
         parent_frames.pop()
 
     verify_frame(visit_source)
-    assert EXPECTED_PARENTS == observed_parents
+    assert _expected_parents(server.base) == observed_parents

--- a/test/test_simple_commands.py
+++ b/test/test_simple_commands.py
@@ -20,7 +20,7 @@ from PIL import Image
 from openwpm import command_sequence
 from openwpm.utilities import db_utils
 
-from .conftest import HttpParams, TaskManagerCreator
+from .conftest import FullConfig, HttpParams, TaskManagerCreator
 from .utilities import ServerUrls
 
 NESTED_TEST_DIR = "/recursive_iframes/"
@@ -104,12 +104,18 @@ def test_get_site_visits_table_valid(
     assert qry_res[1][0] == _url(server.base, "/simple_b.html")
 
 
-def test_get_with_popup_blocking(default_params, task_manager_creator):
+def test_get_with_popup_blocking(
+    default_params: FullConfig,
+    task_manager_creator: TaskManagerCreator,
+    server: ServerUrls,
+) -> None:
     """Verify that visits complete when popup blocking is enabled.
 
     Regression test for #741: dom.disable_open_during_load causes
     tab_restart_browser to crash because window.open() is blocked.
     """
+    url_a = _url(server.base, "/simple_a.html")
+    url_b = _url(server.base, "/simple_b.html")
     manager_params, browser_params = default_params
     # Force a single browser so both visits run on the popup-blocking browser.
     manager_params.num_browsers = 1

--- a/test/test_storage_vectors.py
+++ b/test/test_storage_vectors.py
@@ -7,7 +7,8 @@ on to check for completeness and correctness.
 from openwpm import command_sequence
 from openwpm.utilities import db_utils
 
-from . import utilities
+from .conftest import FullConfig, TaskManagerCreator
+from .utilities import BASE_TEST_URL_DOMAIN, ServerUrls
 
 expected_js_cookie = (
     "added-or-changed",  # record_type
@@ -15,7 +16,7 @@ expected_js_cookie = (
     0,  # is_http_only
     1,  # is_host_only
     0,  # is_session
-    "%s" % utilities.BASE_TEST_URL_DOMAIN,  # host
+    "%s" % BASE_TEST_URL_DOMAIN,  # host
     0,  # is_secure
     "test_cookie",  # name
     "/",  # path
@@ -24,14 +25,18 @@ expected_js_cookie = (
 )
 
 
-def test_js_profile_cookies(default_params, task_manager_creator):
+def test_js_profile_cookies(
+    default_params: FullConfig,
+    task_manager_creator: TaskManagerCreator,
+    server: ServerUrls,
+) -> None:
     """Check that profile cookies set by JS are saved"""
     # Run the test crawl
     manager_params, browser_params = default_params
     for browser_param in browser_params:
         browser_param.cookie_instrument = True
     manager, db = task_manager_creator((manager_params, browser_params))
-    url = utilities.BASE_TEST_URL + "/js_cookie.html"
+    url = server.base + "/js_cookie.html"
     cs = command_sequence.CommandSequence(url)
     cs.get(sleep=3, timeout=120)
     manager.execute_command_sequence(cs)

--- a/test/test_task_manager.py
+++ b/test/test_task_manager.py
@@ -8,7 +8,8 @@ from openwpm.command_sequence import CommandSequence
 from openwpm.commands.types import BaseCommand
 from openwpm.errors import CommandExecutionError
 
-from .utilities import BASE_TEST_URL
+from .conftest import FullConfig, TaskManagerCreator
+from .utilities import ServerUrls
 
 
 def test_failure_limit_value(default_params):
@@ -33,18 +34,22 @@ def test_failure_limit_exceeded(task_manager_creator, default_params):
     manager.close()
 
 
-def test_failure_limit_reset(task_manager_creator, default_params):
+def test_failure_limit_reset(
+    task_manager_creator: TaskManagerCreator,
+    default_params: FullConfig,
+    server: ServerUrls,
+) -> None:
     """Test that failure_count is reset on command sequence completion."""
     manager_params, browser_params = default_params
     manager_params.num_browsers = 1
     manager_params.failure_limit = 1
     manager, _ = task_manager_creator((manager_params, browser_params[:1]))
     manager.get("example.com")  # Selenium requires scheme prefix
-    manager.get(BASE_TEST_URL)  # Successful command sequence
+    manager.get(server.base)  # Successful command sequence
     # Now failure_count should be reset to 0 and the following command
     # failure should not raise a CommandExecutionError
     manager.get("example.com")  # Selenium requires scheme prefix
-    manager.get(BASE_TEST_URL)  # Requires two commands to shut down
+    manager.get(server.base)  # Requires two commands to shut down
     manager.close()
 
 

--- a/test/test_timer.py
+++ b/test/test_timer.py
@@ -1,12 +1,17 @@
 from openwpm.utilities import db_utils
 
-from .utilities import BASE_TEST_URL
+from .conftest import FullConfig, TaskManagerCreator
+from .utilities import ServerUrls
 
 TEST_FILE = "canvas_fingerprinting.html"
-TEST_URL = BASE_TEST_URL + "/" + TEST_FILE
 
 
-def test_command_duration(default_params, task_manager_creator):
+def test_command_duration(
+    default_params: FullConfig,
+    task_manager_creator: TaskManagerCreator,
+    server: ServerUrls,
+) -> None:
+    TEST_URL = server.base + "/" + TEST_FILE
     manager, db = task_manager_creator(default_params)
     manager.get(url=TEST_URL, sleep=5)
     manager.close()

--- a/test/test_xvfb_browser.py
+++ b/test/test_xvfb_browser.py
@@ -7,7 +7,8 @@ from openwpm.commands.types import BaseCommand
 from openwpm.config import BrowserParamsInternal, ManagerParamsInternal
 from openwpm.socket_interface import ClientSocket
 
-from .utilities import BASE_TEST_URL
+from .conftest import FullConfig, TaskManagerCreator
+from .utilities import ServerUrls
 
 
 class ExceptionCommand(BaseCommand):
@@ -21,12 +22,16 @@ class ExceptionCommand(BaseCommand):
         raise RuntimeError("We simulate a Command failing")
 
 
-def test_display_shutdown(task_manager_creator, default_params):
+def test_display_shutdown(
+    task_manager_creator: TaskManagerCreator,
+    default_params: FullConfig,
+    server: ServerUrls,
+) -> None:
     """Test the XVFB display option to see if it runs and deletes the lockfile upon shutdown"""
     manager_params, browser_params = default_params
     for browser_param in browser_params:
         browser_param.display_mode = "xvfb"
-    TEST_SITE = BASE_TEST_URL + "/test_pages/simple_a.html"
+    TEST_SITE = server.base + "/simple_a.html"
     manager, db = task_manager_creator((manager_params, browser_params))
     port = manager.browsers[0].display_port
 

--- a/test/utilities.py
+++ b/test/utilities.py
@@ -1,15 +1,35 @@
 import os
 import socketserver
 import threading
+from dataclasses import dataclass
 from http.server import SimpleHTTPRequestHandler
 from os.path import dirname, realpath
 from urllib.parse import parse_qs, urlparse
 
-LOCAL_WEBSERVER_PORT = 8000
 BASE_TEST_URL_DOMAIN = "localhost"
-BASE_TEST_URL_NOPATH = "http://%s:%s" % (BASE_TEST_URL_DOMAIN, LOCAL_WEBSERVER_PORT)
-BASE_TEST_URL = "%s/test_pages" % BASE_TEST_URL_NOPATH
-BASE_TEST_URL_NOSCHEME = BASE_TEST_URL.split("//")[1]
+
+
+@dataclass(frozen=True)
+class ServerUrls:
+    """URLs for the test HTTP server, computed from the dynamic port."""
+
+    port: int
+    domain: str = BASE_TEST_URL_DOMAIN
+
+    @property
+    def base_nopath(self) -> str:
+        return f"http://{self.domain}:{self.port}"
+
+    @property
+    def base(self) -> str:
+        return f"{self.base_nopath}/test_pages"
+
+    @property
+    def base_noscheme(self) -> str:
+        return self.base.split("//")[1]
+
+    def url(self, path: str) -> str:
+        return self.base + path
 
 
 class MyTCPServer(socketserver.TCPServer):
@@ -52,6 +72,15 @@ class MyHandler(SimpleHTTPRequestHandler):
 
     def __init__(self, *args, **kwargs):
         SimpleHTTPRequestHandler.__init__(self, *args, **kwargs)
+
+    def send_response(self, code, message=None):
+        self._response_code = code
+        super().send_response(code, message)
+
+    def end_headers(self):
+        if getattr(self, "_response_code", None) == 200:
+            self.send_header("Cache-Control", "max-age=3600")
+        super().end_headers()
 
     def do_GET(self, *args, **kwargs):
         # 1. Redirect all requests to `/MAGIC_REDIRECT/`.
@@ -96,19 +125,23 @@ class MyHandler(SimpleHTTPRequestHandler):
         return SimpleHTTPRequestHandler.do_GET(self, *args, **kwargs)
 
 
-def start_server():
+def start_server() -> tuple[MyTCPServer, threading.Thread, ServerUrls]:
     """Start a simple HTTP server to run local tests.
 
     We need this since page-mod events in the extension
     don't fire on `file://*`. Instead, point test code to
-    `http://localhost:8000/test_pages/...`
+    `http://localhost:<port>/test_pages/...`
+
+    Binds to port 0 (OS-assigned free port) to allow parallel test runs.
     """
     print("Starting HTTP Server in a separate thread")
     # switch to test dir, this is where the test files are
     os.chdir(dirname(realpath(__file__)))
-    server = MyTCPServer(("0.0.0.0", LOCAL_WEBSERVER_PORT), MyHandler)
+    server = MyTCPServer(("0.0.0.0", 0), MyHandler)
+    port = server.server_address[1]
+    urls = ServerUrls(port=port)
     thread = threading.Thread(target=server.serve_forever)
     thread.daemon = True
     thread.start()
-    print("...serving at port", LOCAL_WEBSERVER_PORT)
-    return server, thread
+    print("...serving at port", port)
+    return server, thread, urls

--- a/test/utilities.py
+++ b/test/utilities.py
@@ -28,9 +28,6 @@ class ServerUrls:
     def base_noscheme(self) -> str:
         return self.base.split("//")[1]
 
-    def url(self, path: str) -> str:
-        return self.base + path
-
 
 class MyTCPServer(socketserver.TCPServer):
     """Subclass TCPServer to be able to reuse the same port (Errno 98)."""
@@ -72,15 +69,6 @@ class MyHandler(SimpleHTTPRequestHandler):
 
     def __init__(self, *args, **kwargs):
         SimpleHTTPRequestHandler.__init__(self, *args, **kwargs)
-
-    def send_response(self, code, message=None):
-        self._response_code = code
-        super().send_response(code, message)
-
-    def end_headers(self):
-        if getattr(self, "_response_code", None) == 200:
-            self.send_header("Cache-Control", "max-age=3600")
-        super().end_headers()
 
     def do_GET(self, *args, **kwargs):
         # 1. Redirect all requests to `/MAGIC_REDIRECT/`.


### PR DESCRIPTION
## Summary
- Replace hardcoded port 8000 test HTTP server with OS-assigned dynamic ports (port 0), enabling parallel test runs
- Replace module-level URL constants (`BASE_TEST_URL`, `BASE_TEST_URL_NOPATH`, `LOCAL_WEBSERVER_PORT`) with a `ServerUrls` frozen dataclass injected via a session-scoped `server` pytest fixture
- Convert all test files to receive URLs through fixture injection instead of importing globals
- Convert hardcoded `http://localhost:8000/...` URLs in HTML/JS test pages to root-relative paths (`/test_pages/...`)

## Test plan
- [ ] `pre-commit run --all-files` passes (isort, black, mypy all clean)
- [ ] Full test suite passes (all tests except the pre-existing flaky `test_audio_fingerprinting`)
- [ ] Two independent test runs can execute concurrently without port conflicts