### PR TITLE
fix: don't count DNS errors against consecutive failure limit

### DIFF
--- a/openwpm/browser_manager.py
+++ b/openwpm/browser_manager.py
@@ -461,7 +461,18 @@ class BrowserManagerHandle:
                 )
                 return
 
-            if command_status != "ok":
+            # DNS resolution errors are expected when crawling large domain
+            # lists (e.g. Tranco top 100k) and don't indicate a browser or
+            # instrumentation failure, so we skip the failure counter and
+            # browser restart for them.  See:
+            # https://github.com/openwpm/OpenWPM/issues/1116
+            is_dns_error = (
+                command_status == "neterror"
+                and error_text is not None
+                and error_text == "dnsNotFound"
+            )
+
+            if command_status != "ok" and not is_dns_error:
                 with task_manager.threadlock:
                     task_manager.failure_count += 1
                 if task_manager.failure_count > task_manager.failure_limit:


### PR DESCRIPTION
## Summary
- DNS resolution errors (`dnsNotFound`) are expected when crawling large domain lists and don't indicate browser/instrumentation failure
- Skip failure counter increment and browser restart for DNS errors, preventing premature crawl termination
- DNS errors are still properly recorded in `crawl_history` with status `neterror`

Closes #1116

## Changes
- `openwpm/browser_manager.py`: Add `is_dns_error` check before incrementing `failure_count` and triggering browser restart

## Test plan
- [ ] Run `test/test_webdriver_utils.py::test_parse_neterror_integration` to verify DNS errors are still recorded correctly
- [ ] Verify crawls with unreachable domains don't trigger browser restarts
- [ ] Run full test suite to check for regressions