### PR TITLE
fix(browser): exclude DNS errors from consecutive failure limit

### DIFF
--- a/openwpm/browser_manager.py
+++ b/openwpm/browser_manager.py
@@ -43,12 +43,13 @@ if TYPE_CHECKING:
     from .task_manager import TaskManager
 
 
-def _is_dns_error(command_status: str, error_text: Optional[str]) -> bool:
+def is_dns_error(command_status: str, error_text: Optional[str]) -> bool:
     """Return True when the failure is a DNS resolution error (NXDOMAIN).
 
     DNS resolution errors are expected when crawling large domain lists
     (e.g. Tranco top-100k) and don't indicate a browser or instrumentation
-    failure.  # Only NXDOMAIN; DNS timeouts/SERVFAIL intentionally still count
+    failure.  Only NXDOMAIN is excluded; DNS timeouts and SERVFAIL
+    intentionally still count.
     """
     return (
         command_status == "neterror"
@@ -476,7 +477,7 @@ class BrowserManagerHandle:
                 return
 
             if command_status != "ok":
-                if not _is_dns_error(command_status, error_text):
+                if not is_dns_error(command_status, error_text):
                     with task_manager.threadlock:
                         task_manager.failure_count += 1
                 if task_manager.failure_count > task_manager.failure_limit:

--- a/openwpm/browser_manager.py
+++ b/openwpm/browser_manager.py
@@ -48,7 +48,7 @@ def is_dns_error(command_status: str, error_text: Optional[str]) -> bool:
 
     DNS resolution errors are expected when crawling large domain lists
     (e.g. Tranco top-100k) and don't indicate a browser or instrumentation
-    failure.  Only NXDOMAIN is excluded; DNS timeouts and SERVFAIL
+    failure. Only NXDOMAIN is excluded; DNS timeouts and SERVFAIL
     intentionally still count.
     """
     return (

--- a/openwpm/browser_manager.py
+++ b/openwpm/browser_manager.py
@@ -43,6 +43,20 @@ if TYPE_CHECKING:
     from .task_manager import TaskManager
 
 
+def _is_dns_error(command_status: str, error_text: Optional[str]) -> bool:
+    """Return True when the failure is a DNS resolution error (NXDOMAIN).
+
+    DNS resolution errors are expected when crawling large domain lists
+    (e.g. Tranco top-100k) and don't indicate a browser or instrumentation
+    failure.  # Only NXDOMAIN; DNS timeouts/SERVFAIL intentionally still count
+    """
+    return (
+        command_status == "neterror"
+        and error_text is not None
+        and error_text == "dnsNotFound"
+    )
+
+
 class BrowserManagerHandle:
     """The BrowserManagerHandle class is responsible for holding all the
     configuration and status information on BrowserManager process
@@ -462,8 +476,9 @@ class BrowserManagerHandle:
                 return
 
             if command_status != "ok":
-                with task_manager.threadlock:
-                    task_manager.failure_count += 1
+                if not _is_dns_error(command_status, error_text):
+                    with task_manager.threadlock:
+                        task_manager.failure_count += 1
                 if task_manager.failure_count > task_manager.failure_limit:
                     self.logger.critical(
                         "BROWSER %i: Command execution failure pushes failure "

--- a/openwpm/browser_manager.py
+++ b/openwpm/browser_manager.py
@@ -480,17 +480,20 @@ class BrowserManagerHandle:
                 if not is_dns_error(command_status, error_text):
                     with task_manager.threadlock:
                         task_manager.failure_count += 1
-                if task_manager.failure_count > task_manager.failure_limit:
-                    self.logger.critical(
-                        "BROWSER %i: Command execution failure pushes failure "
-                        "count above the allowable limit. Setting "
-                        "failure_status." % self.browser_id
-                    )
-                    task_manager.failure_status = {
-                        "ErrorType": "ExceedCommandFailureLimit",
-                        "CommandSequence": command_sequence,
-                    }
-                    return
+                        exceeded_limit = (
+                            task_manager.failure_count > task_manager.failure_limit
+                        )
+                    if exceeded_limit:
+                        self.logger.critical(
+                            "BROWSER %i: Command execution failure pushes failure "
+                            "count above the allowable limit. Setting "
+                            "failure_status." % self.browser_id
+                        )
+                        task_manager.failure_status = {
+                            "ErrorType": "ExceedCommandFailureLimit",
+                            "CommandSequence": command_sequence,
+                        }
+                        return
                 self.restart_required = True
                 self.logger.debug(
                     "BROWSER %i: Browser restart required" % self.browser_id

--- a/test/test_webdriver_utils.py
+++ b/test/test_webdriver_utils.py
@@ -1,6 +1,6 @@
 import pytest
 
-from openwpm.browser_manager import _is_dns_error
+from openwpm.browser_manager import is_dns_error
 from openwpm.commands.utils.webdriver_utils import parse_neterror
 from openwpm.utilities import db_utils
 
@@ -58,29 +58,29 @@ def test_dns_error_does_not_count_against_failure_limit(
     assert len(dns_rows) == num_domains
 
 
-def test_is_dns_error_predicate():
-    """AC-5: Verify that _is_dns_error is True only for dnsNotFound neterrors.
+def testis_dns_error_predicate():
+    """AC-5: Verify that is_dns_error is True only for dnsNotFound neterrors.
 
     Non-DNS neterror types (connectionRefused, netOffline, etc.) and other
     command statuses must NOT be treated as DNS errors, so they continue to
     increment failure_count as before.
     """
     # Only this exact combination qualifies
-    assert _is_dns_error("neterror", "dnsNotFound") is True
+    assert is_dns_error("neterror", "dnsNotFound") is True
 
     # Other neterror types must NOT be exempt
-    assert _is_dns_error("neterror", "connectionRefused") is False
-    assert _is_dns_error("neterror", "netOffline") is False
-    assert _is_dns_error("neterror", "proxyConnectFailure") is False
+    assert is_dns_error("neterror", "connectionRefused") is False
+    assert is_dns_error("neterror", "netOffline") is False
+    assert is_dns_error("neterror", "proxyConnectFailure") is False
 
     # Missing error_text must NOT be exempt
-    assert _is_dns_error("neterror", None) is False
+    assert is_dns_error("neterror", None) is False
 
     # Non-neterror statuses must NOT be exempt
-    assert _is_dns_error("ok", "dnsNotFound") is False
-    assert _is_dns_error("critical", "dnsNotFound") is False
-    assert _is_dns_error("error", "dnsNotFound") is False
-    assert _is_dns_error("timeout", "dnsNotFound") is False
+    assert is_dns_error("ok", "dnsNotFound") is False
+    assert is_dns_error("critical", "dnsNotFound") is False
+    assert is_dns_error("error", "dnsNotFound") is False
+    assert is_dns_error("timeout", "dnsNotFound") is False
 
     # parse_neterror returns the right code for a DNS failure message
     dns_msg = (
@@ -90,7 +90,7 @@ def test_is_dns_error_predicate():
         "f=regular&d=We+can%27t+connect"
     )
     assert parse_neterror(dns_msg) == "dnsNotFound"
-    assert _is_dns_error("neterror", parse_neterror(dns_msg)) is True
+    assert is_dns_error("neterror", parse_neterror(dns_msg)) is True
 
     # A different neterror code does NOT trigger the exemption
     conn_msg = (
@@ -100,4 +100,4 @@ def test_is_dns_error_predicate():
         "f=regular&d=refused."
     )
     assert parse_neterror(conn_msg) == "connectionRefused"
-    assert _is_dns_error("neterror", parse_neterror(conn_msg)) is False
+    assert is_dns_error("neterror", parse_neterror(conn_msg)) is False

--- a/test/test_webdriver_utils.py
+++ b/test/test_webdriver_utils.py
@@ -1,3 +1,6 @@
+import pytest
+
+from openwpm.browser_manager import _is_dns_error
 from openwpm.commands.utils.webdriver_utils import parse_neterror
 from openwpm.utilities import db_utils
 
@@ -26,3 +29,75 @@ def test_parse_neterror_integration(default_params, task_manager_creator):
 
     assert get_command[0] == "neterror"
     assert get_command[1] == "dnsNotFound"
+
+
+@pytest.mark.slow
+def test_dns_error_does_not_count_against_failure_limit(
+    default_params, task_manager_creator
+):
+    """AC-4: 100+ DNS errors must not trigger CommandExecutionError even with
+    a low failure_limit.  Each navigation to a non-existent domain produces a
+    dnsNotFound neterror that should be excluded from the failure counter."""
+    manager_params, browser_params = default_params
+    manager_params.num_browsers = 1
+    manager_params.failure_limit = 5
+    manager, db = task_manager_creator((manager_params, browser_params[:1]))
+
+    num_domains = 110
+    for i in range(num_domains):
+        manager.get(f"http://domain-{i}.invalid")
+
+    manager.close()
+
+    rows = db_utils.query_db(
+        db,
+        "SELECT command_status, error FROM crawl_history WHERE command='GetCommand'",
+        as_tuple=True,
+    )
+    dns_rows = [(s, e) for s, e in rows if s == "neterror" and e == "dnsNotFound"]
+    assert len(dns_rows) == num_domains
+
+
+def test_is_dns_error_predicate():
+    """AC-5: Verify that _is_dns_error is True only for dnsNotFound neterrors.
+
+    Non-DNS neterror types (connectionRefused, netOffline, etc.) and other
+    command statuses must NOT be treated as DNS errors, so they continue to
+    increment failure_count as before.
+    """
+    # Only this exact combination qualifies
+    assert _is_dns_error("neterror", "dnsNotFound") is True
+
+    # Other neterror types must NOT be exempt
+    assert _is_dns_error("neterror", "connectionRefused") is False
+    assert _is_dns_error("neterror", "netOffline") is False
+    assert _is_dns_error("neterror", "proxyConnectFailure") is False
+
+    # Missing error_text must NOT be exempt
+    assert _is_dns_error("neterror", None) is False
+
+    # Non-neterror statuses must NOT be exempt
+    assert _is_dns_error("ok", "dnsNotFound") is False
+    assert _is_dns_error("critical", "dnsNotFound") is False
+    assert _is_dns_error("error", "dnsNotFound") is False
+    assert _is_dns_error("timeout", "dnsNotFound") is False
+
+    # parse_neterror returns the right code for a DNS failure message
+    dns_msg = (
+        "selenium.common.exceptions.WebDriverException: "
+        "Message: Reached error page: "
+        "about:neterror?e=dnsNotFound&u=http%3A//missing.example/&c=UTF-8&"
+        "f=regular&d=We+can%27t+connect"
+    )
+    assert parse_neterror(dns_msg) == "dnsNotFound"
+    assert _is_dns_error("neterror", parse_neterror(dns_msg)) is True
+
+    # A different neterror code does NOT trigger the exemption
+    conn_msg = (
+        "selenium.common.exceptions.WebDriverException: "
+        "Message: Reached error page: "
+        "about:neterror?e=connectionRefused&u=http%3A//localhost%3A1/&c=UTF-8&"
+        "f=regular&d=refused."
+    )
+    assert parse_neterror(conn_msg) == "connectionRefused"
+    assert _is_dns_error("neterror", parse_neterror(conn_msg)) is False

--- a/test/test_webdriver_utils.py
+++ b/test/test_webdriver_utils.py
@@ -35,8 +35,8 @@ def test_parse_neterror_integration(default_params, task_manager_creator):
 def test_dns_error_does_not_count_against_failure_limit(
     default_params, task_manager_creator
 ):
-    """AC-4: 100+ DNS errors must not trigger CommandExecutionError even with
-    a low failure_limit.  Each navigation to a non-existent domain produces a
+    """100+ DNS errors must not trigger CommandExecutionError even with a low
+    failure_limit.  Each navigation to a non-existent domain produces a
     dnsNotFound neterror that should be excluded from the failure counter."""
     manager_params, browser_params = default_params
     manager_params.num_browsers = 1
@@ -59,7 +59,7 @@ def test_dns_error_does_not_count_against_failure_limit(
 
 
 def test_is_dns_error_predicate():
-    """AC-5: Verify that is_dns_error is True only for dnsNotFound neterrors.
+    """Verify that is_dns_error is True only for dnsNotFound neterrors.
 
     Non-DNS neterror types (connectionRefused, netOffline, etc.) and other
     command statuses must NOT be treated as DNS errors, so they continue to

--- a/test/test_webdriver_utils.py
+++ b/test/test_webdriver_utils.py
@@ -58,7 +58,7 @@ def test_dns_error_does_not_count_against_failure_limit(
     assert len(dns_rows) == num_domains
 
 
-def testis_dns_error_predicate():
+def test_is_dns_error_predicate():
     """AC-5: Verify that is_dns_error is True only for dnsNotFound neterrors.
 
     Non-DNS neterror types (connectionRefused, netOffline, etc.) and other

--- a/test/test_webdriver_utils.py
+++ b/test/test_webdriver_utils.py
@@ -35,19 +35,22 @@ def test_parse_neterror_integration(default_params, task_manager_creator):
 def test_dns_error_does_not_count_against_failure_limit(
     default_params, task_manager_creator
 ):
-    """100+ DNS errors must not trigger CommandExecutionError even with a low
-    failure_limit.  Each navigation to a non-existent domain produces a
-    dnsNotFound neterror that should be excluded from the failure counter."""
+    """DNS errors past failure_limit must not trigger CommandExecutionError.
+
+    Each navigation to a non-existent domain produces a dnsNotFound neterror
+    that should be excluded from the failure counter.
+    """
     manager_params, browser_params = default_params
     manager_params.num_browsers = 1
     manager_params.failure_limit = 5
     manager, db = task_manager_creator((manager_params, browser_params[:1]))
 
-    num_domains = 110
-    for i in range(num_domains):
-        manager.get(f"http://domain-{i}.invalid")
-
-    manager.close()
+    num_domains = manager_params.failure_limit * 3
+    try:
+        for i in range(num_domains):
+            manager.get(f"http://domain-{i}.invalid")
+    finally:
+        manager.close()
 
     rows = db_utils.query_db(
         db,


### PR DESCRIPTION
## Summary
- DNS resolution errors (`dnsNotFound` / NXDOMAIN) no longer count toward the consecutive failure limit that stops crawling. The browser still restarts after each DNS error — appropriately cautious for the measurement use case.
- Extract `is_dns_error()` as a named, importable function for testability
- Hold `task_manager.threadlock` across both the `failure_count` increment and the threshold compare so the update+compare is atomic across browser threads
- Add integration test that navigates to `failure_limit * 3` nonexistent domains, verifying the crawl continues past `failure_limit=5`
- Add unit tests that import and verify the real predicate (not a local copy)

Only `dnsNotFound` is excluded — DNS timeouts/SERVFAIL intentionally still count as they may indicate real network issues.

Supersedes #1139.
Closes https://github.com/openwpm/OpenWPM/issues/1116

## Test plan
- [ ] `test_dns_error_does_not_count_against_failure_limit` passes
- [ ] `test_is_dns_error_predicate` tests the real `is_dns_error` function
- [ ] `pre-commit run --all-files` passes