### PR TITLE
fix(js-instrument): propagate instrumentation failures to BrowserManager

### DIFF
--- a/Extension/src/lib/js-instruments.ts
+++ b/Extension/src/lib/js-instruments.ts
@@ -773,7 +773,11 @@ export function getInstrumentJS(eventId: string, sendMessagesToLogger) {
             `${item.instrumentedName}: ${message}`,
           );
         } catch {
-          // documentElement unwritable; probe will see nothing.
+          // documentElement unwritable; the probe will see nothing.
+          console.warn(
+            "OpenWPM: could not record instrument failure on the DOM; " +
+              "the instrument-status probe will not observe this failure.",
+          );
         }
         return;
       }

--- a/Extension/src/lib/js-instruments.ts
+++ b/Extension/src/lib/js-instruments.ts
@@ -756,6 +756,7 @@ export function getInstrumentJS(eventId: string, sendMessagesToLogger) {
 
     // More details about how this function is invoked are in
     // content/javascript-instrument-content-scope.ts
+    const failures: string[] = [];
     for (const item of JSInstrumentRequests) {
       try {
         instrumentObject(
@@ -764,22 +765,24 @@ export function getInstrumentJS(eventId: string, sendMessagesToLogger) {
           item.logSettings,
         );
       } catch (e) {
-        // Signal failure via the DOM; GetCommand reads + clears this.
-        try {
-          const message =
-            e && (e as Error).message ? (e as Error).message : String(e);
-          document.documentElement.setAttribute(
-            "data-openwpm-instrument-error",
-            `${item.instrumentedName}: ${message}`,
-          );
-        } catch {
-          // documentElement unwritable; the probe will see nothing.
-          console.warn(
-            "OpenWPM: could not record instrument failure on the DOM; " +
-              "the instrument-status probe will not observe this failure.",
-          );
-        }
-        return;
+        const message =
+          e && (e as Error).message ? (e as Error).message : String(e);
+        failures.push(`${item.instrumentedName}: ${message}`);
+      }
+    }
+    if (failures.length) {
+      // Signal failure via the DOM; GetCommand reads + clears this.
+      try {
+        document.documentElement.setAttribute(
+          "data-openwpm-instrument-error",
+          failures.join("; "),
+        );
+      } catch {
+        // documentElement unwritable; the probe will see nothing.
+        console.warn(
+          "OpenWPM: could not record instrument failure on the DOM; " +
+            "the instrument-status probe will not observe this failure.",
+        );
       }
     }
   }

--- a/Extension/src/lib/js-instruments.ts
+++ b/Extension/src/lib/js-instruments.ts
@@ -756,13 +756,28 @@ export function getInstrumentJS(eventId: string, sendMessagesToLogger) {
 
     // More details about how this function is invoked are in
     // content/javascript-instrument-content-scope.ts
-    JSInstrumentRequests.forEach(function (item) {
-      instrumentObject(
-        eval(item.object),
-        item.instrumentedName,
-        item.logSettings,
-      );
-    });
+    for (const item of JSInstrumentRequests) {
+      try {
+        instrumentObject(
+          eval(item.object),
+          item.instrumentedName,
+          item.logSettings,
+        );
+      } catch (e) {
+        // Signal failure via the DOM; GetCommand reads + clears this.
+        try {
+          const message =
+            e && (e as Error).message ? (e as Error).message : String(e);
+          document.documentElement.setAttribute(
+            "data-openwpm-instrument-error",
+            `${item.instrumentedName}: ${message}`,
+          );
+        } catch {
+          // documentElement unwritable; probe will see nothing.
+        }
+        return;
+      }
+    }
   }
 
   // This whole function getInstrumentJS returns just the function `instrumentJS`.

--- a/openwpm/commands/browser_commands.py
+++ b/openwpm/commands/browser_commands.py
@@ -21,6 +21,7 @@ from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.ui import WebDriverWait
 
 from ..config import BrowserParams, ManagerParams
+from ..errors import CommandExecutionError
 from ..socket_interface import ClientSocket
 from .types import BaseCommand
 from .utils.webdriver_utils import (
@@ -139,8 +140,26 @@ class GetCommand(BaseCommand):
 
         close_other_windows(webdriver)
 
+        if browser_params.js_instrument:
+            _check_js_instrumentation_status(webdriver, self)
+
         if browser_params.bot_mitigation:
             bot_mitigation(webdriver)
+
+
+def _check_js_instrumentation_status(webdriver: Firefox, command: BaseCommand) -> None:
+    try:
+        error = webdriver.execute_script(
+            "var e = document.documentElement.getAttribute("
+            "'data-openwpm-instrument-error');"
+            "document.documentElement.removeAttribute("
+            "'data-openwpm-instrument-error');"
+            "return e;"
+        )
+    except WebDriverException:
+        return
+    if error:
+        raise CommandExecutionError(f"JS instrumentation failed for {error}", command)
 
 
 class BrowseCommand(BaseCommand):

--- a/openwpm/commands/browser_commands.py
+++ b/openwpm/commands/browser_commands.py
@@ -150,13 +150,19 @@ class GetCommand(BaseCommand):
 def _check_js_instrumentation_status(webdriver: Firefox, command: BaseCommand) -> None:
     try:
         error = webdriver.execute_script(
-            "var e = document.documentElement.getAttribute("
-            "'data-openwpm-instrument-error');"
-            "document.documentElement.removeAttribute("
-            "'data-openwpm-instrument-error');"
+            "var el = document && document.documentElement;"
+            "if (!el) return null;"
+            "var e = el.getAttribute('data-openwpm-instrument-error');"
+            "el.removeAttribute('data-openwpm-instrument-error');"
             "return e;"
         )
-    except WebDriverException:
+    except WebDriverException as exc:
+        logger.warning(
+            "BROWSER %i: could not check JS instrumentation status; "
+            "the probe failed to run: %s",
+            command.browser_id,
+            exc,
+        )
         return
     if error:
         raise CommandExecutionError(f"JS instrumentation failed for {error}", command)

--- a/test/test_js_instrument.py
+++ b/test/test_js_instrument.py
@@ -425,8 +425,14 @@ class TestJSInstrumentFailurePropagates(OpenWPMJSTest):
         # ``window.NonExistent.deeplyMissing`` throws while setting up the
         # instrumentation. This stands in for a real-world misconfiguration
         # such as instrumenting a Worker-only global on the window scope.
+        #
+        # Two distinct failing targets are configured so the test also
+        # verifies that *every* failure is reported, not just the first or
+        # last one: ``instrumentJS`` runs all requests to completion and
+        # aggregates their messages into a single error.
         browser_params[0].js_instrument_settings = [
             {"window.NonExistent.deeplyMissing": ["foo"]},
+            {"window.AlsoMissing.deeplyMissing": ["bar"]},
         ]
         return manager_params, browser_params
 
@@ -448,6 +454,14 @@ class TestJSInstrumentFailurePropagates(OpenWPMJSTest):
         assert any(
             "window.NonExistent.deeplyMissing" in e for e in errors
         ), f"expected failing item name in error, got errors={errors}"
+        # Both failing targets must appear in the same aggregated error: the
+        # instrument loop runs to completion and reports every failure, so a
+        # regression to first- or last-only reporting would drop one of these.
+        assert any(
+            "window.NonExistent.deeplyMissing" in e
+            and "window.AlsoMissing.deeplyMissing" in e
+            for e in errors
+        ), f"expected both failing item names in a single error, got errors={errors}"
 
         # The browser must never become healthy: no GetCommand may succeed.
         # If it ever returned "ok" the browser would have started measuring

--- a/test/test_js_instrument.py
+++ b/test/test_js_instrument.py
@@ -395,3 +395,36 @@ class TestJSInstrumentRecursiveProperties(OpenWPMJSTest):
             expected_method_calls=self.METHOD_CALLS,
             expected_gets_and_sets=self.GETS_AND_SETS,
         )
+
+
+class TestJSInstrumentFailurePropagates(OpenWPMJSTest):
+    TEST_PAGE = "instrument_pyside.html"
+
+    def get_config(
+        self, data_dir: Optional[Path]
+    ) -> Tuple[ManagerParams, List[BrowserParams]]:
+        manager_params, browser_params = super().get_config(data_dir)
+        browser_params[0].js_instrument_settings = [
+            {"window.NonExistent.deeplyMissing": ["foo"]},
+        ]
+        return manager_params, browser_params
+
+    def test_failure_marks_visit_failed(self):
+        db = self.visit("/js_instrument/%s" % self.TEST_PAGE)
+        rows = db_utils.query_db(
+            db,
+            "SELECT command, command_status, error FROM crawl_history "
+            "WHERE command = 'GetCommand'",
+        )
+        assert rows, "expected a GetCommand row in crawl_history"
+        statuses = [row["command_status"] for row in rows]
+        errors = [row["error"] or "" for row in rows]
+        assert any(
+            s != "ok" for s in statuses
+        ), f"expected a failed GetCommand, got statuses={statuses}"
+        assert any(
+            "JS instrumentation failed" in e for e in errors
+        ), f"expected instrumentation error message, got errors={errors}"
+        assert any(
+            "window.NonExistent.deeplyMissing" in e for e in errors
+        ), f"expected failing item name in error, got errors={errors}"

--- a/test/test_js_instrument.py
+++ b/test/test_js_instrument.py
@@ -398,33 +398,74 @@ class TestJSInstrumentRecursiveProperties(OpenWPMJSTest):
 
 
 class TestJSInstrumentFailurePropagates(OpenWPMJSTest):
+    """An instrument target that cannot be resolved/instrumented is fatal.
+
+    Incomplete instrumentation means the browser would record an invalid
+    measurement, so the desired behavior is that such a browser *never*
+    produces a successful visit: every GetCommand fails with a
+    ``JS instrumentation failed`` error, no ``javascript`` data is recorded,
+    and the visit is marked incomplete. This is intentionally the opposite of
+    silently skipping the failing target and continuing to collect partial
+    data.
+
+    ``instrument_pyside.html`` is reused on purpose: with a *valid* config it
+    exercises instrumented APIs (cookies, ``fetch``) that populate the
+    ``javascript`` table (see ``TestJSInstrumentByPython``). Asserting that the
+    table stays empty here therefore proves the browser never started
+    measuring, rather than merely that one command returned an error.
+    """
+
     TEST_PAGE = "instrument_pyside.html"
 
     def get_config(
         self, data_dir: Optional[Path]
     ) -> Tuple[ManagerParams, List[BrowserParams]]:
         manager_params, browser_params = super().get_config(data_dir)
+        # ``window.NonExistent`` is undefined, so resolving
+        # ``window.NonExistent.deeplyMissing`` throws while setting up the
+        # instrumentation. This stands in for a real-world misconfiguration
+        # such as instrumenting a Worker-only global on the window scope.
         browser_params[0].js_instrument_settings = [
             {"window.NonExistent.deeplyMissing": ["foo"]},
         ]
         return manager_params, browser_params
 
-    def test_failure_marks_visit_failed(self):
+    def test_failure_prevents_measurement(self):
         db = self.visit("/js_instrument/%s" % self.TEST_PAGE)
-        rows = db_utils.query_db(
+
+        # The GetCommand must surface the instrumentation failure.
+        get_rows = db_utils.query_db(
             db,
-            "SELECT command, command_status, error FROM crawl_history "
+            "SELECT command_status, error FROM crawl_history "
             "WHERE command = 'GetCommand'",
         )
-        assert rows, "expected a GetCommand row in crawl_history"
-        statuses = [row["command_status"] for row in rows]
-        errors = [row["error"] or "" for row in rows]
-        assert any(
-            s != "ok" for s in statuses
-        ), f"expected a failed GetCommand, got statuses={statuses}"
+        assert get_rows, "expected a GetCommand row in crawl_history"
+        statuses = [row["command_status"] for row in get_rows]
+        errors = [row["error"] or "" for row in get_rows]
         assert any(
             "JS instrumentation failed" in e for e in errors
         ), f"expected instrumentation error message, got errors={errors}"
         assert any(
             "window.NonExistent.deeplyMissing" in e for e in errors
         ), f"expected failing item name in error, got errors={errors}"
+
+        # The browser must never become healthy: no GetCommand may succeed.
+        # If it ever returned "ok" the browser would have started measuring
+        # despite the incomplete instrumentation.
+        assert "ok" not in statuses, (
+            "no GetCommand should succeed when instrumentation fails, "
+            f"got statuses={statuses}"
+        )
+
+        # No measurement data may be collected. ``instrument_pyside.html``
+        # would populate this table under a valid config; an empty table
+        # confirms the browser never started collecting.
+        js_rows = db_utils.get_javascript_entries(db)
+        assert not js_rows, (
+            "expected no javascript rows when instrumentation fails, "
+            f"got {len(js_rows)} rows"
+        )
+
+        # The visit must be recorded as incomplete (finalized success=False).
+        incomplete = db_utils.query_db(db, "SELECT visit_id FROM incomplete_visits")
+        assert incomplete, "expected the failed visit to be marked incomplete"


### PR DESCRIPTION
## Summary

Propagates JS instrumentation failures (failed `eval(item.object)` or `Object.getPropertyNames(undefined)`) from the page-injected script up to `BrowserManager`, so a broken `js_instrument_settings` config:

- marks each visit as failed in `crawl_history`,
- triggers `restart_required = True` on the browser, and
- consumes `failure_count` budget — which on consecutive failures (the typical case for a config-level mismatch) exhausts `failure_limit` and aborts the crawl.

Refs #1171 (and is an alternative to #1172).

## Motivation

PR #1172 catches `eval` / `getPropertyNames` exceptions in the injected page script and continues with `propertiesToInstrument = []` or `targetObject = undefined`. That recovers the run, but for a measurement framework, silently producing partial instrumentation is a worse failure mode than the original abort: a researcher analyzing the resulting data cannot distinguish "this API was never called" from "this API was never wrapped." The only signal left is a `console.warn` in the **crawled page's** DevTools, which is invisible during any real crawl.

Discussion under #1172 concluded that:

- Failures here almost always indicate a config that doesn't match the running Firefox (typo, removed/renamed API, version skew). That's a researcher error that **should** stop the crawl loudly.
- A site cannot race the instrumentation: content scripts run at `document_start`, before any page script — so this isn't a "browser corrupted, restart immediately" situation.
- Reusing the existing `failure_count` machinery (`browser_manager.py`) gives us the desired escalation for free: one bad site → one failed visit, counter resets on next success; consistently bad config → counter accumulates → crawl aborts after `failure_limit` consecutive failures.

## Changes

**`Extension/src/lib/js-instruments.ts`** — switch `JSInstrumentRequests.forEach` to `for...of`, wrap each item in `try/catch`. On exception, write `document.documentElement[data-openwpm-instrument-error] = "<instrumentedName>: <message>"` and stop processing further items (preserves the "die on first error" semantic the original code had implicitly).

**`openwpm/commands/browser_commands.py`** — after `GetCommand` navigation settles (and only when `browser_params.js_instrument` is set), run a Selenium probe that reads the marker attribute, **removes it from the DOM**, and raises `CommandExecutionError` if it was set. Removing the attribute is hygiene; the page-side visibility window is unavoidable but bounded to the load duration.

**`test/test_js_instrument.py`** — new `TestJSInstrumentFailurePropagates` covers an `eval`-time failure (`window.NonExistent.deeplyMissing`). Asserts the `GetCommand` row in `crawl_history` has `command_status != "ok"` and that the error message contains both `"JS instrumentation failed"` and the failing item name.

## Notes

- This is a smaller and more invasive-to-research-workflow alternative to #1172. If preferred, the recovery from #1172 could be reinstated **alongside** this signal — but that requires a follow-up discussion on what "partial instrumentation succeeded" means for downstream analysis.
- A future change (there is in-progress work on `refactor/extension-finalize-ack` that adds a bidirectional `sendResponse` socket between the extension and `BrowserManager`) can replace the DOM marker with a direct socket message, removing the brief window where a page script could observe the attribute. The probe contract here is intentionally minimal so that swap is straightforward.

## Test plan

- [x] `pytest test/test_js_instrument.py` — all 7 tests pass (including the new failure-propagation test).
- [x] `pre-commit run --all-files` clean.
- [x] `cd Extension && npm run build && npm run lint` clean.
- [ ] Reviewer to spot-check that a benign `js_instrument_settings` does not now flag visits as failed (covered indirectly by the existing 6 passing JS instrument tests, but worth a sanity look).
