### PR TITLE
ci: add 30-minute timeout to test jobs

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -26,6 +26,7 @@ jobs:
       - run: python demo.py --headless
   tests:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     strategy:
       matrix:
         group: [1, 2, 3, 4, 5, 6, 7]


### PR DESCRIPTION
## Summary
- Add `timeout-minutes: 30` to the `tests` job to prevent indefinite hangs when crash-recovery tests deadlock

Tests normally complete in ~12 minutes. The 30-minute limit provides headroom for slow runners while preventing hung jobs from blocking the merge queue indefinitely (the repo-level merge queue timeout is 20 minutes, but the job itself had no timeout and would burn runner minutes for up to 6 hours).