### PR TITLE
fix(prefs): remove obsolete Firefox preferences

### DIFF
--- a/openwpm/deploy_browsers/configure_firefox.py
+++ b/openwpm/deploy_browsers/configure_firefox.py
@@ -47,15 +47,10 @@ def optimize_prefs(fo: Options) -> None:
     """  # noqa
     # Startup / Speed
     fo.set_preference("browser.shell.checkDefaultBrowser", False)
-    fo.set_preference("browser.slowStartup.notificationDisabled", True)
-    fo.set_preference("browser.slowStartup.maxSamples", 0)
-    fo.set_preference("browser.slowStartup.samples", 0)
-    fo.set_preference("extensions.checkCompatibility.nightly", False)
     fo.set_preference("browser.rights.3.shown", True)
     fo.set_preference("reader.parse-on-load.enabled", False)
     fo.set_preference("browser.pagethumbnails.capturing_disabled", True)
     fo.set_preference("browser.uitour.enabled", False)
-    fo.set_preference("dom.flyweb.enabled", False)
 
     # Disable health reports / telemetry / crash reports
     fo.set_preference("datareporting.policy.dataSubmissionEnabled", False)
@@ -65,11 +60,8 @@ def optimize_prefs(fo: Options) -> None:
     fo.set_preference("toolkit.telemetry.enabled", False)
     fo.set_preference("toolkit.telemetry.unified", False)
     fo.set_preference("breakpad.reportURL", "")
-    fo.set_preference("dom.ipc.plugins.reportCrashURL", False)
-    fo.set_preference("browser.selfsupport.url", "")
     fo.set_preference("browser.tabs.crashReporting.sendReport", False)
     fo.set_preference("browser.crashReports.unsubmittedCheck.enabled", False)
-    fo.set_preference("dom.ipc.plugins.flash.subprocess.crashreporter.enabled", False)
 
     # Predictive Actions / Prefetch
     fo.set_preference("network.predictor.enabled", False)
@@ -78,30 +70,21 @@ def optimize_prefs(fo: Options) -> None:
     fo.set_preference("browser.search.suggest.enabled", False)
     fo.set_preference("network.http.speculative-parallel-limit", 0)
     fo.set_preference("keyword.enabled", False)  # location bar using search
-    fo.set_preference("browser.urlbar.userMadeSearchSuggestionsChoice", True)
-    fo.set_preference("browser.casting.enabled", False)
 
     # Disable pinging Mozilla for geoip
     fo.set_preference("browser.search.geoip.url", "")
-    fo.set_preference("browser.search.countryCode", "US")
     fo.set_preference("browser.search.region", "US")
 
-    # Disable pinging Mozilla for geo-specific search
-    fo.set_preference("browser.search.geoSpecificDefaults", False)
-    fo.set_preference("browser.search.geoSpecificDefaults.url", "")
-
     # Disable auto-updating
-    fo.set_preference("app.update.enabled", False)  # browser
-    fo.set_preference("app.update.url", "")  # browser
-    fo.set_preference("browser.search.update", False)  # search
+    fo.set_preference("app.update.url", "")  # browser update URL
+    fo.set_preference("browser.search.update", False)  # search engines
     fo.set_preference("extensions.update.enabled", False)  # extensions
     fo.set_preference("extensions.update.autoUpdateDefault", False)
     fo.set_preference("extensions.getAddons.cache.enabled", False)
-    fo.set_preference("lightweightThemes.update.enabled", False)  # Personas
 
     # Disable Safebrowsing and other security features
-    # that require on remote content
-    fo.set_preference("browser.safebrowsing.phising.enabled", False)
+    # that require remote content
+    fo.set_preference("browser.safebrowsing.phishing.enabled", False)
     fo.set_preference("browser.safebrowsing.malware.enabled", False)
     fo.set_preference("browser.safebrowsing.downloads.enabled", False)
     fo.set_preference("browser.safebrowsing.downloads.remote.enabled", False)
@@ -112,10 +95,10 @@ def optimize_prefs(fo: Options) -> None:
     fo.set_preference("browser.safebrowsing.provider.mozilla.updateURL", "")
     fo.set_preference("browser.safebrowsing.provider.google.updateURL", "")
     fo.set_preference("browser.safebrowsing.provider.google4.updateURL", "")
-    fo.set_preference("browser.safebrowsing.provider.mozilla.lists", "")  # TP
-    fo.set_preference("browser.safebrowsing.provider.google.lists", "")  # TP
-    fo.set_preference("browser.safebrowsing.provider.google4.lists", "")  # TP
-    fo.set_preference("extensions.blocklist.enabled", False)  # extensions
+    fo.set_preference("browser.safebrowsing.provider.mozilla.lists", "")
+    fo.set_preference("browser.safebrowsing.provider.google.lists", "")
+    fo.set_preference("browser.safebrowsing.provider.google4.lists", "")
+    fo.set_preference("extensions.blocklist.enabled", False)
     fo.set_preference("security.OCSP.enabled", 0)
 
     # Disable Content Decryption Module and OpenH264 related downloads
@@ -125,27 +108,14 @@ def optimize_prefs(fo: Options) -> None:
     fo.set_preference("media.gmp-widevinecdm.visible", False)
     fo.set_preference("media.gmp-gmpopenh264.enabled", False)
 
-    # Disable Experiments
-    fo.set_preference("experiments.enabled", False)
-    fo.set_preference("experiments.manifest.uri", "")
-    fo.set_preference("experiments.supported", False)
-    fo.set_preference("experiments.activeExperiment", False)
-    fo.set_preference("network.allow-experiments", False)
-
     # Disable pinging Mozilla for newtab
-    fo.set_preference("browser.newtabpage.directory.ping", "")
-    fo.set_preference("browser.newtabpage.directory.source", "")
     fo.set_preference("browser.newtabpage.enabled", False)
-    fo.set_preference("browser.newtabpage.enhanced", False)
-    fo.set_preference("browser.newtabpage.introShown", True)
-    fo.set_preference("browser.aboutHomeSnippets.updateUrl", "")
 
     # Disable Pocket
     fo.set_preference("extensions.pocket.enabled", False)
 
-    # Disable Shield
+    # Disable Shield / Normandy studies
     fo.set_preference("app.shield.optoutstudies.enabled", False)
-    fo.set_preference("extensions.shield-recipe-client.enabled", False)
 
     # Disable Source Pragmas
     # As per https://bugzilla.mozilla.org/show_bug.cgi?id=1628853


### PR DESCRIPTION
## Summary
- Remove 27 Firefox preferences that no longer exist in modern Firefox (v147+), verified against mozilla-central via searchfox.org
- Fix typo: `browser.safebrowsing.phising.enabled` -> `browser.safebrowsing.phishing.enabled`
- Clean up stale comments

Closes #1060

## Changes
- `openwpm/deploy_browsers/configure_firefox.py`: Remove obsolete prefs, fix typo, update comments

### Removed preferences (categories)
- **Startup**: `browser.slowStartup.*`, `extensions.checkCompatibility.nightly`, `dom.flyweb.enabled`
- **Plugins (NPAPI removed)**: `dom.ipc.plugins.*`
- **Telemetry**: `browser.selfsupport.url`
- **Search/Location**: `browser.urlbar.userMadeSearchSuggestionsChoice`, `browser.casting.enabled`, `browser.search.countryCode`, `browser.search.geoSpecificDefaults*`
- **Updates**: `app.update.enabled`, `lightweightThemes.update.enabled`
- **Experiments**: `experiments.*`, `network.allow-experiments`
- **New Tab**: `browser.newtabpage.directory.*`, `browser.newtabpage.enhanced`, `browser.newtabpage.introShown`, `browser.aboutHomeSnippets.updateUrl`
- **Shield**: `extensions.shield-recipe-client.enabled`
- **Safebrowsing**: `browser.safebrowsing.phising.enabled` (typo'd name removed; corrected `browser.safebrowsing.phishing.enabled` re-added)

## Test plan
- [ ] Run full test suite to verify no regressions
- [ ] Verify Firefox starts correctly with updated preferences
