### PR TITLE
feat(storage): rewrite SQLiteStorageProvider to use SQLAlchemy

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -31,6 +31,7 @@ dependencies:
 - s3fs=2026.2.0
 - selenium=4.41.0
 - sentry-sdk=2.56.0
+- sqlalchemy=2.0.36
 - sphinx-markdown-tables=0.0.17
 - sphinx=9.1.0
 - tabulate=0.10.0

--- a/openwpm/storage/sql_provider.py
+++ b/openwpm/storage/sql_provider.py
@@ -1,109 +1,46 @@
-import json
 import logging
-import os
-import sqlite3
+from asyncio import Task
 from pathlib import Path
-from sqlite3 import (
-    Connection,
-    Cursor,
-    IntegrityError,
-    InterfaceError,
-    OperationalError,
-    ProgrammingError,
-)
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, Optional
 
 from openwpm.types import VisitId
 
+from .sqlalchemy_provider import SQLAlchemyStorageProvider
 from .storage_providers import StructuredStorageProvider, TableName
-
-SCHEMA_FILE = os.path.join(os.path.dirname(__file__), "schema.sql")
 
 
 class SQLiteStorageProvider(StructuredStorageProvider):
-    db: Connection
-    cur: Cursor
+    """SQLite-backed StructuredStorageProvider.
+
+    Thin wrapper around SQLAlchemyStorageProvider that preserves the
+    original ``__init__(self, db_path: Path)`` constructor signature
+    used throughout the codebase.
+    """
 
     def __init__(self, db_path: Path) -> None:
         super().__init__()
         self.db_path = db_path
-        self._sql_counter = 0
-        self._sql_commit_time = 0
+        self._delegate = SQLAlchemyStorageProvider(f"sqlite:///{db_path}")
         self.logger = logging.getLogger("openwpm")
 
     async def init(self) -> None:
-        self.db = sqlite3.connect(str(self.db_path))
-        self.cur = self.db.cursor()
-        self._create_tables()
-
-    def _create_tables(self) -> None:
-        """Create tables (if this is a new database)"""
-        with open(SCHEMA_FILE, "r") as f:
-            self.db.executescript(f.read())
-        self.db.commit()
+        await self._delegate.init()
 
     async def flush_cache(self) -> None:
-        self.db.commit()
+        await self._delegate.flush_cache()
 
     async def store_record(
         self, table: TableName, visit_id: VisitId, record: Dict[str, Any]
     ) -> None:
-        """Submit a record to be stored
-        The storing might not happen immediately
-        """
-        assert self.cur is not None
-        statement, args = self._generate_insert(table=table, data=record)
-        for i in range(len(args)):
-            if isinstance(args[i], bytes):
-                args[i] = str(args[i], errors="ignore")
-            elif callable(args[i]):
-                args[i] = str(args[i])
-            elif type(args[i]) == dict:
-                args[i] = json.dumps(args[i])
-        try:
-            self.cur.execute(statement, args)
-            self._sql_counter += 1
-        except (
-            OperationalError,
-            ProgrammingError,
-            IntegrityError,
-            InterfaceError,
-        ) as e:
-            self.logger.error(
-                "Unsupported record:\n%s\n%s\n%s\n%s\n"
-                % (type(e), e, statement, repr(args))
-            )
-
-    @staticmethod
-    def _generate_insert(
-        table: TableName, data: Dict[str, Any]
-    ) -> Tuple[str, List[Any]]:
-        """Generate a SQL query from `record`"""
-        statement = "INSERT INTO %s (" % table
-        value_str = "VALUES ("
-        values = list()
-        first = True
-        for field, value in data.items():
-            statement += "" if first else ", "
-            statement += field
-            value_str += "?" if first else ",?"
-            values.append(value)
-            first = False
-        statement = statement + ") " + value_str + ")"
-        return statement, values
-
-    def execute_statement(self, statement: str) -> None:
-        self.cur.execute(statement)
-        self.db.commit()
+        await self._delegate.store_record(table, visit_id, record)
 
     async def finalize_visit_id(
         self, visit_id: VisitId, interrupted: bool = False
-    ) -> None:
-        if interrupted:
-            self.logger.warning("Visit with visit_id %d got interrupted", visit_id)
-            self.cur.execute("INSERT INTO incomplete_visits VALUES (?)", (visit_id,))
-        self.db.commit()
+    ) -> Optional[Task[None]]:
+        return await self._delegate.finalize_visit_id(visit_id, interrupted)
 
     async def shutdown(self) -> None:
