### PR TITLE
feat(scripts): sync pre-commit linter versions with conda in update.py

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,15 +1,15 @@
 repos:
   - repo: https://github.com/timothycrosley/isort
-    rev: 5.13.2
+    rev: 8.0.1
     hooks:
       - id: isort
   - repo: https://github.com/psf/black
-    rev: 24.10.0
+    rev: 26.1.0
     hooks:
       - id: black
         language_version: python3
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.8.0
+    rev: v1.19.1
     hooks:
       - id: mypy
         additional_dependencies:

--- a/custom_command.py
+++ b/custom_command.py
@@ -1,4 +1,4 @@
-""" This file aims to demonstrate how to write custom commands in OpenWPM
+"""This file aims to demonstrate how to write custom commands in OpenWPM
 
 Steps to have a custom command run as part of a CommandSequence
 

--- a/docs/Release-Checklist.md
+++ b/docs/Release-Checklist.md
@@ -4,15 +4,17 @@ We aim to release a new version of OpenWPM with each new Firefox release (~1 rel
 
 1. Run `python scripts/update.py` — this will:
     - Repin the conda environment
+    - Sync linter versions in `.pre-commit-config.yaml` to match `environment.yaml` (black, isort, mypy)
     - Bump all npm dependencies to their latest compatible versions
     - Rebuild the extension
     - Automatically detect and apply any new Firefox release to `scripts/install-firefox.sh`
-2. Check if we can unpin our python version (this requires Linux to test) See <https://github.com/openwpm/OpenWPM/issues/1111>
-3. Run `./scripts/install-firefox.sh` to install the updated Firefox locally and verify the test suite passes.
-4. Increment the version number in [VERSION](../VERSION)
-5. Add a summary of changes since the last version to [CHANGELOG](../CHANGELOG.md)
-6. Squash and merge the release PR to master.
-7. Publish a new release from <https://github.com/openwpm/OpenWPM/releases>:
+2. Verify no linter drift warnings were printed by `update.py`. If any `WARNING` lines mention a linter that could not be synced, resolve the mismatch manually.
+3. Check if we can unpin our python version (this requires Linux to test) See <https://github.com/openwpm/OpenWPM/issues/1111>
+4. Run `./scripts/install-firefox.sh` to install the updated Firefox locally and verify the test suite passes.
+5. Increment the version number in [VERSION](../VERSION)
+6. Add a summary of changes since the last version to [CHANGELOG](../CHANGELOG.md)
+7. Squash and merge the release PR to master.
+8. Publish a new release from <https://github.com/openwpm/OpenWPM/releases>:
     1. Click "Draft a new release".
     2. Enter the "Tag version" and "Release title" as `vX.X.X`.
     3. In the description:

--- a/docs/Release-Checklist.md
+++ b/docs/Release-Checklist.md
@@ -9,12 +9,11 @@ We aim to release a new version of OpenWPM with each new Firefox release (~1 rel
     - Rebuild the extension
     - Automatically detect and apply any new Firefox release to `scripts/install-firefox.sh`
 2. Verify no linter drift warnings were printed by `update.py`. If any `WARNING` lines mention a linter that could not be synced, resolve the mismatch manually.
-3. Check if we can unpin our python version (this requires Linux to test) See <https://github.com/openwpm/OpenWPM/issues/1111>
-4. Run `./scripts/install-firefox.sh` to install the updated Firefox locally and verify the test suite passes.
-5. Increment the version number in [VERSION](../VERSION)
-6. Add a summary of changes since the last version to [CHANGELOG](../CHANGELOG.md)
-7. Squash and merge the release PR to master.
-8. Publish a new release from <https://github.com/openwpm/OpenWPM/releases>:
+3. Run `./scripts/install-firefox.sh` to install the updated Firefox locally and verify the test suite passes.
+4. Increment the version number in [VERSION](../VERSION)
+5. Add a summary of changes since the last version to [CHANGELOG](../CHANGELOG.md)
+6. Squash and merge the release PR to master.
+7. Publish a new release from <https://github.com/openwpm/OpenWPM/releases>:
     1. Click "Draft a new release".
     2. Enter the "Tag version" and "Release title" as `vX.X.X`.
     3. In the description:

--- a/docs/Release-Checklist.md
+++ b/docs/Release-Checklist.md
@@ -8,12 +8,11 @@ We aim to release a new version of OpenWPM with each new Firefox release (~1 rel
     - Bump all npm dependencies to their latest compatible versions
     - Rebuild the extension
     - Automatically detect and apply any new Firefox release to `scripts/install-firefox.sh`
-2. Verify no linter drift warnings were printed by `update.py`. If any `WARNING` lines mention a linter that could not be synced, resolve the mismatch manually.
-3. Run `./scripts/install-firefox.sh` to install the updated Firefox locally and verify the test suite passes.
-4. Increment the version number in [VERSION](../VERSION)
-5. Add a summary of changes since the last version to [CHANGELOG](../CHANGELOG.md)
-6. Squash and merge the release PR to master.
-7. Publish a new release from <https://github.com/openwpm/OpenWPM/releases>:
+2. Run `./scripts/install-firefox.sh` to install the updated Firefox locally and verify the test suite passes.
+3. Increment the version number in [VERSION](../VERSION)
+4. Add a summary of changes since the last version to [CHANGELOG](../CHANGELOG.md)
+5. Squash and merge the release PR to master.
+6. Publish a new release from <https://github.com/openwpm/OpenWPM/releases>:
     1. Click "Draft a new release".
     2. Enter the "Tag version" and "Release title" as `vX.X.X`.
     3. In the description:

--- a/openwpm/browser_manager.py
+++ b/openwpm/browser_manager.py
@@ -156,7 +156,7 @@ class BrowserManagerHandle:
                 "BROWSER %i: Spawn attempt %i " % (self.browser_id, unsuccessful_spawns)
             )
             # Resets the command/status queues
-            (self.command_queue, self.status_queue) = (Queue(), Queue())
+            self.command_queue, self.status_queue = (Queue(), Queue())
 
             # builds and launches the browser_manager
 

--- a/openwpm/deploy_browsers/configure_firefox.py
+++ b/openwpm/deploy_browsers/configure_firefox.py
@@ -1,4 +1,4 @@
-""" Set prefs and load extensions in Firefox """
+"""Set prefs and load extensions in Firefox"""
 
 from selenium.webdriver.firefox.options import Options
 

--- a/openwpm/deploy_browsers/deploy_firefox.py
+++ b/openwpm/deploy_browsers/deploy_firefox.py
@@ -88,12 +88,10 @@ def deploy_firefox(
             display.start()
             display_pid, display_port = display.pid, display.display
         except EasyProcessError:
-            raise RuntimeError(
-                "Xvfb could not be started. \
+            raise RuntimeError("Xvfb could not be started. \
                 Please ensure it's on your path. \
                 See www.X.org for full details. \
-                Commonly solved on ubuntu with `sudo apt install xvfb`"
-            )
+                Commonly solved on ubuntu with `sudo apt install xvfb`")
     # Must do this for all display modes,
     # because status_queue is read off no matter what.
     status_queue.put(("STATUS", "Display", (display_pid, display_port)))

--- a/openwpm/errors.py
+++ b/openwpm/errors.py
@@ -1,4 +1,4 @@
-""" OpenWPM Custom Errors """
+"""OpenWPM Custom Errors"""
 
 
 class CommandExecutionError(Exception):

--- a/openwpm/js_instrumentation.py
+++ b/openwpm/js_instrumentation.py
@@ -32,12 +32,10 @@ def _validate(python_list_to_validate):
             propertiesToInstrument = set(propertiesToInstrument)
             excludedProperties = set(setting["logSettings"]["excludedProperties"])
             if len(propertiesToInstrument.intersection(excludedProperties)) != 0:
-                raise ValueError(
-                    f"excludedProperties and \
+                raise ValueError(f"excludedProperties and \
                     propertiesToInstrument collide. This \
                     may have occurred after a merge. \
-                    Setting with collision: {setting}."
-                )
+                    Setting with collision: {setting}.")
     return True
 
 
@@ -127,11 +125,9 @@ def _build_full_settings_object(setting):
 
     elif isinstance(setting, dict):
         if len(setting.keys()) != 1:
-            raise ValueError(
-                f"Invalid settings request. \
+            raise ValueError(f"Invalid settings request. \
                 Settings item is a dictionary with more \
-                than one key. Received {setting}."
-            )
+                than one key. Received {setting}.")
 
         setting_key = list(setting.keys())[0]
         props = setting[setting_key]
@@ -142,18 +138,14 @@ def _build_full_settings_object(setting):
             for k, v in props.items():
                 logSettings[k] = v
         else:
-            raise ValueError(
-                f"Invalid settings request. \
+            raise ValueError(f"Invalid settings request. \
                 Setting was a dictionary. Settings value \
                 must be a list or a dictionary. Received \
-                {setting}."
-            )
+                {setting}.")
     else:
-        raise ValueError(
-            f"Invalid settings request. \
+        raise ValueError(f"Invalid settings request. \
             Must be a string or a dictionary. \
-            Received {setting}."
-        )
+            Received {setting}.")
 
     return {
         "object": obj,
@@ -228,10 +220,8 @@ def clean_js_instrumentation_settings(
 
     """
     if not isinstance(user_requested_settings, list):
-        raise TypeError(
-            f"js_instrumentation_settings must be a list. \
-              Received {user_requested_settings}"
-        )
+        raise TypeError(f"js_instrumentation_settings must be a list. \
+              Received {user_requested_settings}")
     settings = []
     for setting in user_requested_settings:
         if isinstance(setting, str) and (setting in shortcut_specs):

--- a/openwpm/socket_interface.py
+++ b/openwpm/socket_interface.py
@@ -41,7 +41,7 @@ class ServerSocket:
         """Listen for connections and pass handling to a new thread"""
         while True:
             try:
-                (client, address) = self.sock.accept()
+                client, address = self.sock.accept()
                 thread = threading.Thread(
                     target=self._handle_conn, args=(client, address)
                 )

--- a/openwpm/storage/storage_controller.py
+++ b/openwpm/storage/storage_controller.py
@@ -122,20 +122,16 @@ class StorageController:
             record_type, data = record
 
             if record_type == RECORD_TYPE_CREATE:
-                raise RuntimeError(
-                    f"""{RECORD_TYPE_CREATE} is no longer supported.
+                raise RuntimeError(f"""{RECORD_TYPE_CREATE} is no longer supported.
                     Please change the schema before starting the StorageController.
                     For an example of that see test/test_custom_function.py
-                    """
-                )
+                    """)
 
             if record_type == RECORD_TYPE_CONTENT:
                 assert len(data) == 2
                 if self.unstructured_storage is None:
-                    self.logger.error(
-                        """Tried to save content while not having
-                        provided any unstructured storage provider."""
-                    )
+                    self.logger.error("""Tried to save content while not having
+                        provided any unstructured storage provider.""")
                     continue
                 content, content_hash = data
                 content = base64.b64decode(content)

--- a/openwpm/utilities/build_cookie_table.py
+++ b/openwpm/utilities/build_cookie_table.py
@@ -153,17 +153,14 @@ def build_http_cookie_table(database, verbose=False):
     cur1 = con.cursor()
     cur2 = con.cursor()
 
-    cur1.execute(
-        "CREATE TABLE IF NOT EXISTS http_request_cookies ( \
+    cur1.execute("CREATE TABLE IF NOT EXISTS http_request_cookies ( \
                     id INTEGER PRIMARY KEY AUTOINCREMENT, \
                     browser_id INTEGER NOT NULL, \
                     header_id INTEGER NOT NULL, \
                     name VARCHAR(200) NOT NULL, \
                     value TEXT NOT NULL, \
-                    accessed DATETIME);"
-    )
-    cur1.execute(
-        "CREATE TABLE IF NOT EXISTS http_response_cookies ( \
+                    accessed DATETIME);")
+    cur1.execute("CREATE TABLE IF NOT EXISTS http_response_cookies ( \
                     id INTEGER PRIMARY KEY AUTOINCREMENT, \
                     browser_id INTEGER NOT NULL, \
                     header_id INTEGER NOT NULL, \
@@ -177,20 +174,17 @@ def build_http_cookie_table(database, verbose=False):
                     secure BOOLEAN, \
                     comment VARCHAR(200), \
                     version VARCHAR(100), \
-                    accessed DATETIME);"
-    )
+                    accessed DATETIME);")
     con.commit()
 
     # Parse http request cookies
     commit = 0
     last_commit = 0
 
-    cur1.execute(
-        """SELECT id, browser_id, headers, time_stamp
+    cur1.execute("""SELECT id, browser_id, headers, time_stamp
                     FROM http_requests
                     WHERE id NOT IN (SELECT header_id FROM
-                    http_request_cookies)"""
-    )
+                    http_request_cookies)""")
 
     row = cur1.fetchone()
     if row is None:
@@ -225,12 +219,10 @@ def build_http_cookie_table(database, verbose=False):
     # Parse http response cookies
     commit = 0
     last_commit = 0
-    cur1.execute(
-        """SELECT id, browser_id, url, headers, time_stamp
+    cur1.execute("""SELECT id, browser_id, url, headers, time_stamp
                     FROM http_responses
                     WHERE id NOT IN (SELECT header_id
-                    FROM http_response_cookies)"""
-    )
+                    FROM http_response_cookies)""")
 
     row = cur1.fetchone()
     if row is None:

--- a/openwpm/utilities/cookie.py
+++ b/openwpm/utilities/cookie.py
@@ -207,7 +207,6 @@ fact, this simply returns a SmartCookie.
 Finis.
 """
 
-
 # Import our required modules
 #
 
@@ -641,9 +640,7 @@ class Morsel(dict):
         document.cookie = \"%s\";
         // end hiding -->
         </script>
-        """ % (
-            self.OutputString(attrs).replace('"', r"\""),
-        )
+        """ % (self.OutputString(attrs).replace('"', r"\""),)
 
     # end js_output()
 

--- a/scripts/update.py
+++ b/scripts/update.py
@@ -23,6 +23,14 @@ SCRIPTS = ROOT / "scripts"
 
 _MAX_RESOLVE_ATTEMPTS = 10
 
+# Mapping: conda package name → (pre-commit repo URL, rev prefix)
+# The prefix is prepended to the conda version to form the pre-commit rev tag.
+_LINTER_MAP: dict[str, tuple[str, str]] = {
+    "black": ("https://github.com/psf/black", ""),
+    "isort": ("https://github.com/timothycrosley/isort", ""),
+    "mypy": ("https://github.com/pre-commit/mirrors-mypy", "v"),
+}
+
 
 def run(*cmd: str, cwd: Path = ROOT) -> None:
     print(f"+ {' '.join(cmd)}")
@@ -31,6 +39,80 @@ def run(*cmd: str, cwd: Path = ROOT) -> None:
 
 def conda_run(*cmd: str, cwd: Path = ROOT) -> None:
     run("conda", "run", "-n", "openwpm", *cmd, cwd=cwd)
+
+
+def _parse_conda_versions(env_yaml: Path) -> dict[str, str]:
+    """Extract version-pinned package versions from environment.yaml.
+
+    Parses lines like ``- black=26.1.0`` and returns ``{"black": "26.1.0"}``.
+    Skips pip-style ``==`` pins and non-versioned entries.
+    """
+    versions: dict[str, str] = {}
+    for line in env_yaml.read_text().splitlines():
+        stripped = line.strip()
+        if not stripped.startswith("- ") or stripped.startswith("- pip"):
+            continue
+        spec = stripped[2:]
+        if "==" in spec or "=" not in spec:
+            continue
+        name, _, version = spec.partition("=")
+        versions[name] = version
+    return versions
+
+
+def sync_precommit_linter_versions() -> None:
+    """Sync linter revs in .pre-commit-config.yaml to match environment.yaml."""
+    env_yaml = ROOT / "environment.yaml"
+    precommit_yaml = ROOT / ".pre-commit-config.yaml"
+
+    print("\n=== Syncing pre-commit linter versions with conda ===")
+
+    conda_versions = _parse_conda_versions(env_yaml)
+    content = precommit_yaml.read_text()
+
+    updated = False
+    for pkg, (repo_url, prefix) in _LINTER_MAP.items():
+        if pkg not in conda_versions:
+            print(
+                f"WARNING: {pkg} not found in environment.yaml, skipping",
+                file=sys.stderr,
+            )
+            continue
+
+        target_rev = f"{prefix}{conda_versions[pkg]}"
+
+        # Match the repo URL line followed by the rev line, preserving whitespace.
+        pattern = re.compile(
+            rf"(- repo: {re.escape(repo_url)}\s*\n\s*rev:\s*)\S+",
+        )
+        match = pattern.search(content)
+        if not match:
+            print(
+                f"WARNING: repo {repo_url} ({pkg}) not found in "
+                f".pre-commit-config.yaml",
+                file=sys.stderr,
+            )
+            continue
+
+        current_rev = content[match.start(0) + len(match.group(1)) : match.end(0)]
+        if current_rev == target_rev:
+            print(f"  {pkg}: already in sync ({current_rev})")
+            continue
+
+        print(f"  {pkg}: {current_rev} -> {target_rev}")
+        content = (
+            content[: match.start(0)]
+            + match.group(1)
+            + target_rev
+            + content[match.end(0) :]
+        )
+        updated = True
+
+    if updated:
+        precommit_yaml.write_text(content)
+        print("Updated .pre-commit-config.yaml")
+    else:
+        print("All linter versions already in sync.")
 
 
 def _npm_install(cwd: Path) -> tuple[str, bool]:
@@ -149,6 +231,9 @@ def npm_bump_and_resolve(cwd: Path) -> None:
 def main() -> None:
     # Repin the conda environment from unpinned sources
     run("./repin.sh", cwd=SCRIPTS)
+
+    # Sync pre-commit linter versions to match the freshly pinned conda env
+    sync_precommit_linter_versions()
 
     # Bump npm deps to latest and resolve peer dep conflicts
     npm_bump_and_resolve(ROOT)

--- a/scripts/update.py
+++ b/scripts/update.py
@@ -3,10 +3,11 @@
 Steps
 -----
 1. Repin the conda environment (scripts/repin.sh)
-2. Update root npm dependencies to latest, resolving peer dep conflicts
-3. Update Extension npm dependencies to latest, resolving peer dep conflicts
-4. Rebuild the extension
-5. Check hg.mozilla.org for a newer Firefox and update install-firefox.sh if found
+2. Sync pre-commit linter revs to the freshly pinned conda env
+3. Update root npm dependencies to latest, resolving peer dep conflicts
+4. Update Extension npm dependencies to latest, resolving peer dep conflicts
+5. Rebuild the extension
+6. Check hg.mozilla.org for a newer Firefox and update install-firefox.sh if found
 
 Run from the project root:
     python scripts/update.py
@@ -41,43 +42,63 @@ def conda_run(*cmd: str, cwd: Path = ROOT) -> None:
     run("conda", "run", "-n", "openwpm", *cmd, cwd=cwd)
 
 
-def _parse_conda_versions(env_yaml: Path) -> dict[str, str]:
-    """Extract version-pinned package versions from environment.yaml.
+def _versions_from_conda_list_json(json_str: str) -> dict[str, str]:
+    """Parse the output of ``conda list --json`` into ``{name: version}``.
 
-    Parses lines like ``- black=26.1.0`` and returns ``{"black": "26.1.0"}``.
-    Skips pip-style ``==`` pins and non-versioned entries.
+    Separated from the subprocess call so it can be unit-tested without
+    invoking conda.
     """
-    versions: dict[str, str] = {}
-    for line in env_yaml.read_text().splitlines():
-        stripped = line.strip()
-        if not stripped.startswith("- ") or stripped.startswith("- pip"):
-            continue
-        spec = stripped[2:]
-        if "==" in spec or "=" not in spec:
-            continue
-        name, _, version = spec.partition("=")
-        versions[name] = version
-    return versions
+    data = json.loads(json_str)
+    return {pkg["name"]: pkg["version"] for pkg in data}
 
 
-def sync_precommit_linter_versions() -> None:
-    """Sync linter revs in .pre-commit-config.yaml to match environment.yaml."""
-    env_yaml = ROOT / "environment.yaml"
+def _query_conda_versions(env_name: str = "openwpm") -> dict[str, str]:
+    """Return ``{package_name: version}`` for all packages in the conda env.
+
+    Uses ``conda list -n <env> --json`` so we get authoritative, fully-resolved
+    versions without re-parsing environment.yaml ourselves.
+    """
+    try:
+        result = subprocess.run(
+            ["conda", "list", "-n", env_name, "--json"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except FileNotFoundError as e:
+        raise RuntimeError(
+            "conda not found on PATH. Install it via ./install.sh or activate "
+            "your conda installation before running this script."
+        ) from e
+
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"`conda list -n {env_name} --json` failed (exit {result.returncode}). "
+            f"Does the env exist? Run ./install.sh to create it.\n"
+            f"stderr: {result.stderr.strip()}"
+        )
+
+    return _versions_from_conda_list_json(result.stdout)
+
+
+def sync_precommit_linter_versions(env_name: str = "openwpm") -> None:
+    """Sync linter revs in ``.pre-commit-config.yaml`` to the conda env.
+
+    Fails loud if a linter from ``_LINTER_MAP`` is missing from the env or
+    if its hook is missing from ``.pre-commit-config.yaml`` — environment.yaml
+    is supposed to be fully pinned, so silent gaps would mask real bugs.
+    """
     precommit_yaml = ROOT / ".pre-commit-config.yaml"
 
     print("\n=== Syncing pre-commit linter versions with conda ===")
 
-    conda_versions = _parse_conda_versions(env_yaml)
+    conda_versions = _query_conda_versions(env_name)
     content = precommit_yaml.read_text()
 
     updated = False
     for pkg, (repo_url, prefix) in _LINTER_MAP.items():
         if pkg not in conda_versions:
-            print(
-                f"WARNING: {pkg} not found in environment.yaml, skipping",
-                file=sys.stderr,
-            )
-            continue
+            raise RuntimeError(f"{pkg} not found in conda env '{env_name}'.")
 
         target_rev = f"{prefix}{conda_versions[pkg]}"
 
@@ -87,12 +108,9 @@ def sync_precommit_linter_versions() -> None:
         )
         match = pattern.search(content)
         if not match:
-            print(
-                f"WARNING: repo {repo_url} ({pkg}) not found in "
-                f".pre-commit-config.yaml",
-                file=sys.stderr,
+            raise RuntimeError(
+                f"No rev: line found for {repo_url} in .pre-commit-config.yaml"
             )
-            continue
 
         current_rev = content[match.start(0) + len(match.group(1)) : match.end(0)]
         if current_rev == target_rev:

--- a/test/extension/test_logging.py
+++ b/test/extension/test_logging.py
@@ -4,9 +4,7 @@ def test_extension_logging(task_manager_creator, default_params, tmp_path):
     manager_params, browser_params = default_params
     manager_params.log_path = log_path
     for browser_param in browser_params:
-        browser_param.custom_params[
-            "pre_instrumentation_code"
-        ] = f"""
+        browser_param.custom_params["pre_instrumentation_code"] = f"""
             // Weird name needed due to webpack name mangling
             loggingDB.logWarn("{test_msg}"); 
         """

--- a/test/extension/test_startup_timeout.py
+++ b/test/extension/test_startup_timeout.py
@@ -7,9 +7,7 @@ def test_extension_startup_timeout(task_manager_creator, default_params):
     manager_params, browser_params = default_params
     manager_params.num_browsers = 1
     for browser_param in browser_params:
-        browser_param.custom_params[
-            "pre_instrumentation_code"
-        ] = """
+        browser_param.custom_params["pre_instrumentation_code"] = """
            const startTime = Date.now();
            while (Date.now() - startTime < 20000) { // Delaying for 20s
             console.log("delaying startup");

--- a/test/storage/test_values.py
+++ b/test/storage/test_values.py
@@ -1,4 +1,4 @@
-""" This file should contain one entry for every table
+"""This file should contain one entry for every table
 so that we can test storing and loading for every single entry
 for every structured storage provider.
 

--- a/test/test_custom_function_command.py
+++ b/test/test_custom_function_command.py
@@ -86,12 +86,9 @@ def test_custom_function(default_params, xpi, server):
     db = sqlite3.connect(path)
     cur = db.cursor()
 
-    cur.execute(
-        """CREATE TABLE IF NOT EXISTS %s (
+    cur.execute("""CREATE TABLE IF NOT EXISTS %s (
             top_url TEXT, link TEXT,
-            visit_id INTEGER, browser_id INTEGER);"""
-        % table_name
-    )
+            visit_id INTEGER, browser_id INTEGER);""" % table_name)
     cur.close()
     db.close()
 

--- a/test/test_http_instrumentation.py
+++ b/test/test_http_instrumentation.py
@@ -863,9 +863,7 @@ def test_page_visit(
     manager_params, browser_params = http_params()
     if delayed:
         for browser_param in browser_params:
-            browser_param.custom_params[
-                "pre_instrumentation_code"
-            ] = """
+            browser_param.custom_params["pre_instrumentation_code"] = """
                 const startTime = Date.now();
                 while (Date.now() - startTime < 5000) { // Delaying for 5s
                     console.log("delaying startup");

--- a/test/test_profile.py
+++ b/test/test_profile.py
@@ -152,8 +152,7 @@ class AssertConfigSetCommand(BaseCommand):
         extension_socket,
     ):
         webdriver.get("about:config")
-        result = webdriver.execute_script(
-            f"""
+        result = webdriver.execute_script(f"""
                 var prefs = Components
                             .classes["@mozilla.org/preferences-service;1"]
                             .getService(Components.interfaces.nsIPrefBranch);
@@ -162,8 +161,7 @@ class AssertConfigSetCommand(BaseCommand):
                 }} catch (e) {{
                     return false;
                 }}
-            """
-        )
+            """)
         self.logger.error(f"Got result: {result}")
         assert result == self.expected_value
 

--- a/test/test_update_script.py
+++ b/test/test_update_script.py
@@ -1,0 +1,239 @@
+"""Unit tests for scripts/update.py linter-sync helpers.
+
+These tests do not invoke conda — the subprocess call is patched so the
+parsing logic and pre-commit-config rewriting can be exercised in isolation.
+"""
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.pyonly
+
+
+@pytest.fixture(scope="module")
+def update_module():
+    """Load scripts/update.py as a module without making scripts/ a package."""
+    repo_root = Path(__file__).resolve().parent.parent
+    script_path = repo_root / "scripts" / "update.py"
+    spec = importlib.util.spec_from_file_location("scripts_update", script_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["scripts_update"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+SAMPLE_CONDA_LIST = json.dumps(
+    [
+        {
+            "name": "black",
+            "version": "26.1.0",
+            "channel": "conda-forge",
+            "build_string": "pyh866005b_0",
+        },
+        {
+            "name": "isort",
+            "version": "8.0.1",
+            "channel": "conda-forge",
+            "build_string": "pyhd8ed1ab_0",
+        },
+        {
+            "name": "mypy",
+            "version": "1.19.1",
+            "channel": "conda-forge",
+            "build_string": "py314h5bd0f2a_0",
+        },
+        {
+            "name": "pytest",
+            "version": "9.0.2",
+            "channel": "conda-forge",
+            "build_string": "pyhd8ed1ab_0",
+        },
+    ]
+)
+
+
+PRECOMMIT_YAML_TEMPLATE = """\
+repos:
+  - repo: https://github.com/timothycrosley/isort
+    rev: {isort_rev}
+    hooks:
+      - id: isort
+  - repo: https://github.com/psf/black
+    rev: {black_rev}
+    hooks:
+      - id: black
+        language_version: python3
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: {mypy_rev}
+    hooks:
+      - id: mypy
+"""
+
+
+def test_versions_from_conda_list_json_returns_all_versions(update_module):
+    versions = update_module._versions_from_conda_list_json(SAMPLE_CONDA_LIST)
+    assert versions["black"] == "26.1.0"
+    assert versions["isort"] == "8.0.1"
+    assert versions["mypy"] == "1.19.1"
+    assert versions["pytest"] == "9.0.2"
+
+
+def test_versions_from_conda_list_json_invalid_json_raises(update_module):
+    with pytest.raises(json.JSONDecodeError):
+        update_module._versions_from_conda_list_json("not valid json")
+
+
+def test_sync_updates_outdated_revs(update_module, tmp_path, monkeypatch, capsys):
+    precommit = tmp_path / ".pre-commit-config.yaml"
+    precommit.write_text(
+        PRECOMMIT_YAML_TEMPLATE.format(
+            isort_rev="1.0.0", black_rev="20.0.0", mypy_rev="v1.0.0"
+        )
+    )
+    monkeypatch.setattr(update_module, "ROOT", tmp_path)
+    monkeypatch.setattr(
+        update_module,
+        "_query_conda_versions",
+        lambda env_name="openwpm": {
+            "black": "26.1.0",
+            "isort": "8.0.1",
+            "mypy": "1.19.1",
+        },
+    )
+
+    update_module.sync_precommit_linter_versions()
+
+    new_content = precommit.read_text()
+    assert "rev: 26.1.0" in new_content
+    assert "rev: 8.0.1" in new_content
+    assert "rev: v1.19.1" in new_content
+    assert "20.0.0" not in new_content
+    assert "v1.0.0" not in new_content
+
+
+def test_sync_noop_when_versions_match(update_module, tmp_path, monkeypatch):
+    initial = PRECOMMIT_YAML_TEMPLATE.format(
+        isort_rev="8.0.1", black_rev="26.1.0", mypy_rev="v1.19.1"
+    )
+    precommit = tmp_path / ".pre-commit-config.yaml"
+    precommit.write_text(initial)
+    mtime_before = precommit.stat().st_mtime_ns
+
+    monkeypatch.setattr(update_module, "ROOT", tmp_path)
+    monkeypatch.setattr(
+        update_module,
+        "_query_conda_versions",
+        lambda env_name="openwpm": {
+            "black": "26.1.0",
+            "isort": "8.0.1",
+            "mypy": "1.19.1",
+        },
+    )
+
+    update_module.sync_precommit_linter_versions()
+
+    assert precommit.read_text() == initial
+    # File should not have been rewritten when nothing changed.
+    assert precommit.stat().st_mtime_ns == mtime_before
+
+
+def test_sync_raises_when_linter_missing_from_env(update_module, tmp_path, monkeypatch):
+    precommit = tmp_path / ".pre-commit-config.yaml"
+    precommit.write_text(
+        PRECOMMIT_YAML_TEMPLATE.format(
+            isort_rev="8.0.1", black_rev="26.1.0", mypy_rev="v1.19.1"
+        )
+    )
+    monkeypatch.setattr(update_module, "ROOT", tmp_path)
+    monkeypatch.setattr(
+        update_module,
+        "_query_conda_versions",
+        # mypy intentionally missing
+        lambda env_name="openwpm": {"black": "26.1.0", "isort": "8.0.1"},
+    )
+
+    with pytest.raises(RuntimeError, match="mypy"):
+        update_module.sync_precommit_linter_versions()
+
+
+def test_sync_raises_when_hook_missing_from_precommit_config(
+    update_module, tmp_path, monkeypatch
+):
+    # File is missing the mypy hook entirely.
+    precommit = tmp_path / ".pre-commit-config.yaml"
+    precommit.write_text("""\
+repos:
+  - repo: https://github.com/timothycrosley/isort
+    rev: 8.0.1
+    hooks:
+      - id: isort
+  - repo: https://github.com/psf/black
+    rev: 26.1.0
+    hooks:
+      - id: black
+""")
+    monkeypatch.setattr(update_module, "ROOT", tmp_path)
+    monkeypatch.setattr(
+        update_module,
+        "_query_conda_versions",
+        lambda env_name="openwpm": {
+            "black": "26.1.0",
+            "isort": "8.0.1",
+            "mypy": "1.19.1",
+        },
+    )
+
+    with pytest.raises(RuntimeError, match="mypy"):
+        update_module.sync_precommit_linter_versions()
+
+
+def test_query_conda_versions_raises_when_conda_missing(update_module, monkeypatch):
+    def fake_run(*args, **kwargs):
+        raise FileNotFoundError("conda")
+
+    monkeypatch.setattr(update_module.subprocess, "run", fake_run)
+
+    with pytest.raises(RuntimeError, match="conda not found"):
+        update_module._query_conda_versions()
+
+
+def test_query_conda_versions_raises_when_env_missing(update_module, monkeypatch):
+    class FakeResult:
+        returncode = 1
+        stdout = ""
+        stderr = "EnvironmentLocationNotFound: Not a conda environment"
+
+    monkeypatch.setattr(update_module.subprocess, "run", lambda *a, **kw: FakeResult())
+
+    with pytest.raises(RuntimeError, match="install.sh"):
+        update_module._query_conda_versions("nonexistent-env")
+
+
+def test_query_conda_versions_parses_subprocess_output(update_module, monkeypatch):
+    class FakeResult:
+        returncode = 0
+        stdout = SAMPLE_CONDA_LIST
+        stderr = ""
+
+    captured_args = {}
+
+    def fake_run(args, **kwargs):
+        captured_args["args"] = args
+        return FakeResult()
+
+    monkeypatch.setattr(update_module.subprocess, "run", fake_run)
+
+    versions = update_module._query_conda_versions("openwpm")
+    assert versions["black"] == "26.1.0"
+    assert captured_args["args"] == [
+        "conda",
+        "list",
+        "-n",
+        "openwpm",
+        "--json",
+    ]


### PR DESCRIPTION
## Summary

- Adds `sync_precommit_linter_versions()` to `scripts/update.py` that reads pinned versions of black, isort, and mypy from `environment.yaml` and updates the corresponding `rev:` entries in `.pre-commit-config.yaml`
- This runs automatically as part of `python scripts/update.py`, right after repinning the conda environment
- Updates `docs/Release-Checklist.md` to document the new linter drift verification step and fixes step numbering

## Motivation

black, isort, and mypy versions can drift between the conda environment (where they run day-to-day) and `.pre-commit-config.yaml` (where they run in CI/pre-commit hooks). Version drift causes formatting disagreements and false positives/negatives. This change ensures the two stay in sync automatically during the release update process.

## Test plan

- [x] `pre-commit run --all-files` passes
- [ ] Run `python scripts/update.py` in a full conda environment and verify linter versions are synced