### PR TITLE
fix the aborting issue of js instrument

### DIFF
--- a/Extension/src/lib/js-instruments.ts
+++ b/Extension/src/lib/js-instruments.ts
@@ -668,7 +668,15 @@ export function getInstrumentJS(eventId: string, sendMessagesToLogger) {
     if (logSettings.propertiesToInstrument === null) {
       propertiesToInstrument = [];
     } else if (logSettings.propertiesToInstrument.length === 0) {
-      propertiesToInstrument = Object.getPropertyNames(object);
+      try {
+        propertiesToInstrument = Object.getPropertyNames(object);
+      } catch (e) {
+        console.warn(
+          `OpenWPM: Cannot enumerate properties of ${instrumentedName}:`,
+          e,
+        );
+        propertiesToInstrument = [];
+      }
     } else {
       propertiesToInstrument = logSettings.propertiesToInstrument;
     }
@@ -757,11 +765,14 @@ export function getInstrumentJS(eventId: string, sendMessagesToLogger) {
     // More details about how this function is invoked are in
     // content/javascript-instrument-content-scope.ts
     JSInstrumentRequests.forEach(function (item) {
-      instrumentObject(
-        eval(item.object),
-        item.instrumentedName,
-        item.logSettings,
-      );
+      let targetObject;
+      try {
+        targetObject = eval(item.object);
+      } catch (e) {
+        console.warn("OpenWPM: eval failed for instrument target:", item.object, e);
+        targetObject = undefined;
+      }
+      instrumentObject(targetObject, item.instrumentedName, item.logSettings);
     });
   }
 


### PR DESCRIPTION
Fixes #1171

This PR prevents the JS instrumentation process from aborting when:

- Object.getPropertyNames() throws during property enumeration
- eval(item.object) fails for an instrumentation target

The change adds defensive try/catch handling so instrumentation can continue for remaining APIs even if individual targets fail.