-        self.db.commit()
-        self.db.close()
+        await self._delegate.shutdown()
+
+    def execute_statement(self, statement: str) -> None:
+        self._delegate.execute_statement(statement)

--- a/openwpm/storage/sqlalchemy_provider.py
+++ b/openwpm/storage/sqlalchemy_provider.py
@@ -1,0 +1,135 @@
+import json
+import logging
+from asyncio import Task
+from typing import Any, Dict, Optional
+
+from sqlalchemy import MetaData, Table, create_engine, text
+from sqlalchemy.engine import Connection, Engine
+
+from openwpm.types import VisitId
+
+from .sqlalchemy_schema import TABLE_MAP, metadata
+from .storage_providers import StructuredStorageProvider, TableName
+
+
+class SQLAlchemyStorageProvider(StructuredStorageProvider):
+    """StructuredStorageProvider backed by any SQLAlchemy-supported database."""
+
+    def __init__(self, db_url: str, **engine_kwargs: Any) -> None:
+        super().__init__()
+        self.db_url = db_url
+        self.engine_kwargs = engine_kwargs
+        self.logger = logging.getLogger("openwpm")
+        self._engine: Optional[Engine] = None
+        self._connection: Optional[Connection] = None
+        self._sql_counter = 0
+        # Cache for dynamically reflected tables (custom tables not in TABLE_MAP)
+        self._reflected_tables: Dict[str, Table] = {}
+
+    async def init(self) -> None:
+        self._engine = create_engine(self.db_url, **self.engine_kwargs)
+        self._connection = self._engine.connect()
+        metadata.create_all(self._engine)
+
+    def _get_table(self, table_name: str) -> Table:
+        """Look up a SQLAlchemy Table object by name.
+
+        First checks the static TABLE_MAP (for known schema tables).
+        Falls back to reflecting the table from the database (for custom tables
+        like 'page_links' created by custom commands).
+        """
+        if table_name in TABLE_MAP:
+            return TABLE_MAP[table_name]
+        if table_name in self._reflected_tables:
+            return self._reflected_tables[table_name]
+        # Reflect unknown table from database (supports custom tables).
+        # Use a separate MetaData instance to avoid polluting the canonical
+        # metadata with reflected tables. This keeps metadata.create_all()
+        # idempotent (only creates known schema tables).
+        assert self._engine is not None
+        reflected_meta = MetaData()
+        reflected_table = Table(table_name, reflected_meta, autoload_with=self._engine)
+        self._reflected_tables[table_name] = reflected_table
+        return reflected_table
+
+    async def flush_cache(self) -> None:
+        assert self._connection is not None
+        self._connection.commit()
+
+    async def store_record(
+        self, table: TableName, visit_id: VisitId, record: Dict[str, Any]
+    ) -> None:
+        assert self._connection is not None
+        record = self._coerce_record(record)
+        sa_table = self._get_table(table)
+        try:
+            self._connection.execute(sa_table.insert(), record)
+            self._sql_counter += 1
+        except Exception as e:
+            self.logger.error(
+                "Unsupported record:\n%s\n%s\ntable=%s\n%s\n"
+                % (type(e), e, table, repr(record))
+            )
+            # On PostgreSQL, a failed statement aborts the entire transaction.
+            # All subsequent statements would fail with "InFailedSqlTransaction"
+            # until a ROLLBACK is issued. We must rollback here so that
+            # subsequent inserts can succeed.
+            try:
+                self._connection.rollback()
+            except Exception:
+                pass  # Best-effort rollback
+
+    async def finalize_visit_id(
+        self, visit_id: VisitId, interrupted: bool = False
+    ) -> Optional[Task[None]]:
+        assert self._connection is not None
+        if interrupted:
+            self.logger.warning("Visit with visit_id %d got interrupted", visit_id)
+            incomplete = TABLE_MAP["incomplete_visits"]
+            self._connection.execute(incomplete.insert(), {"visit_id": visit_id})
+        self._connection.commit()
+        return None
+
+    async def shutdown(self) -> None:
+        if self._connection is not None:
+            self._connection.commit()
+            self._connection.close()
+        if self._engine is not None:
+            self._engine.dispose()
+
+    def execute_statement(self, statement: str) -> None:
+        """Execute a raw SQL statement and commit.
+
+        This is not part of the StructuredStorageProvider interface.
+        It is provided for backward compatibility with code that uses
+        SQLiteStorageProvider.execute_statement.
+        """
+        assert self._connection is not None
+        self._connection.execute(text(statement))
+        self._connection.commit()
+
+    @staticmethod
+    def _coerce_record(record: Dict[str, Any]) -> Dict[str, Any]:
+        """Apply type coercions to ensure cross-dialect compatibility.
+
+        - bool -> int (defensive for PostgreSQL INTEGER columns)
+        - bytes -> str (with errors='ignore')
+        - callable -> str(callable)
+        - dict -> json.dumps(dict)
+
+        Note: type(value) == dict (not isinstance) is inherited from the
+        original SQLiteStorageProvider. This means dict subclasses like
+        OrderedDict will NOT be JSON-serialized. This is a known limitation.
+        """
+        coerced = {}
+        for key, value in record.items():
+            if isinstance(value, bool):
+                value = int(value)
+            elif isinstance(value, bytes):
+                value = str(value, errors="ignore")
+            elif callable(value):
+                value = str(value)
+            elif type(value) == dict:
+                value = json.dumps(value)
+            coerced[key] = value
+        return coerced

