### PR TITLE
feat(ci): dynamic test duration tracking for pytest-split

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -94,6 +94,7 @@ jobs:
           name: test-durations-${{ matrix.group }}
           path: .test_durations_group_${{ matrix.group }}
           if-no-files-found: ignore
+          include-hidden-files: true
       - name: Upload coverage artifact
         uses: actions/upload-artifact@v4
         if: always()

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -34,6 +34,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup
+      - name: Restore test durations cache
+        uses: actions/cache/restore@v4
+        with:
+          path: .test_durations_cached
+          key: test-durations-${{ github.ref }}-${{ github.run_id }}
+          restore-keys: |
+            test-durations-${{ github.ref }}-
+            test-durations-refs/heads/master-
       - run: ./scripts/ci.sh
         env:
           DISPLAY: ":99.0"
@@ -78,12 +86,58 @@ jobs:
                           f.write(f": {oneliner}")
                       f.write(f"</summary>\n\n```\n{trace}\n```\n</details>\n\n")
           PYEOF
+      - name: Upload test durations
+        uses: actions/upload-artifact@v4
+        if: always()
+        continue-on-error: true
+        with:
+          name: test-durations-${{ matrix.group }}
+          path: .test_durations_group_${{ matrix.group }}
+          if-no-files-found: ignore
       - name: Upload coverage artifact
         uses: actions/upload-artifact@v4
         if: always()
         with:
           name: coverage-${{ matrix.group }}
           path: coverage.xml
+
+  consolidate-durations:
+    runs-on: ubuntu-latest
+    needs: tests
+    if: always()
+    steps:
+      - uses: actions/checkout@v4
+      - name: Download all duration artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: test-durations-*
+          path: duration-artifacts
+      - name: Merge durations
+        run: |
+          python - <<'PYEOF'
+          import json, glob, os
+
+          merged = {}
+          # Start with committed baseline
+          if os.path.exists(".test_durations"):
+              with open(".test_durations") as f:
+                  merged = json.load(f)
+
+          # Overlay fresh durations from each group
+          for path in sorted(glob.glob("duration-artifacts/test-durations-*/.test_durations_group_*")):
+              with open(path) as f:
+                  merged.update(json.load(f))
+
+          with open(".test_durations_cached", "w") as f:
+              json.dump(merged, f, indent=2, sort_keys=True)
+
+          print(f"Merged {len(merged)} test durations")
+          PYEOF
+      - name: Save durations to cache
+        uses: actions/cache/save@v4
+        with:
+          path: .test_durations_cached
+          key: test-durations-${{ github.ref }}-${{ github.run_id }}
 
   upload-coverage:
     runs-on: ubuntu-latest

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -1,9 +1,21 @@
 #!/bin/bash
 
+# Use cached durations if available, fall back to committed baseline
+if [ -f .test_durations_cached ]; then
+    DURATIONS_PATH=.test_durations_cached
+else
+    DURATIONS_PATH=.test_durations
+fi
+
 if [ -n "$GROUP" ] && [ -n "$SPLITS" ]; then
     # CI mode: use pytest-split for optimal distribution
-    python -m pytest --splits "$SPLITS" --group "$GROUP" --splitting-algorithm least_duration --cov=openwpm --junit-xml=junit-report.xml --cov-report=xml -s -v --durations=10
+    python -m pytest --splits "$SPLITS" --group "$GROUP" \
+        --splitting-algorithm least_duration \
+        --durations-path "$DURATIONS_PATH" \
+        --cov=openwpm --junit-xml=junit-report.xml --cov-report=xml \
+        -s -v --durations=10
 else
     # Local mode: run specific tests or all
-    python -m pytest --cov=openwpm --junit-xml=junit-report.xml --cov-report=xml $TESTS -s -v --durations=10
+    python -m pytest --cov=openwpm --junit-xml=junit-report.xml \
+        --cov-report=xml $TESTS -s -v --durations=10
 fi

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -27,16 +27,9 @@ def pytest_sessionfinish(session, exitstatus):
     import json
 
     group = os.environ.get("GROUP")
-    print(
-        f"\n[test-durations] GROUP={group!r}, "
-        f"collected {len(_test_durations)} durations, "
-        f"cwd={os.getcwd()}"
-    )
     if group and _test_durations:
-        path = f".test_durations_group_{group}"
-        with open(path, "w") as f:
+        with open(f".test_durations_group_{group}", "w") as f:
             json.dump(_test_durations, f, indent=2, sort_keys=True)
-        print(f"[test-durations] Wrote {path} ({os.path.getsize(path)} bytes)")
 
 
 EXTENSION_DIR = os.path.join(

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -15,6 +15,23 @@ from . import utilities
 from .openwpmtest import NUM_BROWSERS
 from .utilities import ServerUrls
 
+_test_durations: dict[str, float] = {}
+
+
+def pytest_runtest_logreport(report):
+    if report.when == "call":
+        _test_durations[report.nodeid] = round(report.duration, 2)
+
+
+def pytest_sessionfinish(session, exitstatus):
+    import json
+
+    group = os.environ.get("GROUP")
+    if group and _test_durations:
+        with open(f".test_durations_group_{group}", "w") as f:
+            json.dump(_test_durations, f, indent=2, sort_keys=True)
+
+
 EXTENSION_DIR = os.path.join(
     os.path.dirname(os.path.realpath(__file__)),
     "..",

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -27,9 +27,16 @@ def pytest_sessionfinish(session, exitstatus):
     import json
 
     group = os.environ.get("GROUP")
+    print(
+        f"\n[test-durations] GROUP={group!r}, "
+        f"collected {len(_test_durations)} durations, "
+        f"cwd={os.getcwd()}"
+    )
     if group and _test_durations:
-        with open(f".test_durations_group_{group}", "w") as f:
+        path = f".test_durations_group_{group}"
+        with open(path, "w") as f:
             json.dump(_test_durations, f, indent=2, sort_keys=True)
+        print(f"[test-durations] Wrote {path} ({os.path.getsize(path)} bytes)")
 
 
 EXTENSION_DIR = os.path.join(


### PR DESCRIPTION
## Summary

- Add pytest hooks in `test/conftest.py` to record per-test wall-clock durations, gated on `GROUP` env var (CI only)
- Update `scripts/ci.sh` to prefer cached durations over the committed `.test_durations` baseline
- Add cache restore/save steps and a `consolidate-durations` job to `.github/workflows/run-tests.yaml` that merges per-group artifacts into a single cached file

## How it works

**Per-run data flow:**
```
Restore cache → ci.sh picks cached or committed file → pytest-split distributes tests
    → conftest hook records durations → upload per-group artifacts
    → consolidation job merges all groups → save to cache
```

**Fallback chain** (priority order):
1. Cached durations from the most recent run on the same branch
2. Cached durations from the most recent run on `master`
3. Committed `.test_durations` file (unchanged, serves as baseline)

## Test plan

- [x] Run `pytest test/test_dataclass_validations.py -v` with `GROUP=1` — verified `.test_durations_group_1` is created with correct node IDs matching `.test_durations` format
- [ ] Verify CI workflow: cache restore (miss on first run), artifact upload, consolidation, cache save
- [ ] Push again to verify cache hit and that splitting uses cached durations