### PR TITLE
feat(dns-instrument): capture failed DNS resolutions via onErrorOccurred

### DIFF
--- a/Extension/src/background/dns-instrument.ts
+++ b/Extension/src/background/dns-instrument.ts
@@ -6,12 +6,12 @@ import {
 } from "../types/browser-web-request-event-details";
 import RequestFilter = browser.webRequest.RequestFilter;
 
-// Firefox error strings that indicate DNS resolution failure
-const DNS_ERROR_STRINGS = [
-  "NS_ERROR_UNKNOWN_HOST",
-  "NS_ERROR_DNS_RESOLVE_UNKNOWN_HOST",
-  "NS_ERROR_NET_TIMEOUT",
-];
+// Firefox error strings that indicate DNS resolution failure.
+// Note: NS_ERROR_NET_TIMEOUT is intentionally excluded — it is a generic
+// network timeout (TCP connect, TLS handshake, HTTP read, etc.), not
+// DNS-specific. DNS timeouts in Firefox surface as NS_ERROR_UNKNOWN_HOST
+// when the resolver gives up; there is no dedicated DNS timeout error.
+const DNS_ERROR_STRINGS = ["NS_ERROR_UNKNOWN_HOST"];
 
 export class DnsInstrument {
   private readonly dataReceiver;

--- a/Extension/src/background/dns-instrument.ts
+++ b/Extension/src/background/dns-instrument.ts
@@ -1,12 +1,16 @@
 import { DnsResolved } from "../schema";
 import { allTypes } from "./http-instrument";
-import { WebRequestOnHeadersReceivedDetails } from "../types/browser-web-request-event-details";
+import {
+  WebRequestOnErrorOccurredDetails,
+  WebRequestOnHeadersReceivedDetails,
+} from "../types/browser-web-request-event-details";
 import RequestFilter = browser.webRequest.RequestFilter;
 
 // Firefox error strings that indicate DNS resolution failure
 const DNS_ERROR_STRINGS = [
   "NS_ERROR_UNKNOWN_HOST",
   "NS_ERROR_DNS_RESOLVE_UNKNOWN_HOST",
+  "NS_ERROR_NET_TIMEOUT",
 ];
 
 export class DnsInstrument {
@@ -49,7 +53,7 @@ export class DnsInstrument {
     );
 
     this.onErrorOccurredListener = (
-      details: browser.webRequest._OnErrorOccurredDetails,
+      details: WebRequestOnErrorOccurredDetails,
     ) => {
       // Ignore requests made by extensions
       if (requestStemsFromExtension(details)) {
@@ -113,7 +117,7 @@ export class DnsInstrument {
   }
 
   private onErrorOccurredDnsHandler(
-    details: browser.webRequest._OnErrorOccurredDetails,
+    details: WebRequestOnErrorOccurredDetails,
     crawlID,
   ) {
     const dnsRecord = {} as DnsResolved;

--- a/Extension/src/background/dns-instrument.ts
+++ b/Extension/src/background/dns-instrument.ts
@@ -3,9 +3,16 @@ import { allTypes } from "./http-instrument";
 import { WebRequestOnHeadersReceivedDetails } from "../types/browser-web-request-event-details";
 import RequestFilter = browser.webRequest.RequestFilter;
 
+// Firefox error strings that indicate DNS resolution failure
+const DNS_ERROR_STRINGS = [
+  "NS_ERROR_UNKNOWN_HOST",
+  "NS_ERROR_DNS_RESOLVE_UNKNOWN_HOST",
+];
+
 export class DnsInstrument {
   private readonly dataReceiver;
   private onHeadersReceivedListener;
+  private onErrorOccurredListener;
 
   constructor(dataReceiver) {
     this.dataReceiver = dataReceiver;
@@ -40,12 +47,41 @@ export class DnsInstrument {
       this.onHeadersReceivedListener,
       filter,
     );
+
+    this.onErrorOccurredListener = (
+      details: browser.webRequest._OnErrorOccurredDetails,
+    ) => {
+      // Ignore requests made by extensions
+      if (requestStemsFromExtension(details)) {
+        return;
+      }
+
+      // Only capture DNS-related errors
+      const isDnsError = DNS_ERROR_STRINGS.some((errStr) =>
+        details.error.includes(errStr),
+      );
+      if (!isDnsError) {
+        return;
+      }
+
+      this.onErrorOccurredDnsHandler(details, crawlID);
+    };
+
+    browser.webRequest.onErrorOccurred.addListener(
+      this.onErrorOccurredListener,
+      filter,
+    );
   }
 
   public cleanup() {
     if (this.onHeadersReceivedListener) {
       browser.webRequest.onHeadersReceived.removeListener(
         this.onHeadersReceivedListener,
+      );
+    }
+    if (this.onErrorOccurredListener) {
+      browser.webRequest.onErrorOccurred.removeListener(
+        this.onErrorOccurredListener,
       );
     }
   }
@@ -73,6 +109,24 @@ export class DnsInstrument {
     dnsRecord.addresses = record.addresses.toString();
     dnsRecord.canonical_name = record.canonicalName;
     dnsRecord.is_TRR = record.isTRR;
+    this.dataReceiver.saveRecord("dns_responses", dnsRecord);
+  }
+
+  private onErrorOccurredDnsHandler(
+    details: browser.webRequest._OnErrorOccurredDetails,
+    crawlID,
+  ) {
+    const dnsRecord = {} as DnsResolved;
+    dnsRecord.browser_id = crawlID;
+    dnsRecord.request_id = Number(details.requestId);
+    dnsRecord.redirect_url = details.url;
+    const currentTime = new Date(details.timeStamp);
+    dnsRecord.time_stamp = currentTime.toISOString();
+
+    const url = new URL(details.url);
+    dnsRecord.hostname = url.hostname;
+    dnsRecord.error = details.error;
+
     this.dataReceiver.saveRecord("dns_responses", dnsRecord);
   }
 }

--- a/Extension/src/schema.ts
+++ b/Extension/src/schema.ts
@@ -175,6 +175,7 @@ export interface DnsResolved {
   used_address?: string;
   canonical_name?: string;
   is_TRR?: string;
+  error?: string;
 }
 
 /**

--- a/Extension/src/types/browser-web-request-event-details.ts
+++ b/Extension/src/types/browser-web-request-event-details.ts
@@ -23,3 +23,6 @@ export interface WebRequestOnHeadersReceivedDetails
    */
   ip?: string;
 }
+
+export type WebRequestOnErrorOccurredDetails =
+  browser.webRequest._OnErrorOccurredDetails;

--- a/openwpm/storage/parquet_schema.py
+++ b/openwpm/storage/parquet_schema.py
@@ -242,6 +242,7 @@ fields = [
     pa.field("used_address", pa.string()),
     pa.field("canonical_name", pa.string()),
     pa.field("is_TRR", pa.bool_()),
+    pa.field("error", pa.string()),
     pa.field("time_stamp", pa.string(), nullable=False),
     pa.field("instance_id", pa.uint32(), nullable=False),
 ]

--- a/openwpm/storage/schema.sql
+++ b/openwpm/storage/schema.sql
@@ -245,5 +245,6 @@ CREATE TABLE IF NOT EXISTS dns_responses (
   used_address TEXT,
   canonical_name TEXT,
   is_TRR INTEGER,
+  error TEXT,
   time_stamp DATETIME NOT NULL
  );

--- a/test/storage/test_values.py
+++ b/test/storage/test_values.py
@@ -233,6 +233,7 @@ def generate_test_values() -> dt_test_values:
         "used_address": random_word(12),
         "canonical_name": random_word(12),
         "is_TRR": random.choice([True, False]),
+        "error": random_word(12),
         "time_stamp": random_word(12),
     }
     test_values[TableName("dns_responses")] = fields

--- a/test/test_dns_instrument.py
+++ b/test/test_dns_instrument.py
@@ -46,3 +46,27 @@ def test_dns_captured_on_connection_abort(default_params, task_manager_creator):
     assert result["used_address"] is not None
     assert result["addresses"] is not None
     assert result["hostname"] == "localhost"
+
+
+def test_dns_failure_captured(default_params, task_manager_creator):
+    """DNS failures (NXDOMAIN) should be captured via onErrorOccurred
+    with error details and null addresses."""
+    manager_params, browser_params = default_params
+    for browser_param in browser_params:
+        browser_param.dns_instrument = True
+
+    manager, db = task_manager_creator((manager_params, browser_params))
+    # example.invalid is guaranteed NXDOMAIN per RFC 2606
+    manager.get("http://example.invalid/")
+    manager.close()
+
+    results = db_utils.query_db(db, "SELECT * FROM dns_responses")
+    assert len(results) > 0, "No DNS responses captured for failed resolution"
+    # Find the row for example.invalid
+    dns_failure = [r for r in results if "example.invalid" in (r["hostname"] or "")]
+    assert len(dns_failure) > 0, "No DNS failure row for example.invalid"
+    result = dns_failure[0]
+    assert isinstance(result, Row)
+    assert result["addresses"] is None
+    assert result["used_address"] is None
+    assert result["error"] is not None


### PR DESCRIPTION
## Summary
- Add `browser.webRequest.onErrorOccurred` listener to DNS instrumentation
- Failed DNS lookups (NXDOMAIN, timeouts, SERVFAIL) now produce `dns_responses` rows with `addresses=NULL` and the error string in a new `error` column
- Schema updated: `error` column (TEXT, nullable) added to `dns_responses` in `schema.sql`, `parquet_schema.py`, and `schema.ts`
- Test: navigates to `http://example.invalid/` (RFC 2606 guaranteed NXDOMAIN) and asserts a `dns_responses` row with NULL addresses and non-NULL error

Closes #1159. Builds on #1158 (onHeadersReceived for redirect chains) — this covers the failure case that `onHeadersReceived` cannot observe.

## Test plan
- [ ] `test_dns_failure_captured` passes (example.invalid produces a dns_responses row)
- [ ] Existing `test_name_resolution` still passes (successful DNS unaffected)
- [ ] `test_dns_captured_on_connection_abort` still passes
- [ ] `pre-commit run --all-files` passes