--- a/openwpm/storage/sqlalchemy_schema.py
+++ b/openwpm/storage/sqlalchemy_schema.py
@@ -1,0 +1,274 @@
+from sqlalchemy import Column, Integer, MetaData, String, Table, Text, text
+
+metadata = MetaData()
+
+# Note: All DATETIME columns from schema.sql are defined as Text here.
+# Rationale: The extension sends timestamp strings (not Python datetime objects),
+# and test_values.py uses random_word(12) for all timestamp fields. Using Text
+# ensures cross-dialect compatibility (SQLite stores datetimes as text anyway,
+# and PostgreSQL would reject non-datetime strings in a DATETIME column).
+# Columns with server_default still use text("CURRENT_TIMESTAMP") which works
+# on both SQLite and PostgreSQL regardless of column type.
+
+# Note: Foreign keys from schema.sql are NOT included in the SQLAlchemy schema.
+# Rationale: SQLite does not enforce FKs by default (requires PRAGMA foreign_keys=ON),
+# and the current codebase never enables this pragma. PostgreSQL enforces FKs by
+# default, and test data (test_values.py) generates random IDs that violate FK
+# constraints. Removing FKs from the SQLAlchemy schema avoids PostgreSQL insert
+# failures. The FKs remain documented in schema.sql as a reference.
+
+task = Table(
+    "task",
+    metadata,
+    Column("task_id", Integer, primary_key=True, autoincrement=True),
+    Column("start_time", Text, server_default=text("CURRENT_TIMESTAMP")),
+    Column("manager_params", Text, nullable=False),
+    Column("openwpm_version", Text, nullable=False),
+    Column("browser_version", Text, nullable=False),
+    sqlite_autoincrement=True,
+)
+
+crawl = Table(
+    "crawl",
+    metadata,
+    Column("browser_id", Integer, primary_key=True, autoincrement=False),
+    Column("task_id", Integer, nullable=False),
+    Column("browser_params", Text, nullable=False),
+    Column("start_time", Text, server_default=text("CURRENT_TIMESTAMP")),
+)
+
+site_visits = Table(
+    "site_visits",
+    metadata,
+    Column("visit_id", Integer, primary_key=True, autoincrement=False),
+    Column("browser_id", Integer, nullable=False),
+    Column("site_url", String(500), nullable=False),
+    Column("site_rank", Integer),
+)
+
+crawl_history = Table(
+    "crawl_history",
+    metadata,
+    Column("browser_id", Integer),
+    Column("visit_id", Integer),
+    Column("command", Text),
+    Column("arguments", Text),
+    Column("retry_number", Integer),
+    Column("command_status", Text),
+    Column("error", Text),
+    Column("traceback", Text),
+    Column("duration", Integer),
+    Column("dtg", Text, server_default=text("CURRENT_TIMESTAMP")),
+)
+
+http_requests = Table(
+    "http_requests",
+    metadata,
+    Column("id", Integer, primary_key=True, autoincrement=True),
+    Column("incognito", Integer),
+    Column("browser_id", Integer, nullable=False),
+    Column("visit_id", Integer, nullable=False),
+    Column("extension_session_uuid", Text),
+    Column("event_ordinal", Integer),
+    Column("window_id", Integer),
+    Column("tab_id", Integer),
+    Column("frame_id", Integer),
+    Column("url", Text, nullable=False),
+    Column("top_level_url", Text),
+    Column("parent_frame_id", Integer),
+    Column("frame_ancestors", Text),
+    Column("method", Text, nullable=False),
+    Column("referrer", Text, nullable=False),
+    Column("headers", Text, nullable=False),
+    Column("request_id", Integer, nullable=False),
+    Column("is_XHR", Integer),
+    Column("is_third_party_channel", Integer),
+    Column("is_third_party_to_top_window", Integer),
+    Column("triggering_origin", Text),
+    Column("loading_origin", Text),
+    Column("loading_href", Text),
+    Column("req_call_stack", Text),
+    Column("resource_type", Text, nullable=False),
+    Column("post_body", Text),
+    Column("post_body_raw", Text),
+    Column("time_stamp", Text, nullable=False),
+    sqlite_autoincrement=True,
+)
+
+http_responses = Table(
+    "http_responses",
+    metadata,
+    Column("id", Integer, primary_key=True, autoincrement=True),
+    Column("incognito", Integer),
+    Column("browser_id", Integer, nullable=False),
+    Column("visit_id", Integer, nullable=False),
+    Column("extension_session_uuid", Text),
+    Column("event_ordinal", Integer),
+    Column("window_id", Integer),
+    Column("tab_id", Integer),
+    Column("frame_id", Integer),
+    Column("url", Text, nullable=False),
+    Column("method", Text, nullable=False),
+    Column("response_status", Integer),
+    Column("response_status_text", Text, nullable=False),
+    Column("is_cached", Integer, nullable=False),
+    Column("headers", Text, nullable=False),
+    Column("request_id", Integer, nullable=False),
+    Column("location", Text, nullable=False),
+    Column("time_stamp", Text, nullable=False),
+    Column("content_hash", Text),
+    sqlite_autoincrement=True,
+)
+
+http_redirects = Table(
+    "http_redirects",
+    metadata,
+    Column("id", Integer, primary_key=True, autoincrement=True),
+    Column("incognito", Integer),
+    Column("browser_id", Integer, nullable=False),
+    Column("visit_id", Integer, nullable=False),
+    Column("old_request_url", Text),
+    Column("old_request_id", Text),
+    Column("new_request_url", Text),
+    Column("new_request_id", Text),
+    Column("extension_session_uuid", Text),
+    Column("event_ordinal", Integer),
+    Column("window_id", Integer),
+    Column("tab_id", Integer),
+    Column("frame_id", Integer),
+    Column("response_status", Integer, nullable=False),
+    Column("response_status_text", Text, nullable=False),
+    Column("headers", Text, nullable=False),
+    Column("time_stamp", Text, nullable=False),
+    sqlite_autoincrement=True,
+)
+
+# javascript: Note that id is INTEGER PRIMARY KEY *without* AUTOINCREMENT.
+# The id is provided by the extension, not auto-generated.
+javascript = Table(
+    "javascript",
+    metadata,
+    Column("id", Integer, primary_key=True, autoincrement=False),
+    Column("incognito", Integer),
+    Column("browser_id", Integer, nullable=False),
+    Column("visit_id", Integer, nullable=False),
+    Column("extension_session_uuid", Text),
+    Column("event_ordinal", Integer),
+    Column("page_scoped_event_ordinal", Integer),
+    Column("window_id", Integer),
+    Column("tab_id", Integer),
+    Column("frame_id", Integer),
+    Column("script_url", Text),
+    Column("script_line", Text),
+    Column("script_col", Text),
+    Column("func_name", Text),
+    Column("script_loc_eval", Text),
+    Column("document_url", Text),
+    Column("top_level_url", Text),
+    Column("call_stack", Text),
+    Column("symbol", Text),
+    Column("operation", Text),
+    Column("value", Text),
+    Column("arguments", Text),
+    Column("time_stamp", Text, nullable=False),
+)
+
+# javascript_cookies: id is INTEGER PRIMARY KEY ASC (no AUTOINCREMENT).
+# ASC merely specifies sort order (which is the default); it does NOT add
+# AUTOINCREMENT semantics. Use autoincrement=False.
+javascript_cookies = Table(
+    "javascript_cookies",
+    metadata,
+    Column("id", Integer, primary_key=True, autoincrement=False),
+    Column("browser_id", Integer, nullable=False),
+    Column("visit_id", Integer, nullable=False),
+    Column("extension_session_uuid", Text),
+    Column("event_ordinal", Integer),
+    Column("record_type", Text),
+    Column("change_cause", Text),
+    Column("expiry", Text),
+    Column("is_http_only", Integer),
+    Column("is_host_only", Integer),
+    Column("is_session", Integer),
+    Column("host", Text),
+    Column("is_secure", Integer),
+    Column("name", Text),
+    Column("path", Text),
+    Column("value", Text),
+    Column("same_site", Text),
+    Column("first_party_domain", Text),
+    Column(
+        "store_id", Text
+    ),  # schema.sql uses STRING, which is non-standard; Text is correct
+    Column("time_stamp", Text),
+)
+
+# navigations: UNUSUAL -- id is just INTEGER (not a primary key at all).
+# No autoincrement. Has committed_time_stamp as a separate DATETIME column.
+navigations = Table(
+    "navigations",
+    metadata,
+    Column("id", Integer),  # NOT a primary key
+    Column("incognito", Integer),
+    Column("browser_id", Integer, nullable=False),
+    Column("visit_id", Integer, nullable=False),
+    Column("extension_session_uuid", Text),
+    Column("process_id", Integer),
+    Column("window_id", Integer),
+    Column("tab_id", Integer),
+    Column("tab_opener_tab_id", Integer),
+    Column("frame_id", Integer),
+    Column("parent_frame_id", Integer),
+    Column("window_width", Integer),
+    Column("window_height", Integer),
+    Column("window_type", Text),
+    Column("tab_width", Integer),
+    Column("tab_height", Integer),
+    Column("tab_cookie_store_id", Text),
+    Column("uuid", Text),
+    Column("url", Text),
+    Column("transition_qualifiers", Text),
+    Column("transition_type", Text),
+    Column("before_navigate_event_ordinal", Integer),
+    Column("before_navigate_time_stamp", Text),
+    Column("committed_event_ordinal", Integer),
+    Column("committed_time_stamp", Text),
+)
+
+callstacks = Table(
+    "callstacks",
+    metadata,
+    Column("id", Integer, primary_key=True, autoincrement=True),
+    Column("request_id", Integer, nullable=False),
+    Column("browser_id", Integer, nullable=False),
+    Column("visit_id", Integer, nullable=False),
+    Column("call_stack", Text),
+    sqlite_autoincrement=True,
+)
+
+incomplete_visits = Table(
+    "incomplete_visits",
+    metadata,
+    Column("visit_id", Integer, nullable=False),
+)
+
+# dns_responses: Note the used_address column which IS in schema.sql
+# but is NOT in test_values.py. It must be included here.
+dns_responses = Table(
+    "dns_responses",
+    metadata,
+    Column("id", Integer, primary_key=True, autoincrement=True),
+    Column("request_id", Integer, nullable=False),
+    Column("browser_id", Integer, nullable=False),
+    Column("visit_id", Integer, nullable=False),
+    Column("hostname", Text),
+    Column("addresses", Text),
+    Column("used_address", Text),
+    Column("canonical_name", Text),
+    Column("is_TRR", Integer),
+    Column("time_stamp", Text, nullable=False),
+    sqlite_autoincrement=True,
+)
+
+# A dict mapping TableName -> Table for runtime lookup:
+TABLE_MAP = {t.name: t for t in metadata.sorted_tables}

