### PR TITLE
feat(otel): OpenTelemetry tracing with cross-process span propagation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
     hooks:
       - id: mypy
         additional_dependencies:
-          [pytest, types-tabulate, types-PyYAML, types-redis]
+          [pytest, types-tabulate, types-PyYAML, types-redis, types-requests]
         # We may need to add more and more dependencies here, as pre-commit
         # runs in an environment without our dependencies
   - repo: https://github.com/rhysd/actionlint

--- a/environment.yaml
+++ b/environment.yaml
@@ -40,9 +40,14 @@ dependencies:
   - dataclasses-json==0.6.7
   - domain-utils==0.7.1
   - jsonschema==4.26.0
+  - opentelemetry-api==1.30.0
+  - opentelemetry-sdk==1.30.0
+  - opentelemetry-exporter-otlp-proto-http==1.30.0
   - pytest-split==0.11.0
+  - testcontainers==4.12.0
   - tranco==0.8.1
   - types-pyyaml==6.0.12.20260518
+  - types-requests==2.32.0.20250515
   - types-redis==4.6.0.20241004
   - types-tabulate==0.10.0.20260508
 name: openwpm

--- a/openwpm/browser_manager.py
+++ b/openwpm/browser_manager.py
@@ -12,10 +12,12 @@ import time
 import traceback
 from pathlib import Path
 from queue import Empty as EmptyQueue
-from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple, Type, Union
+from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple, Type, Union, cast
 
 import psutil
 from multiprocess import Queue
+from opentelemetry import trace
+from opentelemetry.util.types import AttributeValue
 from selenium.common.exceptions import WebDriverException
 from tblib import Traceback, pickling_support
 
@@ -45,6 +47,8 @@ pickling_support.install()
 
 if TYPE_CHECKING:
     from .task_manager import TaskManager
+
+_tracer = trace.get_tracer(__name__)
 
 
 def is_dns_error(command_status: str, error_text: Optional[str]) -> bool:
@@ -360,6 +364,7 @@ class BrowserManagerHandle:
             if not shutdown_complete:
                 self.kill_browser_manager()
 
+    @_tracer.start_as_current_span("execute_command_sequence")
     def execute_command_sequence(
         self,
         # Quoting to break cyclic import, see https://stackoverflow.com/a/39757388
@@ -371,6 +376,10 @@ class BrowserManagerHandle:
         """
         assert self.browser_id is not None
         assert self.curr_visit_id is not None
+        trace.get_current_span().set_attributes(
+            {"browser_id": self.browser_id, "visit_id": self.curr_visit_id}
+        )
+
         task_manager.sock.store_record(
             TableName("site_visits"),
             self.curr_visit_id,
@@ -394,71 +403,71 @@ class BrowserManagerHandle:
         assert self.status_queue is not None
 
         for command_and_timeout in command_sequence.get_commands_with_timeout():
-            command, timeout = command_and_timeout
-            command.set_visit_browser_id(self.curr_visit_id, self.browser_id)
-            command.set_start_time(time.time())
-            self.current_timeout = timeout
+            command: BaseCommand = command_and_timeout[0]
+            timeout: int = command_and_timeout[1]
+            with _tracer.start_as_current_span(type(command).__name__):
+                trace.get_current_span().set_attributes({"timeout": timeout})
+                command.set_visit_browser_id(self.curr_visit_id, self.browser_id)
+                command.set_start_time(time.time())
+                self.current_timeout = timeout
 
-            # Adding timer to track performance of commands
-            t1 = time.time_ns()
+                # Adding timer to track performance of commands
+                t1 = time.time_ns()
 
-            # passes off command and waits for a success (or failure signal)
-            self.command_queue.put(command)
+                # passes off command and waits for a success (or failure signal)
+                self.command_queue.put(command)
 
-            # received reply from BrowserManager, either success or failure
-            error_text = None
-            tb = None
-            status = None
-            try:
-                status = self.status_queue.get(True, self.current_timeout)
-            except EmptyQueue:
-                self.logger.info(
-                    "BROWSER %i: Timeout while executing command, %s, killing "
-                    "browser manager" % (self.browser_id, repr(command))
-                )
+                # received reply from BrowserManager, either success or failure
+                error_text = None
+                tb = None
+                status = None
+                try:
+                    status = self.status_queue.get(True, self.current_timeout)
+                except EmptyQueue:
+                    self.logger.info(
+                        "BROWSER %i: Timeout while executing command, %s, killing "
+                        "browser manager" % (self.browser_id, repr(command))
+                    )
 
-            if status is None:
-                # allows us to skip this entire block without having to bloat
-                # every if statement
-                command_status = "timeout"
-                pass
-            elif status == "OK":
-                command_status = "ok"
-            elif status[0] == "CRITICAL":
-                command_status = "critical"
-                self.logger.critical(
-                    "BROWSER %i: Received critical error from browser "
-                    "process while executing command %s. Setting failure "
-                    "status." % (self.browser_id, str(command))
-                )
-                task_manager.failure_status = {
-                    "ErrorType": "CriticalChildException",
-                    "CommandSequence": command_sequence,
-                    "Exception": status[1],
-                }
-                error_text, tb = self._unpack_pickled_error(status[1])
-            elif status[0] == "FAILED":
-                command_status = "error"
-                error_text, tb = self._unpack_pickled_error(status[1])
-                self.logger.info(
-                    "BROWSER %i: Received failure status while executing "
-                    "command: %s" % (self.browser_id, repr(command))
-                )
-            elif status[0] == "NETERROR":
-                command_status = "neterror"
-                error_text, tb = self._unpack_pickled_error(status[1])
-                error_text = parse_neterror(error_text)
-                self.logger.info(
-                    "BROWSER %i: Received neterror %s while executing "
-                    "command: %s" % (self.browser_id, error_text, repr(command))
-                )
-            else:
-                raise ValueError("Unknown browser status message %s" % status)
+                if status is None:
+                    # allows us to skip this entire block without having to bloat
+                    # every if statement
+                    command_status = "timeout"
+                    pass
+                elif status == "OK":
+                    command_status = "ok"
+                elif status[0] == "CRITICAL":
+                    command_status = "critical"
+                    self.logger.critical(
+                        "BROWSER %i: Received critical error from browser "
+                        "process while executing command %s. Setting failure "
+                        "status." % (self.browser_id, str(command))
+                    )
+                    task_manager.failure_status = {
+                        "ErrorType": "CriticalChildException",
+                        "CommandSequence": command_sequence,
+                        "Exception": status[1],
+                    }
+                    error_text, tb = self._unpack_pickled_error(status[1])
+                elif status[0] == "FAILED":
+                    command_status = "error"
+                    error_text, tb = self._unpack_pickled_error(status[1])
+                    self.logger.info(
+                        "BROWSER %i: Received failure status while executing "
+                        "command: %s" % (self.browser_id, repr(command))
+                    )
+                elif status[0] == "NETERROR":
+                    command_status = "neterror"
+                    error_text, tb = self._unpack_pickled_error(status[1])
+                    error_text = parse_neterror(error_text)
+                    self.logger.info(
+                        "BROWSER %i: Received neterror %s while executing "
+                        "command: %s" % (self.browser_id, error_text, repr(command))
+                    )
+                else:
+                    raise ValueError("Unknown browser status message %s" % status)
 
-            task_manager.sock.store_record(
-                TableName("crawl_history"),
-                self.curr_visit_id,
-                {
+                table_entry = {
                     "browser_id": self.browser_id,
                     "visit_id": self.curr_visit_id,
                     "command": type(command).__name__,
@@ -470,85 +479,104 @@ class BrowserManagerHandle:
                     "error": error_text,
                     "traceback": tb,
                     "duration": int((time.time_ns() - t1) / 1000000),
-                },
-            )
-
-            if command_status == "critical":
-                task_manager.sock.finalize_visit_id(
-                    success=False,
-                    visit_id=self.curr_visit_id,
-                )
-                return
-
-            if command_status != "ok":
-                if not is_dns_error(command_status, error_text):
-                    with task_manager.threadlock:
-                        task_manager.failure_count += 1
-                        exceeded_limit = (
-                            task_manager.failure_count > task_manager.failure_limit
-                        )
-                    if exceeded_limit:
-                        self.logger.critical(
-                            "BROWSER %i: Command execution failure pushes failure "
-                            "count above the allowable limit. Setting "
-                            "failure_status." % self.browser_id
-                        )
-                        task_manager.failure_status = {
-                            "ErrorType": "ExceedCommandFailureLimit",
-                            "CommandSequence": command_sequence,
-                        }
-                        return
-                self.restart_required = True
-                self.logger.debug(
-                    "BROWSER %i: Browser restart required" % self.browser_id
-                )
-            # Reset failure_count at the end of each successful command sequence
-            elif type(command) is FinalizeCommand:
-                with task_manager.threadlock:
-                    task_manager.failure_count = 0
-
-            if self.restart_required:
-                task_manager.sock.finalize_visit_id(
-                    success=False, visit_id=self.curr_visit_id
-                )
-                break
-
-        self.logger.info(
-            "Finished working on CommandSequence with "
-            "visit_id %d on browser with id %d",
-            self.curr_visit_id,
-            self.browser_id,
-        )
-        # Sleep after executing CommandSequence to provide extra time for
-        # internal buffers to drain. Stopgap in support of #135
-        time.sleep(2)
-
-        if task_manager.closing:
-            return
-
-        # Allow StorageWatchdog to utilize built-in browser reset functionality
-        # which results in a graceful restart of the browser instance
-        if self.browser_params.maximum_profile_size:
-            assert self.current_profile_path is not None
-
-            reset = profile_size_exceeds_max_size(
-                self.current_profile_path,
-                self.browser_params.maximum_profile_size,
-            )
-
-        if self.restart_required or reset:
-            success = self.restart_browser_manager(clear_profile=reset)
-            if not success:
-                self.logger.critical(
-                    "BROWSER %i: Exceeded the maximum allowable consecutive "
-                    "browser launch failures. Setting failure_status." % self.browser_id
-                )
-                task_manager.failure_status = {
-                    "ErrorType": "ExceedLaunchFailureLimit",
-                    "CommandSequence": command_sequence,
                 }
+                task_manager.sock.store_record(
+                    TableName("crawl_history"),
+                    self.curr_visit_id,
+                    table_entry,
+                )
+                for k in [
+                    "browser_id",
+                    "visit_id",
+                    "command",
+                    "duration",
+                    "arguments",
+                    "traceback",
+                ]:
+                    table_entry.pop(k, None)
+                for k in list(table_entry.keys()):
+                    if table_entry[k] is None:
+                        del table_entry[k]
+                table_entry = cast(dict[str, AttributeValue], table_entry)
+                trace.get_current_span().set_attributes(table_entry)
+
+                if command_status == "critical":
+                    task_manager.sock.finalize_visit_id(
+                        success=False,
+                        visit_id=self.curr_visit_id,
+                    )
+                    return
+
+                if command_status != "ok":
+                    if not is_dns_error(command_status, error_text):
+                        with task_manager.threadlock:
+                            task_manager.failure_count += 1
+                            exceeded_limit = (
+                                task_manager.failure_count > task_manager.failure_limit
+                            )
+                        if exceeded_limit:
+                            self.logger.critical(
+                                "BROWSER %i: Command execution failure pushes failure "
+                                "count above the allowable limit. Setting "
+                                "failure_status." % self.browser_id
+                            )
+                            task_manager.failure_status = {
+                                "ErrorType": "ExceedCommandFailureLimit",
+                                "CommandSequence": command_sequence,
+                            }
+                            return
+                    self.restart_required = True
+                    self.logger.debug(
+                        "BROWSER %i: Browser restart required" % self.browser_id
+                    )
+                # Reset failure_count at the end of each successful command sequence
+                elif type(command) is FinalizeCommand:
+                    with task_manager.threadlock:
+                        task_manager.failure_count = 0
+
+                if self.restart_required:
+                    task_manager.sock.finalize_visit_id(
+                        success=False, visit_id=self.curr_visit_id
+                    )
+                    break
+        with _tracer.start_as_current_span("post_cs_chores"):
+            self.logger.info(
+                "Finished working on CommandSequence with "
+                "visit_id %d on browser with id %d",
+                self.curr_visit_id,
+                self.browser_id,
+            )
+            # Sleep after executing CommandSequence to provide extra time for
+            # internal buffers to drain. Stopgap in support of #135
+            time.sleep(2)
+
+            if task_manager.closing:
                 return
-            self.restart_required = False
+
+            # Allow StorageWatchdog to utilize built-in browser reset functionality
+            # which results in a graceful restart of the browser instance
+            if self.browser_params.maximum_profile_size:
+                assert self.current_profile_path is not None
+
+                reset = profile_size_exceeds_max_size(
+                    self.current_profile_path,
+                    self.browser_params.maximum_profile_size,
+                )
+
+            if self.restart_required or reset:
+                success = self.restart_browser_manager(clear_profile=reset)
+                if not success:
+                    self.logger.critical(
+                        "BROWSER %i: Exceeded the maximum allowable consecutive "
+                        "browser launch failures. Setting failure_status."
+                        % self.browser_id
+                    )
+                    task_manager.failure_status = {
+                        "ErrorType": "ExceedLaunchFailureLimit",
+                        "CommandSequence": command_sequence,
+                    }
+                    return
+                self.restart_required = False
 
     def _unpack_pickled_error(self, pickled_error: bytes) -> Tuple[str, str]:
         """Unpacks `pickled_error` into an error `message` and `tb` string."""
@@ -683,6 +711,7 @@ class BrowserManager(Process):
         crash_recovery: bool,
     ) -> None:
         super().__init__()
+        self.name = f"BrowserManager-{browser_params.browser_id}"
         self.logger = logging.getLogger("openwpm")
         self.command_queue = command_queue
         self.status_queue = status_queue
@@ -697,6 +726,7 @@ class BrowserManager(Process):
         if self.manager_params.testing:
             self.critical_exceptions += (AssertionError,)
 
+    @_tracer.start_as_current_span("start_extension")
     def _start_extension(self, browser_profile_path: Path) -> ClientSocket:
         """Start up the extension
         Blocks until the extension has fully started up
@@ -763,25 +793,26 @@ class BrowserManager(Process):
             )
 
         try:
-            # Start Xvfb (if necessary), webdriver, and browser
-            driver, browser_profile_path, display = deploy_firefox.deploy_firefox(
-                self.status_queue,
-                self.browser_params,
-                self.manager_params,
-                self.crash_recovery,
-            )
+            with _tracer.start_as_current_span("browser_startup"):
+                # Start Xvfb (if necessary), webdriver, and browser
+                driver, browser_profile_path, display = deploy_firefox.deploy_firefox(
+                    self.status_queue,
+                    self.browser_params,
+                    self.manager_params,
+                    self.crash_recovery,
+                )
 