--- a/scripts/environment-unpinned.yaml
+++ b/scripts/environment-unpinned.yaml
@@ -23,6 +23,7 @@ dependencies:
     - redis-py
     - s3fs
     - selenium
+    - sqlalchemy
     - sentry-sdk
     - tabulate
     - tblib

--- a/test/storage/fixtures.py
+++ b/test/storage/fixtures.py
@@ -11,6 +11,7 @@ from openwpm.storage.in_memory_storage import (
 from openwpm.storage.leveldb import LevelDbProvider
 from openwpm.storage.local_storage import LocalGzipProvider
 from openwpm.storage.sql_provider import SQLiteStorageProvider
+from openwpm.storage.sqlalchemy_provider import SQLAlchemyStorageProvider
 from openwpm.storage.storage_controller import INVALID_VISIT_ID
 from openwpm.storage.storage_providers import (
     StructuredStorageProvider,
@@ -20,6 +21,7 @@ from test.storage.test_values import dt_test_values, generate_test_values
 
 memory_structured = "memory_structured"
 sqlite = "sqlite"
+sqlalchemy_sqlite = "sqlalchemy_sqlite"
 memory_arrow = "memory_arrow"
 
 
@@ -32,6 +34,9 @@ def structured_provider(
     elif request.param == sqlite:
         tmp_path = tmp_path_factory.mktemp("sqlite")
         return SQLiteStorageProvider(tmp_path / "test_db.sqlite")
+    elif request.param == sqlalchemy_sqlite:
+        tmp_path = tmp_path_factory.mktemp("sqlalchemy_sqlite")
+        return SQLAlchemyStorageProvider(f"sqlite:///{tmp_path / 'test_db.sqlite'}")
     elif request.param == memory_arrow:
         return MemoryArrowProvider()
     assert isinstance(
@@ -43,6 +48,7 @@ def structured_provider(
 structured_scenarios: List[str] = [
     memory_structured,
     sqlite,
+    sqlalchemy_sqlite,
     memory_arrow,
 ]
 

--- a/test/storage/test_sqlalchemy_provider.py
+++ b/test/storage/test_sqlalchemy_provider.py
@@ -1,0 +1,198 @@
+"""Tests for the SQLAlchemy storage provider.
+
+Covers:
+1. Schema equivalence: SQLAlchemy-generated DDL matches schema.sql
+2. All-tables insertion: parametrized across all structured providers
+3. _coerce_record edge cases: bool, bytes, callable, dict coercions
+"""
+
+import json
+import os
+import re
+import sqlite3
+
+import pytest
+
+from openwpm.storage.sqlalchemy_provider import SQLAlchemyStorageProvider
+from openwpm.storage.storage_providers import StructuredStorageProvider, TableName
+from openwpm.types import VisitId
+
+from .fixtures import structured_scenarios
+from .test_values import dt_test_values
+
+SCHEMA_FILE = os.path.join(
+    os.path.dirname(os.path.realpath(__file__)),
+    "..",
+    "..",
+    "openwpm",
+    "storage",
+    "schema.sql",
+)
+
+
+@pytest.mark.pyonly
+@pytest.mark.asyncio
+async def test_schema_equivalence(tmp_path):
+    """Verify that SQLAlchemy DDL produces the same schema as schema.sql.
+
+    Compares column names, types, NOT NULL constraints, default values,
+    and AUTOINCREMENT status for every table.
+    """
+    # Create database via schema.sql directly (bypassing SQLiteStorageProvider
+    # which now delegates to SQLAlchemy — we need independent comparison).
+    legacy_db = tmp_path / "legacy.sqlite"
+    legacy_conn_setup = sqlite3.connect(str(legacy_db))
+    with open(SCHEMA_FILE, "r") as f:
+        legacy_conn_setup.executescript(f.read())
+    legacy_conn_setup.commit()
+    legacy_conn_setup.close()
+
+    # Create database via SQLAlchemy
+    sa_db = tmp_path / "sqlalchemy.sqlite"
+    sa_provider = SQLAlchemyStorageProvider(f"sqlite:///{sa_db}")
+    await sa_provider.init()
+    await sa_provider.shutdown()
+
+    legacy_conn = sqlite3.connect(str(legacy_db))
+    sa_conn = sqlite3.connect(str(sa_db))
+
+    try:
+        # Get table lists
+        legacy_tables = {
+            row[0]
+            for row in legacy_conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' "
+                "AND name != 'sqlite_sequence'"
+            ).fetchall()
+        }
+        sa_tables = {
+            row[0]
+            for row in sa_conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' "
+                "AND name != 'sqlite_sequence'"
+            ).fetchall()
+        }
+        assert (
+            legacy_tables == sa_tables
+        ), f"Table sets differ: legacy={legacy_tables}, sa={sa_tables}"
+
+        # Type normalization: schema.sql uses DATETIME, VARCHAR, STRING
+        # which SQLAlchemy normalizes to TEXT
+        type_map = {
+            "DATETIME": "TEXT",
+            "STRING": "TEXT",
+        }
+
+        def normalize_type(t: str) -> str:
+            upper = t.upper()
+            # Handle VARCHAR(N) -> VARCHAR(N) (both use it)
+            if upper in type_map:
+                return type_map[upper]
+            return upper
+
+        for table_name in sorted(legacy_tables):
+            legacy_cols = legacy_conn.execute(
+                f"PRAGMA table_info({table_name})"
+            ).fetchall()
+            sa_cols = sa_conn.execute(f"PRAGMA table_info({table_name})").fetchall()
+
+            # Verify same number of columns
+            assert len(legacy_cols) == len(sa_cols), (
+                f"Column count mismatch for {table_name}: "
+                f"legacy={len(legacy_cols)}, sa={len(sa_cols)}"
+            )
+
+            # PRAGMA table_info columns: cid, name, type, notnull, dflt_value, pk
+            for legacy_col, sa_col in zip(legacy_cols, sa_cols):
+                l_cid, l_name, l_type, l_notnull, l_default, l_pk = legacy_col
+                s_cid, s_name, s_type, s_notnull, s_default, s_pk = sa_col
+
+                assert (
+                    l_name == s_name
+                ), f"Column name mismatch in {table_name}: {l_name} vs {s_name}"
+                assert normalize_type(l_type) == normalize_type(s_type), (
+                    f"Type mismatch for {table_name}.{l_name}: " f"{l_type} vs {s_type}"
+                )
+                # Skip NOT NULL comparison for primary keys: SQLAlchemy always
+                # adds NOT NULL to PKs, while schema.sql may not have it.
+                if not l_pk:
+                    assert l_notnull == s_notnull, (
+                        f"NOT NULL mismatch for {table_name}.{l_name}: "
+                        f"{l_notnull} vs {s_notnull}"
+                    )
+                assert (
+                    l_pk == s_pk
+                ), f"PK mismatch for {table_name}.{l_name}: {l_pk} vs {s_pk}"
+
+            # Check AUTOINCREMENT via sqlite_master DDL
+            def _has_autoincrement(conn, tbl):
+                row = conn.execute(
+                    "SELECT sql FROM sqlite_master WHERE type='table' AND name=?",
+                    (tbl,),
+                ).fetchone()
+                return bool(row and re.search(r"AUTOINCREMENT", row[0], re.IGNORECASE))
+
+            legacy_ai = _has_autoincrement(legacy_conn, table_name)
+            sa_ai = _has_autoincrement(sa_conn, table_name)
+            assert legacy_ai == sa_ai, (
+                f"AUTOINCREMENT mismatch for {table_name}: "
+                f"legacy={legacy_ai}, sa={sa_ai}"
+            )
+    finally:
+        legacy_conn.close()
+        sa_conn.close()
+
+
+@pytest.mark.pyonly
+@pytest.mark.parametrize("structured_provider", structured_scenarios, indirect=True)
+@pytest.mark.asyncio
+async def test_all_tables_access(
+    structured_provider: StructuredStorageProvider,
+    test_values: dt_test_values,
+) -> None:
+    """Insert one record into every table across all structured providers."""
+    test_table, visit_ids = test_values
+    await structured_provider.init()
+
+    for table_name, test_data in test_table.items():
+        await structured_provider.store_record(
+            TableName(table_name), test_data["visit_id"], test_data
+        )
+
+    for visit_id in visit_ids:
+        await structured_provider.finalize_visit_id(visit_id)
+
+    await structured_provider.flush_cache()
+    await structured_provider.shutdown()
+
+
+@pytest.mark.pyonly
+def test_coerce_record_edge_cases():
+    """Unit test for SQLAlchemyStorageProvider._coerce_record."""
+    coerce = SQLAlchemyStorageProvider._coerce_record
+
+    # bool -> int
+    assert coerce({"flag": True}) == {"flag": 1}
+    assert coerce({"flag": False}) == {"flag": 0}
+
+    # bytes -> str (using str(bytes_val, errors="ignore"))
+    result = coerce({"data": b"hello"})
+    assert result["data"] == "hello"
+    assert isinstance(result["data"], str)
+
+    # callable -> str
+    result = coerce({"func": len})
+    assert isinstance(result["func"], str)
+    assert "len" in result["func"]
+
+    # dict -> json
+    d = {"key": "value", "num": 42}
+    result = coerce({"nested": d})
+    assert result["nested"] == json.dumps(d)
+
+    # passthrough: str, int, None
+    assert coerce({"s": "hello", "n": 42, "x": None}) == {
+        "s": "hello",
+        "n": 42,
+        "x": None,
+    }


### PR DESCRIPTION
## Summary

- Add `SQLAlchemyStorageProvider` backed by SQLAlchemy Core that supports any SQLAlchemy-compatible database (SQLite, PostgreSQL, etc.)
- Rewrite `SQLiteStorageProvider` as a thin wrapper delegating to `SQLAlchemyStorageProvider` with a `sqlite:///` URL
- Add comprehensive tests: schema equivalence verification, all-tables insertion across all providers, and `_coerce_record` edge cases

## Design decisions

- **SQLAlchemy Core** (not ORM) — matches the append-only insert pattern
- **DATETIME → Text** for cross-dialect compatibility (extension sends timestamp strings, not Python datetime objects)
- **No foreign keys** in SQLAlchemy schema (SQLite doesn't enforce them by default; test data violates them on PostgreSQL)
- **PostgreSQL transaction abort recovery** — `store_record` catches exceptions and rolls back so subsequent inserts can proceed
- **Table reflection fallback** — `_get_table()` reflects unknown tables from the database for custom commands (e.g. `page_links`)
- **`sqlite_autoincrement=True`** on tables that use `AUTOINCREMENT` in schema.sql, verified by schema equivalence test

## New files

| File | Description |
|------|-------------|
| `openwpm/storage/sqlalchemy_schema.py` | All 13 tables as SQLAlchemy `Table` objects on shared `MetaData` |
| `openwpm/storage/sqlalchemy_provider.py` | `StructuredStorageProvider` implementation |
| `test/storage/test_sqlalchemy_provider.py` | Schema equivalence + all-tables + coercion tests |

## Modified files

| File | Change |
|------|--------|
| `openwpm/storage/sql_provider.py` | Rewritten as thin wrapper around `SQLAlchemyStorageProvider` |
| `test/storage/fixtures.py` | Added `sqlalchemy_sqlite` scenario to structured providers |
| `environment.yaml` | Added `sqlalchemy>=2.0` dependency |

## Test plan

- [x] Schema equivalence test: PRAGMA table_info + AUTOINCREMENT comparison between schema.sql and SQLAlchemy DDL
- [x] All-tables insertion: parametrized across memory, sqlite, sqlalchemy_sqlite, and arrow providers (13 tables each)
- [x] `_coerce_record` edge cases: bool→int, bytes→str, callable→str, dict→json, passthrough
- [x] All 17 existing storage tests pass with the new `sqlalchemy_sqlite` scenario added

Closes #1143