-            extension_socket = self._start_extension(browser_profile_path)
+                extension_socket = self._start_extension(browser_profile_path)
 
-            self.logger.debug(
-                "BROWSER %i: BrowserManager ready." % self.browser_params.browser_id
-            )
+                self.logger.debug(
+                    "BROWSER %i: BrowserManager ready." % self.browser_params.browser_id
+                )
 
-            # passes "READY" to the TaskManager to signal a successful startup
-            self.status_queue.put(("STATUS", "Browser Ready", "READY"))
-            self.browser_params.profile_path = browser_profile_path
+                # passes "READY" to the TaskManager to signal a successful startup
+                self.status_queue.put(("STATUS", "Browser Ready", "READY"))
+                self.browser_params.profile_path = browser_profile_path
 
-            assert extension_socket is not None
+                assert extension_socket is not None
             # starts accepting arguments until told to die
             while True:
                 # no command for now -> sleep to avoid pegging CPU on blocking get

--- a/openwpm/browser_manager.py
+++ b/openwpm/browser_manager.py
@@ -16,7 +16,7 @@ from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple, Type, Union, cast
 
 import psutil
 from multiprocess import Queue
-from opentelemetry import trace
+from opentelemetry import propagate, trace
 from opentelemetry.util.types import AttributeValue
 from selenium.common.exceptions import WebDriverException
 from tblib import Traceback, pickling_support
@@ -328,7 +328,7 @@ class BrowserManagerHandle:
 
             # Send the shutdown command
             command = ShutdownSignal()
-            self.command_queue.put(command)
+            self.command_queue.put((command, {}))
 
             # Verify that webdriver has closed (30 second timeout)
             try:
@@ -414,8 +414,13 @@ class BrowserManagerHandle:
                 # Adding timer to track performance of commands
                 t1 = time.time_ns()
 
+                # Inject OTel span context so BrowserManager can
+                # create child spans linked to this command span.
+                carrier: Dict[str, str] = {}
+                propagate.inject(carrier)
+
                 # passes off command and waits for a success (or failure signal)
-                self.command_queue.put(command)
+                self.command_queue.put((command, carrier))
 
                 # received reply from BrowserManager, either success or failure
                 error_text = None
@@ -820,7 +825,12 @@ class BrowserManager(Process):
                     time.sleep(0.001)
                     continue
 
-                command: Union[ShutdownSignal, BaseCommand] = self.command_queue.get()
+                command: Union[ShutdownSignal, BaseCommand]
+                item = self.command_queue.get()
+                if isinstance(item, tuple):
+                    command, carrier = item
+                else:
+                    command, carrier = item, {}
 
                 if isinstance(command, ShutdownSignal):
                     driver.quit()
@@ -833,16 +843,23 @@ class BrowserManager(Process):
                     % (self.browser_params.browser_id, str(command))
                 )
 
+                # Extract the parent span context propagated from
+                # TaskManager so this span is linked in the same trace.
+                parent_ctx = propagate.extract(carrier)
+
                 # attempts to perform an action and return an OK signal
                 # if command fails for whatever reason, tell the TaskManager to
                 # kill and restart its worker processes
                 try:
-                    command.execute(
-                        driver,
-                        self.browser_params,
-                        self.manager_params,
-                        extension_socket,
-                    )
+                    with _tracer.start_as_current_span(
+                        type(command).__name__, context=parent_ctx
+                    ):
+                        command.execute(
+                            driver,
+                            self.browser_params,
+                            self.manager_params,
+                            extension_socket,
+                        )
                     self.status_queue.put("OK")
                 except WebDriverException:
                     # We handle WebDriverExceptions separately here because they

--- a/openwpm/browser_manager.py
+++ b/openwpm/browser_manager.py
@@ -392,7 +392,6 @@ class BrowserManagerHandle:
         )
         self.is_fresh = False
 
-        reset = command_sequence.reset
         self.logger.info(
             "Starting to work on CommandSequence with "
             "visit_id %d on browser with id %d",
@@ -497,6 +496,10 @@ class BrowserManagerHandle:
                     "duration",
                     "arguments",
                     "traceback",
+                    # store_record mutates table_entry to inject the OTel
+                    # context carrier (a dict); drop it so set_attributes
+                    # below is not handed a non-primitive value.
+                    "__otel_ctx",
                 ]:
                     table_entry.pop(k, None)
                 for k in list(table_entry.keys()):
@@ -559,11 +562,14 @@ class BrowserManagerHandle:
                 return
 
             # Allow StorageWatchdog to utilize built-in browser reset functionality
-            # which results in a graceful restart of the browser instance
+            # which results in a graceful restart of the browser instance.
+            # Preserve an explicitly requested stateless-crawl reset; the
+            # profile-size check can only add to it, never clear it.
+            reset = command_sequence.reset
             if self.browser_params.maximum_profile_size:
                 assert self.current_profile_path is not None
 
-                reset = profile_size_exceeds_max_size(
+                reset = reset or profile_size_exceeds_max_size(
                     self.current_profile_path,
                     self.browser_params.maximum_profile_size,
                 )

--- a/openwpm/storage/storage_controller.py
+++ b/openwpm/storage/storage_controller.py
@@ -11,7 +11,7 @@ from collections import defaultdict
 from typing import Any, DefaultDict, Dict, List, NoReturn, Optional, Tuple
 
 from multiprocess import Queue
-from opentelemetry import trace
+from opentelemetry import propagate, trace
 
 from openwpm.utilities.multiprocess_utils import Process
 
@@ -103,14 +103,12 @@ class StorageController:
         writer.close()
         await writer.wait_closed()
 
-    @_tracer.start_as_current_span("request_handler")
     async def handler(
         self, reader: asyncio.StreamReader, _: asyncio.StreamWriter
     ) -> None:
         """Created for every new connection to the Server"""
         client_name = await get_message_from_reader(reader)
         self.logger.info(f"Initializing new handler for {client_name}")
-        trace.get_current_span().set_attribute("client_name", client_name)
 
         while True:
             try:
@@ -127,39 +125,54 @@ class StorageController:
             self._last_record_received = time.time()
             record_type, data = record
 
-            if record_type == RECORD_TYPE_CREATE:
-                raise RuntimeError(f"""{RECORD_TYPE_CREATE} is no longer supported.
-                    Please change the schema before starting the StorageController.
-                    For an example of that see test/test_custom_function.py
-                    """)
+            # Extract propagated OTel context so spans in the
+            # StorageController are children of the caller's span.
+            parent_ctx = None
+            if isinstance(data, dict):
+                otel_carrier = data.pop("__otel_ctx", None)
+                if otel_carrier:
+                    parent_ctx = propagate.extract(otel_carrier)
 
-            if record_type == RECORD_TYPE_CONTENT:
-                assert len(data) == 2
-                if self.unstructured_storage is None:
-                    self.logger.error("""Tried to save content while not having
-                        provided any unstructured storage provider.""")
+            with _tracer.start_as_current_span(
+                "process_record", context=parent_ctx
+            ) as span:
+                span.set_attributes(
+                    {"record_type": record_type, "client_name": client_name}
+                )
+
+                if record_type == RECORD_TYPE_CREATE:
+                    raise RuntimeError(f"""{RECORD_TYPE_CREATE} is no longer supported.
+                        Please change the schema before starting the StorageController.
+                        For an example of that see test/test_custom_function.py
+                        """)
+
+                if record_type == RECORD_TYPE_CONTENT:
+                    assert len(data) == 2
+                    if self.unstructured_storage is None:
+                        self.logger.error("""Tried to save content while not having
+                            provided any unstructured storage provider.""")
+                        continue
+                    content, content_hash = data
+                    content = base64.b64decode(content)
+                    await self.unstructured_storage.store_blob(
+                        filename=content_hash, blob=content
+                    )
                     continue
-                content, content_hash = data
-                content = base64.b64decode(content)
-                await self.unstructured_storage.store_blob(
-                    filename=content_hash, blob=content
-                )
-                continue
 
-            if "visit_id" not in data:
-                self.logger.error(
-                    "Skipping record: No visit_id contained in record %r", record
-                )
-                continue
+                if "visit_id" not in data:
+                    self.logger.error(
+                        "Skipping record: No visit_id contained in record %r", record
+                    )
+                    continue
 
-            visit_id = VisitId(data["visit_id"])
+                visit_id = VisitId(data["visit_id"])
 
-            if record_type == RECORD_TYPE_META:
-                await self._handle_meta(visit_id, data)
-                continue
+                if record_type == RECORD_TYPE_META:
+                    await self._handle_meta(visit_id, data)
+                    continue
 
-            table_name = TableName(record_type)
-            await self.store_record(table_name, visit_id, data)
+                table_name = TableName(record_type)
+                await self.store_record(table_name, visit_id, data)
 
     async def store_record(
         self, table_name: TableName, visit_id: VisitId, data: Dict[str, Any]
@@ -408,6 +421,10 @@ class DataSocket:
         self, table_name: TableName, visit_id: VisitId, data: Dict[str, Any]
     ) -> None:
         data["visit_id"] = visit_id
+        carrier: Dict[str, str] = {}
+        propagate.inject(carrier)
+        if carrier:
+            data["__otel_ctx"] = carrier
         self.socket.send(
             (
                 table_name,
@@ -416,14 +433,19 @@ class DataSocket:
         )
 
     def finalize_visit_id(self, visit_id: VisitId, success: bool) -> None:
+        meta_data: Dict[str, Any] = {
+            "action": ACTION_TYPE_FINALIZE,
+            "visit_id": visit_id,
+            "success": success,
+        }
+        carrier: Dict[str, str] = {}
+        propagate.inject(carrier)
+        if carrier:
+            meta_data["__otel_ctx"] = carrier
         self.socket.send(
             (
                 RECORD_TYPE_META,
-                {
-                    "action": ACTION_TYPE_FINALIZE,
-                    "visit_id": visit_id,
-                    "success": success,
-                },
+                meta_data,
             )
         )
 

--- a/openwpm/storage/storage_controller.py
+++ b/openwpm/storage/storage_controller.py
@@ -11,6 +11,7 @@ from collections import defaultdict
 from typing import Any, DefaultDict, Dict, List, NoReturn, Optional, Tuple
 
 from multiprocess import Queue
+from opentelemetry import trace
 
 from openwpm.utilities.multiprocess_utils import Process
 
@@ -36,6 +37,8 @@ BATCH_COMMIT_TIMEOUT = 30  # commit a batch if no new records for N seconds
 
 STATUS_UPDATE_INTERVAL = 5  # seconds
 INVALID_VISIT_ID = VisitId(-1)
+
+_tracer = trace.get_tracer(__name__)
 
 
 class StorageController:
@@ -100,12 +103,15 @@ class StorageController:
         writer.close()
         await writer.wait_closed()
 
+    @_tracer.start_as_current_span("request_handler")
     async def handler(
         self, reader: asyncio.StreamReader, _: asyncio.StreamWriter
     ) -> None:
         """Created for every new connection to the Server"""
         client_name = await get_message_from_reader(reader)
         self.logger.info(f"Initializing new handler for {client_name}")
+        trace.get_current_span().set_attribute("client_name", client_name)
+
         while True:
             try:
                 record: Tuple[str, Any] = await get_message_from_reader(reader)
@@ -191,6 +197,7 @@ class StorageController:
         else:
             raise ValueError("Unexpected action: %s", action)
 
+    @_tracer.start_as_current_span("finalize_visit_id")
     async def finalize_visit_id(
         self, visit_id: VisitId, success: bool
     ) -> Optional[Task[None]]:
@@ -201,6 +208,9 @@ class StorageController:
         See StructuredStorageProvider::finalize_visit_id for additional
         documentation
         """
+        trace.get_current_span().set_attributes(
+            {"success": success, "visit_id": visit_id}
+        )
 
         # If the following critical section contains any await statement
         # we can run into race conditions as reported by https://github.com/openwpm/OpenWPM/issues/1068
@@ -254,6 +264,7 @@ class StorageController:
                 visit_id_count,
             )
 
+    @_tracer.start_as_current_span("data_saving")
     async def shutdown(self, completion_queue_task: Task[None]) -> None:
         self.logger.info("Entering self.shutdown")
         completion_tokens = {}
@@ -334,13 +345,15 @@ class StorageController:
             self.finalize_tasks = new_finalize_tasks
             await asyncio.sleep(5)
 
+    @_tracer.start_as_current_span("storage_controller")
     async def _run(self) -> None:
-        await self.structured_storage.init()
-        if self.unstructured_storage:
-            await self.unstructured_storage.init()
-        server: Server = await asyncio.start_server(
-            self._handler, "localhost", 0, family=socket.AF_INET
-        )
+        with _tracer.start_as_current_span("startup"):
+            await self.structured_storage.init()
+            if self.unstructured_storage:
+                await self.unstructured_storage.init()
+            server: Server = await asyncio.start_server(
+                self._handler, "localhost", 0, family=socket.AF_INET
+            )
         sockets = server.sockets
         assert sockets is not None
         socketname = sockets[0].getsockname()
@@ -357,20 +370,25 @@ class StorageController:
         )
         # Blocks until we should shut down
         await self.should_shutdown()
-        self.logger.info(f"Closing Server")
-        server.close()
-        self.logger.info("Closed Server")
-        self.logger.info("Cancelling status_queue_update")
-        status_queue_update.cancel()
-        self.logger.info("Cancelled status_queue_update")
-        self.logger.info("Cancelling timeout_check")
-        timeout_check.cancel()
-        self.logger.info("Cancelled timeout_check")
-        self.logger.info("Starting wait_closed")
-        await server.wait_closed()
-        self.logger.info("Completed wait_closed")
+        with _tracer.start_as_current_span("storage_controller_shutdown"):
+            with _tracer.start_as_current_span("server_close"):
+                self.logger.info("Closing Server")
+                server.close()
+                self.logger.info("Closed Server")
+            with _tracer.start_as_current_span("status_queue_cancel"):
+                self.logger.info("Cancelling status_queue_update")
+                status_queue_update.cancel()
+                self.logger.info("Cancelled status_queue_update")
+            with _tracer.start_as_current_span("timeout_check_cancel"):
+                self.logger.info("Cancelling timeout_check")
+                timeout_check.cancel()
+                self.logger.info("Cancelled timeout_check")
+            with _tracer.start_as_current_span("server_wait_closed"):
+                self.logger.info("Starting wait_closed")
+                await server.wait_closed()
+                self.logger.info("Completed wait_closed")
 
-        await self.shutdown(update_completion_queue)
+            await self.shutdown(update_completion_queue)
 
     def run(self) -> None:
         logging.getLogger("asyncio").setLevel(logging.WARNING)

--- a/openwpm/task_manager.py
+++ b/openwpm/task_manager.py
@@ -9,6 +9,7 @@ from typing import Any, Dict, List, Optional, Set, Type
 
 import psutil
 import tblib
+from opentelemetry import trace
 
 from openwpm.config import (
     BrowserParams,
@@ -28,7 +29,10 @@ from .storage.storage_providers import (
     StructuredStorageProvider,
     UnstructuredStorageProvider,
 )
-from .utilities.multiprocess_utils import kill_process_and_children
+from .utilities.multiprocess_utils import (
+    configure_otel_for_process,
+    kill_process_and_children,
+)
 from .utilities.platform_utils import get_configuration_string, get_version
 from .utilities.storage_watchdog import StorageLogger
 
@@ -38,6 +42,8 @@ SLEEP_CONS = 0.1  # command sleep constant (in seconds)
 BROWSER_MEMORY_LIMIT = 1500  # in MB
 
 STORAGE_CONTROLLER_JOB_LIMIT = 10000  # number of records in the queue
+
+_tracer = trace.get_tracer(__name__)
 
 
 class TaskManager:
@@ -123,6 +129,12 @@ class TaskManager:
         # Sets up the BrowserManager(s) + associated queues
         self.browsers = self._initialize_browsers(browser_params)
         self._launch_browsers()
+
+        # Configure OTel after forking browser processes.
+        # The SDK exporter runs on a background thread that doesn't
+        # survive fork, so we must set up the TracerProvider in each
+        # process after all forks are complete.
+        configure_otel_for_process("openwpm-task-manager")
 
         # Start the manager watchdog
         thread = threading.Thread(target=self._manager_watchdog, args=())
@@ -503,5 +515,8 @@ class TaskManager:
             return
         start_time = time.time()
         self._shutdown_manager(relaxed=relaxed)
+        provider = trace.get_tracer_provider()
+        if hasattr(provider, "shutdown"):
+            provider.shutdown()
         # We don't have a logging thread at this time anymore
         print("Shutdown took %s seconds" % str(time.time() - start_time))

--- a/openwpm/task_manager.py
+++ b/openwpm/task_manager.py
@@ -134,7 +134,7 @@ class TaskManager:
         # The SDK exporter runs on a background thread that doesn't
         # survive fork, so we must set up the TracerProvider in each
         # process after all forks are complete.
-        configure_otel_for_process("openwpm-task-manager")
+        self._otel_provider = configure_otel_for_process("openwpm-task-manager")
 
         # Start the manager watchdog
         thread = threading.Thread(target=self._manager_watchdog, args=())
@@ -515,8 +515,9 @@ class TaskManager:
             return
         start_time = time.time()
         self._shutdown_manager(relaxed=relaxed)
-        provider = trace.get_tracer_provider()
-        if hasattr(provider, "shutdown"):
-            provider.shutdown()
+        # Shut down only the tracer provider OpenWPM configured, so a provider
+        # set up by an embedding application is never torn down here.
+        if self._otel_provider is not None:
+            self._otel_provider.shutdown()
         # We don't have a logging thread at this time anymore
         print("Shutdown took %s seconds" % str(time.time() - start_time))

--- a/openwpm/utilities/multiprocess_utils.py
+++ b/openwpm/utilities/multiprocess_utils.py
@@ -2,9 +2,11 @@ import logging
 import os
 import sys
 import traceback
+from typing import Any
 
 import multiprocess as mp
 import psutil
+from opentelemetry import trace
 
 
 def parse_traceback_for_sentry(tb):
@@ -33,20 +35,40 @@ def parse_traceback_for_sentry(tb):
     return out
 
 
+def configure_otel_for_process(service_name: str) -> None:
+    """Configure OpenTelemetry for a child process.
+
+    No-op when OTEL_EXPORTER_OTLP_ENDPOINT is not set.
+    """
+    if not os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT"):
+        return
+
+    from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+    from opentelemetry.sdk.resources import Resource
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import BatchSpanProcessor
+
+    resource = Resource.create({"service.name": service_name})
+    provider = TracerProvider(resource=resource)
+    provider.add_span_processor(BatchSpanProcessor(OTLPSpanExporter()))
+    trace.set_tracer_provider(provider)
+
+
 class Process(mp.Process):
     """Wrapper Process class that includes exception logging"""
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         mp.Process.__init__(self, *args, **kwargs)
         self.logger = logging.getLogger("openwpm")
 
-    def run(self):
+    def run(self) -> None:
         # Enable coverage collection in child processes when COVERAGE_PROCESS_START is set
         if "COVERAGE_PROCESS_START" in os.environ:
             import coverage
 
             coverage.process_startup()
 
+        configure_otel_for_process(self.name)
         try:
             self.run_impl()
         except Exception as e:
@@ -56,6 +78,9 @@ class Process(mp.Process):
             self.logger.error("Exception in child process.", exc_info=True, extra=extra)
             raise e
         finally:
+            provider = trace.get_tracer_provider()
+            if hasattr(provider, "shutdown"):
+                provider.shutdown()
             # Save coverage data before the process exits, since
             # multiprocess.Process uses os._exit() which skips atexit handlers.
             if "COVERAGE_PROCESS_START" in os.environ:

--- a/openwpm/utilities/multiprocess_utils.py
+++ b/openwpm/utilities/multiprocess_utils.py
@@ -2,7 +2,7 @@ import logging
 import os
 import sys
 import traceback
-from typing import Any
+from typing import Any, Optional
 
 import multiprocess as mp
 import psutil
@@ -35,13 +35,17 @@ def parse_traceback_for_sentry(tb):
     return out
 
 
-def configure_otel_for_process(service_name: str) -> None:
+def configure_otel_for_process(service_name: str) -> Optional[trace.TracerProvider]:
     """Configure OpenTelemetry for a child process.
 
     No-op when OTEL_EXPORTER_OTLP_ENDPOINT is not set.
+
+    Returns the TracerProvider configured by OpenWPM so the caller can shut
+    down only the provider it owns, or None when OTel was not configured (so
+    a tracer provider set up by an embedding application is never touched).
     """
     if not os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT"):
-        return
+        return None
 
     from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
     from opentelemetry.sdk.resources import Resource
@@ -52,6 +56,7 @@ def configure_otel_for_process(service_name: str) -> None:
     provider = TracerProvider(resource=resource)
     provider.add_span_processor(BatchSpanProcessor(OTLPSpanExporter()))
     trace.set_tracer_provider(provider)
+    return provider
 
 
 class Process(mp.Process):
@@ -68,7 +73,7 @@ class Process(mp.Process):
 
             coverage.process_startup()
 
-        configure_otel_for_process(self.name)
+        provider = configure_otel_for_process(self.name)
         try:
             self.run_impl()
         except Exception as e:
@@ -78,8 +83,7 @@ class Process(mp.Process):
             self.logger.error("Exception in child process.", exc_info=True, extra=extra)
             raise e
         finally:
-            provider = trace.get_tracer_provider()
-            if hasattr(provider, "shutdown"):
+            if provider is not None:
                 provider.shutdown()
             # Save coverage data before the process exits, since
             # multiprocess.Process uses os._exit() which skips atexit handlers.

--- a/scripts/environment-unpinned.yaml
+++ b/scripts/environment-unpinned.yaml
@@ -31,4 +31,9 @@ dependencies:
         - dataclasses-json
         - domain-utils
         - jsonschema
+        - opentelemetry-api
+        - opentelemetry-sdk
+        - opentelemetry-exporter-otlp-proto-http
+        - testcontainers
         - tranco
+        - types-requests

--- a/test/test_otel.py
+++ b/test/test_otel.py
@@ -87,28 +87,27 @@ def test_command_sequence_full_trace(jaeger_container, server, tmp_path, xpi):
         db_path = tmp_path / "crawl-data.sqlite"
         structured_provider = SQLiteStorageProvider(db_path)
 
-        manager = TaskManager(
+        with TaskManager(
             manager_params,
             browser_params,
             structured_provider,
             None,
-        )
+        ) as manager:
+            test_url = utilities.BASE_TEST_URL + "/simple_a.html"
+            cs = CommandSequence(test_url, blocking=True)
+            cs.get(sleep=0, timeout=60)
+            manager.execute_command_sequence(cs)
 
-        test_url = utilities.BASE_TEST_URL + "/simple_a.html"
-        cs = CommandSequence(test_url, blocking=True)
-        cs.get(sleep=0, timeout=60)
-        manager.execute_command_sequence(cs)
-        manager.close()
-
-        # Give Jaeger time to process and index the spans
-        time.sleep(5)
-
-        # Query Jaeger for traces from the browser manager service
-        service_name = "BrowserManager-"
-        # First, discover the actual service name (it includes the browser_id)
-        services_resp = requests.get(f"{jaeger_query_url}/api/services")
-        services_resp.raise_for_status()
-        services = services_resp.json().get("data", [])
+        # Poll Jaeger until spans are indexed (up to 30s)
+        services = []
+        deadline = time.monotonic() + 30
+        while time.monotonic() < deadline:
+            time.sleep(2)
+            services_resp = requests.get(f"{jaeger_query_url}/api/services")
+            services_resp.raise_for_status()
+            services = services_resp.json().get("data", [])
+            if any(s.startswith("BrowserManager-") for s in services):
+                break
         browser_service = None
         for svc in services:
             if svc.startswith("BrowserManager-"):

--- a/test/test_otel.py
+++ b/test/test_otel.py
@@ -1,0 +1,246 @@
+"""Integration test for OpenTelemetry tracing instrumentation.
+
+Uses a Jaeger all-in-one container (via testcontainers) as an OTLP receiver,
+runs a single-URL crawl, then queries the Jaeger HTTP API to verify the
+expected span tree exists with correct parentage.
+"""
+
+import os
+import time
+from pathlib import Path
+
+import pytest
+import requests
+
+from openwpm.command_sequence import CommandSequence
+from openwpm.config import BrowserParams, ManagerParams
+from openwpm.storage.sql_provider import SQLiteStorageProvider
+from openwpm.task_manager import TaskManager
+
+from . import utilities
+
+# Skip the entire module if Docker is not available
+docker = pytest.importorskip("testcontainers")
+
+from testcontainers.core.container import DockerContainer
+from testcontainers.core.waiting_utils import wait_for_logs
+
+
+@pytest.fixture(scope="module")
+def jaeger_container():
+    """Start a Jaeger all-in-one container exposing OTLP HTTP and query API."""
+    container = (
+        DockerContainer("jaegertracing/all-in-one:1.65")
+        .with_env("COLLECTOR_OTLP_ENABLED", "true")
+        .with_exposed_ports(4318, 16686)
+    )
+    container.start()
+    # Wait for Jaeger to be ready
+    wait_for_logs(container, "Starting HTTP server", timeout=30)
+    # Give a moment for all endpoints to bind
+    time.sleep(2)
+    yield container
+    container.stop()
+
+
+@pytest.fixture(scope="module")
+def server():
+    """Run an HTTP server during the tests."""
+    srv, server_thread = utilities.start_server()
+    yield
+    srv.shutdown()
+    server_thread.join()
+
+
+def _get_jaeger_port(container, port):
+    """Get the mapped host port for a container port."""
+    return container.get_exposed_port(port)
+
+
+def _get_jaeger_host(container):
+    """Get the host for the Jaeger container."""
+    return container.get_container_host_ip()
+
+
+def test_command_sequence_full_trace(jaeger_container, server, tmp_path, xpi):
+    """Verify the full CommandSequence span hierarchy end-to-end.
+
+    Crawls a single URL with OTel export pointing at the Jaeger container,
+    then queries the Jaeger API to assert spans exist with correct parentage.
+    """
+    host = _get_jaeger_host(jaeger_container)
+    otlp_port = _get_jaeger_port(jaeger_container, 4318)
+    query_port = _get_jaeger_port(jaeger_container, 16686)
+
+    otlp_endpoint = f"http://{host}:{otlp_port}"
+    jaeger_query_url = f"http://{host}:{query_port}"
+
+    # Set the OTLP endpoint so OTel activates
+    os.environ["OTEL_EXPORTER_OTLP_ENDPOINT"] = otlp_endpoint
+
+    try:
+        manager_params = ManagerParams(num_browsers=1)
+        browser_params = [BrowserParams(display_mode="headless")]
+        manager_params.data_directory = tmp_path
+        manager_params.log_path = tmp_path / "openwpm.log"
+        manager_params.testing = True
+
+        db_path = tmp_path / "crawl-data.sqlite"
+        structured_provider = SQLiteStorageProvider(db_path)
+
+        manager = TaskManager(
+            manager_params,
+            browser_params,
+            structured_provider,
+            None,
+        )
+
+        test_url = utilities.BASE_TEST_URL + "/simple_a.html"
+        cs = CommandSequence(test_url, blocking=True)
+        cs.get(sleep=0, timeout=60)
+        manager.execute_command_sequence(cs)
+        manager.close()
+
+        # Give Jaeger time to process and index the spans
+        time.sleep(5)
+
+        # Query Jaeger for traces from the browser manager service
+        service_name = "BrowserManager-"
+        # First, discover the actual service name (it includes the browser_id)
+        services_resp = requests.get(f"{jaeger_query_url}/api/services")
+        services_resp.raise_for_status()
+        services = services_resp.json().get("data", [])
+        browser_service = None
+        for svc in services:
+            if svc.startswith("BrowserManager-"):
+                browser_service = svc
+                break
+
+        # Also check for task manager service
+        task_manager_service = None
+        for svc in services:
+            if svc == "openwpm-task-manager":
+                task_manager_service = svc
+                break
+
+        assert (
+            browser_service is not None
+        ), f"No BrowserManager service found in Jaeger. Available services: {services}"
+
+        # Query traces for the browser manager
+        traces_resp = requests.get(
+            f"{jaeger_query_url}/api/traces",
+            params={"service": browser_service, "limit": 10},
+        )
+        traces_resp.raise_for_status()
+        traces_data = traces_resp.json().get("data", [])
+        assert len(traces_data) > 0, "No traces found for browser manager service"
+
+        # Collect all spans across all traces
+        all_spans = []
+        for trace_data in traces_data:
+            all_spans.extend(trace_data.get("spans", []))
+
+        # Build a map of span names for easier assertion
+        span_names = [s["operationName"] for s in all_spans]
+
+        # Assert expected spans exist
+        assert (
+            "browser_startup" in span_names
+        ), f"browser_startup span not found. Spans: {span_names}"
+        assert (
+            "start_extension" in span_names
+        ), f"start_extension span not found. Spans: {span_names}"
+
+        # Now check the task manager service for command sequence spans
+        if task_manager_service:
+            tm_traces_resp = requests.get(
+                f"{jaeger_query_url}/api/traces",
+                params={"service": task_manager_service, "limit": 10},
+            )
+            tm_traces_resp.raise_for_status()
+            tm_traces = tm_traces_resp.json().get("data", [])
+
+            tm_spans = []
+            for trace_data in tm_traces:
+                tm_spans.extend(trace_data.get("spans", []))
+
+            # The execute_command_sequence and per-command spans run in the
+            # TaskManager process (on the command thread), so they use the
+            # task-manager tracer provider.
+            tm_span_names = [s["operationName"] for s in tm_spans]
+
+            assert (
+                "execute_command_sequence" in tm_span_names
+            ), f"execute_command_sequence span not found. TM Spans: {tm_span_names}"
+            assert (
+                "GetCommand" in tm_span_names
+            ), f"GetCommand span not found. TM Spans: {tm_span_names}"
+            assert (
+                "FinalizeCommand" in tm_span_names
+            ), f"FinalizeCommand span not found. TM Spans: {tm_span_names}"
+            assert (
+                "post_cs_chores" in tm_span_names
+            ), f"post_cs_chores span not found. TM Spans: {tm_span_names}"
+
+            # Verify parentage: GetCommand should be child of execute_command_sequence
+            span_by_id = {s["spanID"]: s for s in tm_spans}
+            ecs_span = next(
+                s for s in tm_spans if s["operationName"] == "execute_command_sequence"
+            )
+            get_span = next(s for s in tm_spans if s["operationName"] == "GetCommand")
+            finalize_span = next(
+                s for s in tm_spans if s["operationName"] == "FinalizeCommand"
+            )
+
+            # In Jaeger, references[0].spanID is the parent
+            def get_parent_span_id(span):
+                refs = span.get("references", [])
+                for ref in refs:
+                    if ref.get("refType") == "CHILD_OF":
+                        return ref.get("spanID")
+                return None
+
+            assert (
+                get_parent_span_id(get_span) == ecs_span["spanID"]
+            ), "GetCommand should be a child of execute_command_sequence"
+            assert (
+                get_parent_span_id(finalize_span) == ecs_span["spanID"]
+            ), "FinalizeCommand should be a child of execute_command_sequence"
+
+            # Verify execute_command_sequence has browser_id and visit_id attributes
+            ecs_tags = {t["key"]: t["value"] for t in ecs_span.get("tags", [])}
+            assert (
+                "browser_id" in ecs_tags
+            ), "execute_command_sequence should have browser_id attribute"
+            assert (
+                "visit_id" in ecs_tags
+            ), "execute_command_sequence should have visit_id attribute"
+
+        # Check storage controller service
+        storage_service = None
+        for svc in services:
+            if svc == "StorageController":
+                storage_service = svc
+                break
+
+        if storage_service:
+            sc_traces_resp = requests.get(
+                f"{jaeger_query_url}/api/traces",
+                params={"service": storage_service, "limit": 10},
+            )
+            sc_traces_resp.raise_for_status()
+            sc_traces = sc_traces_resp.json().get("data", [])
+
+            sc_spans = []
+            for trace_data in sc_traces:
+                sc_spans.extend(trace_data.get("spans", []))
+
+            sc_span_names = [s["operationName"] for s in sc_spans]
+
+            assert (
+                "finalize_visit_id" in sc_span_names
+            ), f"finalize_visit_id span not found. SC Spans: {sc_span_names}"
+
+    finally:
+        os.environ.pop("OTEL_EXPORTER_OTLP_ENDPOINT", None)

--- a/test/test_otel.py
+++ b/test/test_otel.py
@@ -106,7 +106,11 @@ def test_command_sequence_full_trace(jaeger_container, server, tmp_path, xpi):
             services_resp = requests.get(f"{jaeger_query_url}/api/services")
             services_resp.raise_for_status()
             services = services_resp.json().get("data", [])
-            if any(s.startswith("BrowserManager-") for s in services):
+            if (
+                any(s.startswith("BrowserManager-") for s in services)
+                and "openwpm-task-manager" in services
+                and "StorageController" in services
+            ):
                 break
         browser_service = None
         for svc in services:

--- a/test/test_otel.py
+++ b/test/test_otel.py
@@ -7,7 +7,6 @@ expected span tree exists with correct parentage.
 
 import os
 import time
-from pathlib import Path
 
 import pytest
 import requests
@@ -116,16 +115,29 @@ def test_command_sequence_full_trace(jaeger_container, server, tmp_path, xpi):
                 browser_service = svc
                 break
 
-        # Also check for task manager service
+        # Check for task manager service
         task_manager_service = None
         for svc in services:
             if svc == "openwpm-task-manager":
                 task_manager_service = svc
                 break
 
+        # Check for storage controller service
+        storage_service = None
+        for svc in services:
+            if svc == "StorageController":
+                storage_service = svc
+                break
+
         assert (
             browser_service is not None
         ), f"No BrowserManager service found in Jaeger. Available services: {services}"
+        assert (
+            task_manager_service is not None
+        ), f"No openwpm-task-manager service found in Jaeger. Available services: {services}"
+        assert (
+            storage_service is not None
+        ), f"No StorageController service found in Jaeger. Available services: {services}"
 
         # Query traces for the browser manager
         traces_resp = requests.get(
@@ -152,95 +164,101 @@ def test_command_sequence_full_trace(jaeger_container, server, tmp_path, xpi):
             "start_extension" in span_names
         ), f"start_extension span not found. Spans: {span_names}"
 
-        # Now check the task manager service for command sequence spans
-        if task_manager_service:
-            tm_traces_resp = requests.get(
-                f"{jaeger_query_url}/api/traces",
-                params={"service": task_manager_service, "limit": 10},
-            )
-            tm_traces_resp.raise_for_status()
-            tm_traces = tm_traces_resp.json().get("data", [])
+        # Check the task manager service for command sequence spans
+        tm_traces_resp = requests.get(
+            f"{jaeger_query_url}/api/traces",
+            params={"service": task_manager_service, "limit": 10},
+        )
+        tm_traces_resp.raise_for_status()
+        tm_traces = tm_traces_resp.json().get("data", [])
 
-            tm_spans = []
-            for trace_data in tm_traces:
-                tm_spans.extend(trace_data.get("spans", []))
+        tm_spans = []
+        for trace_data in tm_traces:
+            tm_spans.extend(trace_data.get("spans", []))
 
-            # The execute_command_sequence and per-command spans run in the
-            # TaskManager process (on the command thread), so they use the
-            # task-manager tracer provider.
-            tm_span_names = [s["operationName"] for s in tm_spans]
+        # The execute_command_sequence and per-command spans run in the
+        # TaskManager process (on the command thread), so they use the
+        # task-manager tracer provider.
+        tm_span_names = [s["operationName"] for s in tm_spans]
 
-            assert (
-                "execute_command_sequence" in tm_span_names
-            ), f"execute_command_sequence span not found. TM Spans: {tm_span_names}"
-            assert (
-                "GetCommand" in tm_span_names
-            ), f"GetCommand span not found. TM Spans: {tm_span_names}"
-            assert (
-                "FinalizeCommand" in tm_span_names
-            ), f"FinalizeCommand span not found. TM Spans: {tm_span_names}"
-            assert (
-                "post_cs_chores" in tm_span_names
-            ), f"post_cs_chores span not found. TM Spans: {tm_span_names}"
+        assert (
+            "execute_command_sequence" in tm_span_names
+        ), f"execute_command_sequence span not found. TM Spans: {tm_span_names}"
+        assert (
+            "GetCommand" in tm_span_names
+        ), f"GetCommand span not found. TM Spans: {tm_span_names}"
+        assert (
+            "FinalizeCommand" in tm_span_names
+        ), f"FinalizeCommand span not found. TM Spans: {tm_span_names}"
+        assert (
+            "post_cs_chores" in tm_span_names
+        ), f"post_cs_chores span not found. TM Spans: {tm_span_names}"
 
-            # Verify parentage: GetCommand should be child of execute_command_sequence
-            span_by_id = {s["spanID"]: s for s in tm_spans}
-            ecs_span = next(
-                s for s in tm_spans if s["operationName"] == "execute_command_sequence"
-            )
-            get_span = next(s for s in tm_spans if s["operationName"] == "GetCommand")
-            finalize_span = next(
-                s for s in tm_spans if s["operationName"] == "FinalizeCommand"
-            )
+        # Verify parentage: GetCommand should be child of execute_command_sequence
+        ecs_span = next(
+            s for s in tm_spans if s["operationName"] == "execute_command_sequence"
+        )
+        get_span = next(s for s in tm_spans if s["operationName"] == "GetCommand")
+        finalize_span = next(
+            s for s in tm_spans if s["operationName"] == "FinalizeCommand"
+        )
 
-            # In Jaeger, references[0].spanID is the parent
-            def get_parent_span_id(span):
-                refs = span.get("references", [])
-                for ref in refs:
-                    if ref.get("refType") == "CHILD_OF":
-                        return ref.get("spanID")
-                return None
+        # In Jaeger, references[0].spanID is the parent
+        def get_parent_span_id(span):
+            refs = span.get("references", [])
+            for ref in refs:
+                if ref.get("refType") == "CHILD_OF":
+                    return ref.get("spanID")
+            return None
 
-            assert (
-                get_parent_span_id(get_span) == ecs_span["spanID"]
-            ), "GetCommand should be a child of execute_command_sequence"
-            assert (
-                get_parent_span_id(finalize_span) == ecs_span["spanID"]
-            ), "FinalizeCommand should be a child of execute_command_sequence"
+        assert (
+            get_parent_span_id(get_span) == ecs_span["spanID"]
+        ), "GetCommand should be a child of execute_command_sequence"
+        assert (
+            get_parent_span_id(finalize_span) == ecs_span["spanID"]
+        ), "FinalizeCommand should be a child of execute_command_sequence"
 
-            # Verify execute_command_sequence has browser_id and visit_id attributes
-            ecs_tags = {t["key"]: t["value"] for t in ecs_span.get("tags", [])}
-            assert (
-                "browser_id" in ecs_tags
-            ), "execute_command_sequence should have browser_id attribute"
-            assert (
-                "visit_id" in ecs_tags
-            ), "execute_command_sequence should have visit_id attribute"
+        # Verify execute_command_sequence has browser_id and visit_id attributes
+        ecs_tags = {t["key"]: t["value"] for t in ecs_span.get("tags", [])}
+        assert (
+            "browser_id" in ecs_tags
+        ), "execute_command_sequence should have browser_id attribute"
+        assert (
+            "visit_id" in ecs_tags
+        ), "execute_command_sequence should have visit_id attribute"
 
-        # Check storage controller service
-        storage_service = None
-        for svc in services:
-            if svc == "StorageController":
-                storage_service = svc
-                break
+        # Check storage controller spans
+        sc_traces_resp = requests.get(
+            f"{jaeger_query_url}/api/traces",
+            params={"service": storage_service, "limit": 10},
+        )
+        sc_traces_resp.raise_for_status()
+        sc_traces = sc_traces_resp.json().get("data", [])
 
-        if storage_service:
-            sc_traces_resp = requests.get(
-                f"{jaeger_query_url}/api/traces",
-                params={"service": storage_service, "limit": 10},
-            )
-            sc_traces_resp.raise_for_status()
-            sc_traces = sc_traces_resp.json().get("data", [])
+        sc_spans = []
+        for trace_data in sc_traces:
+            sc_spans.extend(trace_data.get("spans", []))
 
-            sc_spans = []
-            for trace_data in sc_traces:
-                sc_spans.extend(trace_data.get("spans", []))
+        sc_span_names = [s["operationName"] for s in sc_spans]
 
-            sc_span_names = [s["operationName"] for s in sc_spans]
+        assert (
+            "process_record" in sc_span_names
+        ), f"process_record span not found. SC Spans: {sc_span_names}"
+        assert (
+            "finalize_visit_id" in sc_span_names
+        ), f"finalize_visit_id span not found. SC Spans: {sc_span_names}"
 
-            assert (
-                "finalize_visit_id" in sc_span_names
-            ), f"finalize_visit_id span not found. SC Spans: {sc_span_names}"
+        # Verify cross-process trace linking: all three services
+        # should share at least one trace ID
+        browser_trace_ids = {t["traceID"] for t in traces_data}
+        tm_trace_ids = {t["traceID"] for t in tm_traces}
+        sc_trace_ids = {t["traceID"] for t in sc_traces}
+        shared_traces = browser_trace_ids & tm_trace_ids & sc_trace_ids
+        assert shared_traces, (
+            "No shared trace IDs across all three services — "
+            "cross-process context propagation is broken. "
+            f"Browser: {browser_trace_ids}, TM: {tm_trace_ids}, SC: {sc_trace_ids}"
+        )
 
     finally:
         os.environ.pop("OTEL_EXPORTER_OTLP_ENDPOINT", None)

--- a/test/test_otel.py
+++ b/test/test_otel.py
@@ -29,7 +29,7 @@ from testcontainers.core.waiting_utils import wait_for_logs
 def jaeger_container():
     """Start a Jaeger all-in-one container exposing OTLP HTTP and query API."""
     container = (
-        DockerContainer("jaegertracing/all-in-one:1.65")
+        DockerContainer("jaegertracing/all-in-one:1.76.0")
         .with_env("COLLECTOR_OTLP_ENABLED", "true")
         .with_exposed_ports(4318, 16686)
     )


### PR DESCRIPTION
## Summary
- Add OpenTelemetry tracing to TaskManager, BrowserManager, and StorageController
- Propagate trace context across process boundaries via `inject()`/`extract()` through multiprocessing queues
- Per-record spans in StorageController (not per-connection)
- Jaeger testcontainer integration test asserting full span tree with shared trace IDs across all three services

Supersedes #1087. Incorporates fixes from adversarial review (VDD methodology).

## VDD Review History
- **Round 1**: Found no cross-process context propagation (3 disconnected trace trees), per-connection span wrapping entire crawl, soft-fail test guards
- **Round 2**: All critical findings fixed — inject/extract present for both process boundaries, per-record spans, hard assertions in test. Remaining: dead backward-compat else branch (cleanup), duplicate span names (cosmetic).
- **Final verdict**: Begrudgingly Adequate (converged)

## Test plan
- [ ] `test_otel_tracing` asserts spans from all 3 services share trace IDs
- [ ] Jaeger testcontainer receives spans within flush interval
- [ ] `pre-commit run --all-files` passes