### PR TITLE
feat: add extension-to-BrowserManager finalize ack

### DIFF
--- a/Extension/bundled/privileged/sockets/api.js
+++ b/Extension/bundled/privileged/sockets/api.js
@@ -19,6 +19,9 @@ const gManager = {
   sendingSocketMap: new Map(),
   nextSendingSocketId: 0,
   onDataReceivedListeners: new Set(),
+  // Map of connectionId -> { stream, bOutputStream } for accepted connections
+  connectionMap: new Map(),
+  nextConnectionId: 0,
 };
 
 let bufferpack;
@@ -32,6 +35,56 @@ function writeAll(bOutputStream, bytes) {
   bOutputStream.writeByteArray(bytes, bytes.length);
 }
 
+// Narrow an already-encoded byte-string (each char in 0-255, as produced by
+// escapeString()/encode_utf8() in Extension/src/lib/string-utils.ts) into a
+// Uint8Array of raw bytes. Running TextEncoder over this already-UTF-8 string
+// would double-encode it; assigning into a Uint8Array applies ToUint8 (mod
+// 256), so each already-byte-sized char code lands as the intended raw byte.
+function toBytes(data) {
+  const bytes = new Uint8Array(data.length);
+  for (let i = 0; i < data.length; i++) {
+    bytes[i] = data.charCodeAt(i);
+  }
+  return bytes;
+}
+
+// Pack the length-prefixed header for a payload of `byteLength` bytes. The
+// length field is a big-endian u32 (`>L`); bufferpack silently clamps
+// out-of-range values, which would emit a wrong length and permanently desync
+// the stream. Reject oversized payloads instead.
+function packHeader(byteLength, serializationSymbol) {
+  if (byteLength > 0xffffffff) {
+    throw new Error(
+      `Payload of ${byteLength} bytes exceeds the u32 length ` +
+        `field (max ${0xffffffff}); refusing to send to avoid ` +
+        `framing desync.`,
+    );
+  }
+  return bufferpack.pack(">Lc", [byteLength, serializationSymbol]);
+}
+
+/**
+ * Write a length-prefixed message to a connection's output stream.
+ *
+ * The wire format matches the Python `socket_interface` framing: a 4-byte
+ * big-endian length, a 1-byte serialization tag, then the payload.
+ *
+ * `conn` is a `{ stream, bOutputStream }` pair as stored in `sendingSocketMap`
+ * (outbound connections) or `connectionMap` (replies on accepted connections).
+ *
+ * `data` is an already-encoded byte-string (see `toBytes`); framing on the
+ * narrowed byte length keeps the prefix consistent with the bytes on the wire
+ * for non-ASCII payloads too. Both the header and the payload go through
+ * `writeAll` on the blocking binary stream so a frame can never be partially
+ * written (which would desync the length-prefixed stream).
+ */
+function writeFramedMessage(conn, data, json) {
+  const serializationSymbol = json ? "j" : "n";
+  const bytes = toBytes(data);
+  const header = packHeader(bytes.length, serializationSymbol);
+  writeAll(conn.bOutputStream, header);
+  writeAll(conn.bOutputStream, bytes);
+}
 this.sockets = class extends ExtensionAPI {
   getAPI(context) {
     if (!bufferpack) {
@@ -61,6 +114,29 @@ this.sockets = class extends ExtensionAPI {
           socket.asyncListen({
             onSocketAccepted: (sock, transport) => {
               const inputStream = transport.openInputStream(0, 0, 0);
+              // Open the reply stream in blocking mode (the default flag 0
+              // would yield a non-blocking stream whose write() can throw
+              // NS_BASE_STREAM_WOULD_BLOCK). Replies are tiny and the peer is
+              // a localhost socket that is actively reading, so a blocking
+              // write returns immediately; this mirrors the outbound
+              // `connect()` stream below.
+              const outputStream = transport.openOutputStream(
+                Ci.nsITransport.OPEN_BLOCKING,
+                0,
+                0,
+              );
+
+              gManager.nextConnectionId++;
+              const connectionId = gManager.nextConnectionId;
+              const bOutputStream = Cc[
+                "@mozilla.org/binaryoutputstream;1"
+              ].createInstance(Ci.nsIBinaryOutputStream);
+              bOutputStream.setOutputStream(outputStream);
+              gManager.connectionMap.set(connectionId, {
+                stream: outputStream,
+                bOutputStream,
+              });
+
               const socketListener = {
                 onInputStreamReady: () => {
                   try {
@@ -70,6 +146,18 @@ this.sockets = class extends ExtensionAPI {
                       // Abnormal close, let's log the error.
                       console.error(e);
                     }
+                    // Connection closed: close the paired output stream so we
+                    // don't leak it, then drop the bookkeeping entry.
+                    const conn = gManager.connectionMap.get(connectionId);
+                    if (conn) {
+                      try {
+                        conn.stream.close();
+                      } catch {
+                        // Already closed by the peer; nothing to do.
+                      }
+                    }
+                    inputStream.close();
+                    gManager.connectionMap.delete(connectionId);
                     return;
                   }
                   const bis = Cc[
@@ -99,12 +187,12 @@ this.sockets = class extends ExtensionAPI {
                       new Uint8Array(payloadBytes),
                     );
                     gManager.onDataReceivedListeners.forEach((listener) => {
-                      listener(port, string, tag === "j");
+                      listener(port, string, tag === "j", connectionId);
                     });
                   } else if (tag === "n") {
                     const rawBytes = new Uint8Array(payloadBytes);
                     gManager.onDataReceivedListeners.forEach((listener) => {
-                      listener(port, rawBytes, false);
+                      listener(port, rawBytes, false, connectionId);
                     });
                   } else {
                     console.error(`Unsupported serialization type ('${tag}').`);
@@ -122,8 +210,8 @@ this.sockets = class extends ExtensionAPI {
           context,
           name: "sockets.onDataReceived",
           register: (fire) => {
-            const listener = (id, data, is_json) => {
-              fire.async(id, data, is_json);
+            const listener = (id, data, is_json, connectionId) => {
+              fire.async(id, data, is_json, connectionId);
             };
             gManager.onDataReceivedListeners.add(listener);
             return () => {
@@ -131,6 +219,27 @@ this.sockets = class extends ExtensionAPI {
             };
           },
         }).api(),
+
+        sendResponse(connectionId, data, json) {
+          if (!gManager.connectionMap.has(connectionId)) {
+            console.error(
+              "Unknown connection ID for sendResponse; connection may have closed.",
+            );
+            return false;
+          }
+
+          try {
+            writeFramedMessage(
+              gManager.connectionMap.get(connectionId),
+              data,
+              json,
+            );
+            return true;
+          } catch (err) {
+            console.error(err, err.message);
+            return false;
+          }
+        },
 
         async createSendingSocket() {
           gManager.nextSendingSocketId++;
@@ -181,45 +290,17 @@ this.sockets = class extends ExtensionAPI {
             return false;
           }
 
-          const socket = gManager.sendingSocketMap.get(id);
           try {
-            const serializationSymbol = json ? "j" : "n";
-            // `data` is ALREADY a byte-string, NOT a Unicode string. Every
-            // caller funnels payloads through escapeString()/encode_utf8()
-            // (see Extension/src/lib/string-utils.ts), which converts the
-            // source text to UTF-8 and exposes each byte as a Latin-1 char
-            // (code points 0-255); binary POST bodies arrive the same way. The
-            // bytes we must put on the wire are therefore exactly those char
-            // codes narrowed to one byte each -- this is the lossless byte
-            // pass-through the Python reader (socket_interface._parse) decodes
-            // as UTF-8. Running TextEncoder over this already-encoded
-            // byte-string would double-encode it (the UTF-8 of "你好" turns
-            // into the UTF-8 of "ä½\xa0å¥½" mojibake), so we narrow instead of
-            // re-encode (api.js narrows each char to a byte below). Framing on
-            // bytes.length (== data.length here, since every char is one byte)
-            // keeps the length prefix consistent with the payload.
-            // Assigning into a Uint8Array applies ToUint8 (mod 256), so each
-            // already-byte-sized char code lands as the intended raw byte.
-            const bytes = new Uint8Array(data.length);
-            for (let i = 0; i < data.length; i++) {
-              bytes[i] = data.charCodeAt(i);
-            }
-            // The length field is a big-endian u32 (`>L`); bufferpack silently
-            // clamps out-of-range values, which would emit a wrong length and
-            // permanently desync the stream. Reject oversized payloads instead.
-            if (bytes.length > 0xffffffff) {
-              throw new Error(
-                `Payload of ${bytes.length} bytes exceeds the u32 length ` +
-                  `field (max ${0xffffffff}); refusing to send to avoid ` +
-                  `framing desync.`,
-              );
-            }
-            const buff = bufferpack.pack(">Lc", [
-              bytes.length,
-              serializationSymbol,
-            ]);
-            writeAll(socket.bOutputStream, buff);
-            writeAll(socket.bOutputStream, bytes);
+            // Outbound framing shares the hardened code path with replies:
+            // `data` is an already-encoded byte-string (each char in 0-255 via
+            // escapeString()/encode_utf8() in Extension/src/lib/string-utils.ts;
+            // binary POST bodies arrive the same way). writeFramedMessage()
+            // narrows those char codes back to raw bytes -- re-encoding with
+            // TextEncoder would double-encode and corrupt non-ASCII payloads --
+            // frames on the narrowed byte length, rejects payloads over the u32
+            // length field, and writes header+payload through writeAll() on the
+            // blocking stream so a frame can never be partially written.
+            writeFramedMessage(gManager.sendingSocketMap.get(id), data, json);
             return true;
           } catch (err) {
             console.error(err, err.message);

--- a/Extension/bundled/privileged/sockets/schema.json
+++ b/Extension/bundled/privileged/sockets/schema.json
@@ -73,6 +73,25 @@
             "name": "id"
           }
         ]
+      },
+      {
+        "name": "sendResponse",
+        "type": "function",
+        "async": false,
+        "parameters": [
+          {
+            "type": "number",
+            "name": "connectionId"
+          },
+          {
+            "type": "string",
+            "name": "data"
+          },
+          {
+            "type": "boolean",
+            "name": "json"
+          }
+        ]
       }
     ],
     "events": [
@@ -91,6 +110,10 @@
           {
             "type": "boolean",
             "name": "json"
+          },
+          {
+            "type": "number",
+            "name": "connectionId"
           }
         ]
       }

--- a/Extension/src/loggingdb.ts
+++ b/Extension/src/loggingdb.ts
@@ -11,6 +11,7 @@ interface VisitControlMessage {
   visit_id?: number;
   browser_id?: number | null;
   success?: boolean;
+  finalize_grace_seconds?: number;
 }
 
 let crawlID: number | null = null;
@@ -20,7 +21,10 @@ let storageController: socket.SendingSocket | null = null;
 let logAggregator: socket.SendingSocket | null = null;
 let listeningSocket: socket.ListeningSocket | null = null;
 
-const listeningSocketCallback = async (data: unknown) => {
+const listeningSocketCallback = async (
+  data: unknown,
+  respond: socket.RespondFn,
+) => {
   // This works even if data is an int
   const message = data as VisitControlMessage;
   const action = message.action;
@@ -34,7 +38,7 @@ const listeningSocketCallback = async (data: unknown) => {
       message.browser_id = crawlID ?? null;
       storageController?.send(JSON.stringify(["meta_information", message]));
       break;
-    case "Finalize":
+    case "Finalize": {
       if (!visitID) {
         logWarn("Received Finalize while no visit_id was set");
       }
@@ -46,9 +50,33 @@ const listeningSocketCallback = async (data: unknown) => {
       }
       message.browser_id = crawlID ?? null;
       message.success = true;
+      // BrowserManager has already torn down the visit's tab, but events
+      // captured just before that can still be in flight (content script ->
+      // background messaging, late webRequest callbacks). Keep visitID set
+      // during a short grace period so those stragglers are still attributed
+      // to this visit -- this is what the old Python-side pre-Finalize sleep
+      // achieved, except the wait now happens in the event loop that actually
+      // drains the stragglers rather than in an idle Python sleep.
+      //
+      // No fallback is needed for a missing finalize_grace_seconds: the
+      // extension xpi is built from, and shipped inside, the same repo commit
+      // as the Python that drives it (see install.sh / scripts/build-extension),
+      // so the two never disagree on the control-socket message shape.
+      const graceMs = message.finalize_grace_seconds! * 1000;
+      delete message.finalize_grace_seconds;
+      await new Promise((resolve) => setTimeout(resolve, graceMs));
+      // Grace elapsed: meta_information is the visit's last record, so the
+      // storage controller sees it only after every straggler. Clear the
+      // visit, then acknowledge -- the ack means "visit fully finalized".
       storageController?.send(JSON.stringify(["meta_information", message]));
       visitID = null;
+      respond({
+        action: "FinalizeAck",
+        visit_id: newVisitID,
+        success: true,
+      });
       break;
+    }
     default:
       // Just making sure that it's a valid number before logging
       newVisitID = parseInt(String(data), 10);

--- a/Extension/src/socket.ts
+++ b/Extension/src/socket.ts
@@ -1,11 +1,14 @@
 /* eslint-disable max-classes-per-file */
 
+export type RespondFn = (msg: any) => void;
+
 const DataReceiver = {
   callbacks: new Map(),
   onDataReceived: (
     aSocketId: number,
     aData: string | Uint8Array,
     aJSON: boolean,
+    aConnectionId: number,
   ): void => {
     if (!DataReceiver.callbacks.has(aSocketId)) {
       return;
@@ -13,16 +16,19 @@ const DataReceiver = {
     // aJSON is only ever true for the "j" tag, whose payload is a UTF-8
     // string; "n" arrives as a raw Uint8Array and is handed through untouched.
     const data = aJSON ? JSON.parse(aData as string) : aData;
-    DataReceiver.callbacks.get(aSocketId)(data);
+    const respond: RespondFn = (msg: any) => {
+      browser.sockets.sendResponse(aConnectionId, JSON.stringify(msg), true);
+    };
+    DataReceiver.callbacks.get(aSocketId)(data, respond);
   },
 };
 
 browser.sockets.onDataReceived.addListener(DataReceiver.onDataReceived);
 
 export class ListeningSocket {
-  callback: (data: unknown) => void;
+  callback: (data: unknown, respond: RespondFn) => void;
   port!: number; // assigned in startListening()
-  constructor(callback: (data: unknown) => void) {
+  constructor(callback: (data: unknown, respond: RespondFn) => void) {
     this.callback = callback;
   }
 

--- a/Extension/src/types/browser.d.ts
+++ b/Extension/src/types/browser.d.ts
@@ -4,6 +4,7 @@ declare namespace browser.profileDirIO {
 }
 
 declare namespace browser.sockets {
+  export type ConnectionId = number;
   export const onDataReceived: {
     // `data` is a UTF-8 string for the "j"/"u" tags (isJson is true only for
     // "j") and a raw Uint8Array for the "n" (no-serialization) tag, mirroring
@@ -13,6 +14,7 @@ declare namespace browser.sockets {
         socketId: number,
         data: string | Uint8Array,
         isJson: boolean,
+        connectionId: ConnectionId,
       ) => void,
     ): void;
   };
@@ -30,6 +32,11 @@ declare namespace browser.sockets {
   // (e.g. the connection dropped) or the socket id is unknown.
   export function sendData(
     id: SendingSocketId,
+    data: string,
+    json: boolean,
+  ): boolean;
+  export function sendResponse(
+    connectionId: ConnectionId,
     data: string,
     json: boolean,
   ): boolean;

--- a/openwpm/browser_manager.py
+++ b/openwpm/browser_manager.py
@@ -20,7 +20,7 @@ from selenium.common.exceptions import WebDriverException
 from tblib import Traceback, pickling_support
 
 from .command_sequence import CommandSequence
-from .commands.browser_commands import FinalizeCommand
+from .commands.browser_commands import FinalizeAckTimeout, FinalizeCommand
 from .commands.profile_commands import dump_profile
 from .commands.types import BaseCommand, ShutdownSignal
 from .commands.utils.webdriver_utils import parse_neterror
@@ -452,6 +452,13 @@ class BrowserManagerHandle:
                     "BROWSER %i: Received neterror %s while executing "
                     "command: %s" % (self.browser_id, error_text, repr(command))
                 )
+            elif status[0] == "FINALIZE_INCOMPLETE":
+                command_status = "finalize_incomplete"
+                error_text, tb = self._unpack_pickled_error(status[1])
+                self.logger.warning(
+                    "BROWSER %i: FinalizeAck timed out; marking visit "
+                    "incomplete: %s" % (self.browser_id, repr(command))
+                )
             else:
                 raise ValueError("Unknown browser status message %s" % status)
 
@@ -480,7 +487,31 @@ class BrowserManagerHandle:
                 )
                 return
 
-            if command_status != "ok":
+            if command_status == "finalize_incomplete":
+                # The extension never acknowledged the Finalize, so the visit's
+                # data may be incomplete. Mark the visit unsuccessful and count
+                # it as a failure, but do NOT restart the browser: a merely-slow
+                # drain is not a crash and shouldn't pay the restart cost.
+                task_manager.sock.finalize_visit_id(
+                    success=False, visit_id=self.curr_visit_id
+                )
+                with task_manager.threadlock:
+                    task_manager.failure_count += 1
+                    exceeded_limit = (
+                        task_manager.failure_count > task_manager.failure_limit
+                    )
+                if exceeded_limit:
+                    self.logger.critical(
+                        "BROWSER %i: Command execution failure pushes failure "
+                        "count above the allowable limit. Setting "
+                        "failure_status." % self.browser_id
+                    )
+                    task_manager.failure_status = {
+                        "ErrorType": "ExceedCommandFailureLimit",
+                        "CommandSequence": command_sequence,
+                    }
+                    return
+            elif command_status != "ok":
                 if not is_dns_error(command_status, error_text):
                     with task_manager.threadlock:
                         task_manager.failure_count += 1
@@ -813,6 +844,14 @@ class BrowserManager(Process):
                         extension_socket,
                     )
                     self.status_queue.put("OK")
+                except FinalizeAckTimeout:
+                    # The extension never acknowledged the Finalize within the
+                    # grace+margin window. The visit's data may be incomplete,
+                    # but the browser is still healthy so we keep it running.
+                    self.status_queue.put(
+                        ("FINALIZE_INCOMPLETE", pickle.dumps(sys.exc_info()))
+                    )
+                    continue
                 except WebDriverException:
                     # We handle WebDriverExceptions separately here because they
                     # are quite common, and we often still have a handle to the

--- a/openwpm/command_sequence.py
+++ b/openwpm/command_sequence.py
@@ -1,7 +1,9 @@
+import math
 from pathlib import Path
 from typing import Callable, List, Optional, Tuple
 
 from .commands.browser_commands import (
+    FINALIZE_ACK_MARGIN,
     BrowseCommand,
     DumpPageSourceCommand,
     FinalizeCommand,
@@ -197,5 +199,13 @@ class CommandSequence:
         """
         commands = list(self._commands_with_timeout)
         commands.insert(0, (InitializeCommand(), 10))
-        commands.append((FinalizeCommand(sleep=5), 10))
+        # FinalizeCommand.execute() blocks up to ``sleep + FINALIZE_ACK_MARGIN``
+        # seconds waiting for the extension's FinalizeAck. The command timeout
+        # MUST exceed that bound (plus headroom for the command-queue handoff),
+        # otherwise the watchdog would kill a healthy browser that is still
+        # draining in-flight events before its ack arrives. Derive both from the
+        # same constants so they cannot silently drift apart.
+        finalize_sleep = 5
+        finalize_timeout = math.ceil(finalize_sleep + FINALIZE_ACK_MARGIN) + 5
+        commands.append((FinalizeCommand(sleep=finalize_sleep), finalize_timeout))
         return commands

--- a/openwpm/commands/browser_commands.py
+++ b/openwpm/commands/browser_commands.py
@@ -3,6 +3,8 @@ import json
 import logging
 import os
 import random
+import socket
+import struct
 import sys
 import time
 import traceback
@@ -37,6 +39,16 @@ from .utils.webdriver_utils import (
 NUM_MOUSE_MOVES = 10  # Times to randomly move the mouse
 RANDOM_SLEEP_LOW = 1  # low (in sec) for random sleep between page loads
 RANDOM_SLEEP_HIGH = 7  # high (in sec) for random sleep between page loads
+# Slack added on top of the extension-side finalize grace period when waiting
+# for a FinalizeAck: covers the control-socket round trip and the extension
+# handing the visit's meta_information to the storage controller.
+#
+# INVARIANT: FinalizeCommand.execute() blocks for up to
+# ``grace + FINALIZE_ACK_MARGIN`` seconds. The FinalizeCommand's per-command
+# timeout (set in CommandSequence.get_commands_with_timeout) MUST stay strictly
+# greater than this, or the watchdog will kill a healthy browser mid-drain.
+# That timeout is derived from this constant so the two cannot drift apart.
+FINALIZE_ACK_MARGIN = 10.0
 logger = logging.getLogger("openwpm")
 
 
@@ -96,6 +108,11 @@ def tab_restart_browser(webdriver):
     # to content-level popup blocking.
     webdriver.switch_to.new_window("tab")
     close_other_windows(webdriver)
+
+
+class FinalizeAckTimeout(Exception):
+    """Raised when the extension does not acknowledge a Finalize within the
+    grace+margin window, meaning the visit's data may be incomplete."""
 
 
 class GetCommand(BaseCommand):
@@ -500,11 +517,65 @@ class FinalizeCommand(BaseCommand):
     ):
         """Informs the extension that a visit is done"""
         tab_restart_browser(webdriver)
-        # This doesn't immediately stop data saving from the current
-        # visit so we sleep briefly before unsetting the visit_id.
-        time.sleep(self.sleep)
-        msg = {"action": "Finalize", "visit_id": self.visit_id}
+        # The extension keeps attributing events to this visit for a short
+        # grace period after Finalize (events can still be in flight once the
+        # tab is torn down). We hand it that grace duration and then block on
+        # its FinalizeAck, so the visit is only considered done once the
+        # extension has flushed meta_information to the storage controller.
+        grace = 0.5 if manager_params.testing else self.sleep
+        msg = {
+            "action": "Finalize",
+            "visit_id": self.visit_id,
+            "finalize_grace_seconds": grace,
+        }
         extension_socket.send(msg)
+
+        deadline = time.monotonic() + grace + FINALIZE_ACK_MARGIN
+        browser_id = browser_params.browser_id
+        try:
+            while True:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    raise socket.timeout()
+                ack = extension_socket.receive(timeout=remaining)
+                # The control socket is strictly request/response, but a
+                # FinalizeAck from a previous visit that timed out could still
+                # be buffered. Only a matching ack ends the wait.
+                if (
+                    isinstance(ack, dict)
+                    and ack.get("action") == "FinalizeAck"
+                    and ack.get("visit_id") == self.visit_id
+                ):
+                    logger.debug(
+                        "BROWSER %s: received FinalizeAck for visit_id %s",
+                        browser_id,
+                        self.visit_id,
+                    )
+                    break
+                logger.warning(
+                    "BROWSER %s: discarding unexpected control-socket message "
+                    "while waiting for FinalizeAck of visit_id %s: %r",
+                    browser_id,
+                    self.visit_id,
+                    ack,
+                )
+        except socket.timeout:
+            logger.warning(
+                "BROWSER %s: timed out waiting for FinalizeAck of visit_id %s; "
+                "marking visit incomplete",
+                browser_id,
+                self.visit_id,
+            )
+            raise FinalizeAckTimeout(
+                "BROWSER %s: no FinalizeAck for visit_id %s within grace+margin"
+                % (browser_id, self.visit_id)
+            ) from None
+        except (RuntimeError, ValueError, struct.error):
+            logger.exception(
+                "BROWSER %s: error reading FinalizeAck of visit_id %s",
+                browser_id,
+                self.visit_id,
+            )
 
 
 class InitializeCommand(BaseCommand):

--- a/openwpm/socket_interface.py
+++ b/openwpm/socket_interface.py
@@ -4,6 +4,7 @@ import json
 import socket
 import struct
 import threading
+import time
 import traceback
 from queue import Queue
 from typing import Any
@@ -138,6 +139,12 @@ class ClientSocket:
             raise ValueError("Unsupported serialization type: %s" % serialization)
         self.serialization = serialization
         self.verbose = verbose
+        # Bytes read from the socket but not yet consumed by receive(). Holding
+        # them on the instance keeps the framing synchronized: a timeout part
+        # way through a frame leaves the already-read bytes here for the next
+        # call, and a read that overshoots into the following frame keeps the
+        # surplus rather than discarding it.
+        self._recv_buffer = b""
 
     def connect(self, host, port):
         if self.verbose:
@@ -187,6 +194,50 @@ class ClientSocket:
             if sent == 0:
                 raise RuntimeError("socket connection broken")
             totalsent = totalsent + sent
+
+    def _fill(self, nbytes: int, deadline: float) -> None:
+        """Read until ``self._recv_buffer`` holds at least ``nbytes``.
+
+        Reads stop at ``deadline`` (a ``time.monotonic()`` value). Bytes that
+        have already been read are kept in ``self._recv_buffer`` even when the
+        deadline is hit, so the caller can resume framing on the next call.
+
+        :raises socket.timeout: if the deadline passes before enough bytes
+            have arrived.
+        :raises RuntimeError: if the peer closes the connection.
+        """
+        while len(self._recv_buffer) < nbytes:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise socket.timeout("timed out while reading response")
+            self.sock.settimeout(remaining)
+            chunk = self.sock.recv(4096)
+            if not chunk:
+                raise RuntimeError("socket connection broken")
+            self._recv_buffer += chunk
+
+    def receive(self, timeout: float = 5.0) -> Any:
+        """Read a single response message from the socket.
+
+        Uses the same wire format as :meth:`send`: 4-byte big-endian length +
+        1-byte serialization type + payload. ``timeout`` bounds the whole
+        read; any socket timeout configured before the call is restored
+        afterwards.
+
+        :raises socket.timeout: if no complete message arrives within
+            ``timeout`` seconds.
+        """
+        prev_timeout = self.sock.gettimeout()
+        deadline = time.monotonic() + timeout
+        try:
+            self._fill(5, deadline)
+            msglen, serialization = struct.unpack(">Lc", self._recv_buffer[:5])
+            self._fill(5 + msglen, deadline)
+            frame = self._recv_buffer[: 5 + msglen]
+            self._recv_buffer = self._recv_buffer[5 + msglen :]
+            return _parse(serialization, frame[5:])
+        finally:
+            self.sock.settimeout(prev_timeout)
 
     def close(self):
         self.sock.close()

--- a/test/test_finalize_ack.py
+++ b/test/test_finalize_ack.py
@@ -1,0 +1,142 @@
+"""Unit tests for the synchronous ``FinalizeCommand`` FinalizeAck handshake.
+
+These are ``pyonly`` tests: they drive ``FinalizeCommand.execute`` directly with
+a fake extension socket, no browser or extension involved. The behavior under
+test is the refinement introduced on the finalize-ack branch: when the extension
+does not acknowledge a ``Finalize`` within ``grace + FINALIZE_ACK_MARGIN``,
+``execute`` raises ``FinalizeAckTimeout`` (rather than silently proceeding); a
+matching ``FinalizeAck`` instead lets ``execute`` return normally.
+"""
+
+import socket
+import time
+from types import SimpleNamespace
+from typing import Any, Optional
+
+import pytest
+
+from openwpm.commands import browser_commands
+from openwpm.commands.browser_commands import FinalizeAckTimeout, FinalizeCommand
+
+pytestmark = pytest.mark.pyonly
+
+VISIT_ID = 42
+BROWSER_ID = 0
+
+
+@pytest.fixture(autouse=True)
+def _no_tab_restart(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``FinalizeCommand.execute`` calls ``tab_restart_browser`` first; stub it
+    out so the tests need no real webdriver."""
+    monkeypatch.setattr(browser_commands, "tab_restart_browser", lambda webdriver: None)
+
+
+def _make_command() -> FinalizeCommand:
+    command = FinalizeCommand(sleep=1)
+    command.set_visit_browser_id(VISIT_ID, BROWSER_ID)
+    return command
+
+
+def _run(extension_socket: Any) -> None:
+    command = _make_command()
+    manager_params = SimpleNamespace(testing=True)  # grace == 0.5s
+    browser_params = SimpleNamespace(browser_id=BROWSER_ID)
+    command.execute(
+        webdriver=object(),
+        browser_params=browser_params,
+        manager_params=manager_params,
+        extension_socket=extension_socket,
+    )
+
+
+class _TimeoutSocket:
+    """Never acknowledges: ``receive`` blocks for the requested timeout, then
+    raises ``socket.timeout`` -- exactly what a real socket does when nothing
+    arrives before the deadline."""
+
+    def __init__(self) -> None:
+        self.sent: list = []
+
+    def send(self, msg: Any) -> None:
+        self.sent.append(msg)
+
+    def receive(self, timeout: Optional[float] = None) -> Any:
+        if timeout and timeout > 0:
+            time.sleep(timeout)
+        raise socket.timeout()
+
+
+class _ImmediateTimeoutSocket(_TimeoutSocket):
+    """As above, but ``receive`` raises immediately (no blocking)."""
+
+    def receive(self, timeout: Optional[float] = None) -> Any:
+        raise socket.timeout()
+
+
+class _AckSocket:
+    """Acknowledges immediately with a matching ``FinalizeAck``."""
+
+    def __init__(self, visit_id: int) -> None:
+        self.visit_id = visit_id
+        self.sent: list = []
+
+    def send(self, msg: Any) -> None:
+        self.sent.append(msg)
+
+    def receive(self, timeout: Optional[float] = None) -> Any:
+        return {"action": "FinalizeAck", "visit_id": self.visit_id}
+
+
+def test_finalize_sends_grace_and_visit_id() -> None:
+    sock = _AckSocket(VISIT_ID)
+    _run(sock)
+    assert len(sock.sent) == 1
+    msg = sock.sent[0]
+    assert msg["action"] == "Finalize"
+    assert msg["visit_id"] == VISIT_ID
+    # testing=True forces the grace to 0.5s regardless of sleep
+    assert msg["finalize_grace_seconds"] == 0.5
+
+
+def test_ack_makes_execute_return_normally() -> None:
+    # A matching FinalizeAck must let execute return without raising.
+    _run(_AckSocket(VISIT_ID))
+
+
+def test_timeout_raises_finalize_ack_timeout() -> None:
+    with pytest.raises(FinalizeAckTimeout):
+        _run(_ImmediateTimeoutSocket())
+
+
+def test_timeout_raises_after_roughly_the_deadline(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Shrink the margin so the test stays fast; grace is 0.5s (testing=True),
+    # so the deadline is ~0.5 + 0.2 == 0.7s.
+    monkeypatch.setattr(browser_commands, "FINALIZE_ACK_MARGIN", 0.2)
+    start = time.monotonic()
+    with pytest.raises(FinalizeAckTimeout):
+        _run(_TimeoutSocket())
+    elapsed = time.monotonic() - start
+    # Should block for roughly grace + margin before giving up.
+    assert 0.5 <= elapsed <= 3.0
+
+
+def test_non_matching_message_is_discarded_then_ack_accepted() -> None:
+    # A stale ack for a different visit must not end the wait; the matching
+    # ack that follows should.
+    class _StaleThenAckSocket:
+        def __init__(self) -> None:
+            self.sent: list = []
+            self._responses = [
+                {"action": "FinalizeAck", "visit_id": VISIT_ID + 999},
+                {"action": "FinalizeAck", "visit_id": VISIT_ID},
+            ]
+
+        def send(self, msg: Any) -> None:
+            self.sent.append(msg)
+
+        def receive(self, timeout: Optional[float] = None) -> Any:
+            return self._responses.pop(0)
+
+    _run(_StaleThenAckSocket())

--- a/test/test_socket_interface.py
+++ b/test/test_socket_interface.py
@@ -21,6 +21,7 @@ encodes real ``str`` objects), exercised by the first two tests below.
 import json
 import socket
 import struct
+import threading
 from typing import Any
 
 import pytest
@@ -199,3 +200,96 @@ def test_send_rejects_oversized_payload() -> None:
             client.close()
     finally:
         server.close()
+
+
+# ---------------------------------------------------------------------------
+# Read-side framing tests for ClientSocket.receive() (the response channel
+# used by the finalize-ack round trips). Exercised against a plain TCP peer.
+# ---------------------------------------------------------------------------
+
+
+def frame(obj: object, serialization: bytes = b"j") -> bytes:
+    """Encode ``obj`` the way the extension's socket API frames a reply."""
+    payload = json.dumps(obj).encode("utf-8")
+    return struct.pack(">Lc", len(payload), serialization) + payload
+
+
+@pytest.fixture
+def connected_pair():
+    """Yield ``(peer_conn, client)`` for a connected localhost TCP pair."""
+    listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    listener.bind(("localhost", 0))
+    listener.listen(1)
+    host, port = listener.getsockname()
+
+    client = ClientSocket(serialization="json")
+    client.connect(host, port)
+    peer_conn, _ = listener.accept()
+    listener.close()
+    try:
+        yield peer_conn, client
+    finally:
+        peer_conn.close()
+        client.close()
+
+
+def test_receive_single_frame(connected_pair):
+    peer, client = connected_pair
+    peer.sendall(frame({"action": "FinalizeAck", "visit_id": 7}))
+    assert client.receive(timeout=2.0) == {"action": "FinalizeAck", "visit_id": 7}
+
+
+def test_receive_two_frames_in_one_chunk(connected_pair):
+    """A read that overshoots into the next frame keeps the surplus buffered."""
+    peer, client = connected_pair
+    peer.sendall(frame({"visit_id": 1}) + frame({"visit_id": 2}))
+    assert client.receive(timeout=2.0) == {"visit_id": 1}
+    assert client.receive(timeout=2.0) == {"visit_id": 2}
+
+
+def test_partial_frame_timeout_does_not_desync(connected_pair):
+    """A timeout part-way through a frame must not corrupt the next read."""
+    peer, client = connected_pair
+    full = frame({"action": "FinalizeAck", "visit_id": 9})
+
+    peer.sendall(full[:3])  # only part of the 5-byte header
+    with pytest.raises(socket.timeout):
+        client.receive(timeout=0.2)
+
+    peer.sendall(full[3:])  # the remainder arrives later
+    assert client.receive(timeout=2.0) == {"action": "FinalizeAck", "visit_id": 9}
+
+
+def test_receive_restores_prior_socket_timeout(connected_pair):
+    peer, client = connected_pair
+    client.sock.settimeout(3.5)
+    peer.sendall(frame({"ok": True}))
+    client.receive(timeout=1.0)
+    assert client.sock.gettimeout() == 3.5
+
+
+def test_receive_raises_when_peer_closes(connected_pair):
+    peer, client = connected_pair
+    peer.close()
+    with pytest.raises(RuntimeError):
+        client.receive(timeout=2.0)
+
+
+def test_receive_handles_frame_split_across_recv_calls(connected_pair):
+    """A frame delivered in trickled writes is reassembled into one message."""
+    peer, client = connected_pair
+    full = frame({"action": "FinalizeAck", "visit_id": 42})
+
+    def trickle():
+        for byte in full:
+            peer.sendall(bytes([byte]))
+
+    sender = threading.Thread(target=trickle)
+    sender.start()
+    try:
+        assert client.receive(timeout=5.0) == {
+            "action": "FinalizeAck",
+            "visit_id": 42,
+        }
+    finally:
+        sender.join()


### PR DESCRIPTION
## Summary

Adds a bidirectional channel on the existing extension control socket so the
WebExtension can send responses back to `BrowserManager`, and uses it to
replace `FinalizeCommand`'s fixed pre-`Finalize` sleep with an explicit
`FinalizeAck` from the extension.

This is the extension→BrowserManager back-channel discussed as option (b)
under #1172 / #1173: a general-purpose reply path a follow-up can reuse to
route JS instrumentation failures (and other extension-side signals) directly
to `BrowserManager`.

> **Note on history:** this revision is a substantial rewrite of the original
> WIP. The review below explains what changed and why; the earlier
> implementation should not be used as a reference.

## Background

The control socket (`Initialize` / `Finalize`, Python → extension) was
send-only. Per-visit teardown worked like this:

```python
tab_restart_browser(webdriver)   # close the visited tab
time.sleep(self.sleep)           # fixed 5s grace (FinalizeCommand(sleep=5))
extension_socket.send(Finalize)  # extension clears visit_id
```

The `sleep` exists because closing the tab does **not** immediately stop data
collection — events captured just before teardown are still in flight
(content-script→background messaging, late `webRequest` callbacks). The sleep
runs *before* `Finalize`, so `visit_id` stays set in the extension during it
and those stragglers are still attributed to the correct visit. After the
sleep, `Finalize` clears `visit_id`.

Two problems: it always costs the full fixed interval, and `BrowserManager`
gets no confirmation that the extension actually finished.

### Why the first cut of this PR was wrong

The initial implementation sent `Finalize` *immediately* (no grace) and had
the extension clear `visit_id` and ack right away. That ack only confirmed the
control-socket round trip — it did **not** wait for stragglers, and by
removing the grace it made any event arriving after `Finalize` get tagged
`visit_id = -1`. For a measurement framework that is a worse regression than
the slowness it set out to fix. The redesign below keeps the grace's
guarantee.

## Design

**The grace period moves into the extension, where the stragglers actually
are.** On `Finalize`, the extension keeps `visit_id` set, waits out a grace
period, *then* flushes `meta_information`, clears the visit, and only then
replies `FinalizeAck`. `BrowserManager` passes the grace duration in the
`Finalize` message and blocks on the ack.

This is strictly better than the old Python-side sleep: the wait now happens
inside the JS event loop that drains the in-flight events, instead of in an
idle Python `time.sleep()` in a different process. The ack is now meaningful —
it means "this visit is fully finalized and handed off to storage" — which is
exactly the signal the #1173 follow-up needs. Behaviour for real crawls is
unchanged (same grace, same attribution); the test suite uses a short grace.

### Ack-timeout handling

Because a visit is now considered done only once its `FinalizeAck` arrives, the
timeout path carries real meaning: if the extension does not reply within the
`grace + FINALIZE_ACK_MARGIN` window, the visit's data may be **incomplete**.
Rather than silently proceeding (which would leave an incomplete visit
indistinguishable from a clean one in the data), the timeout is now surfaced as
a distinct, non-fatal outcome:

- `FinalizeCommand` raises `FinalizeAckTimeout` when the deadline is hit.
- `BrowserManager` maps that to a dedicated `FINALIZE_INCOMPLETE` command
  status and, on it, **marks the visit unsuccessful**
  (`finalize_visit_id(success=False)`) and **increments `failure_count`** — but
  does **not** set `restart_required`. A merely-slow drain is not a crash and
  shouldn't pay the browser-restart cost.
- The increment still feeds the existing failure-limit safety, so a *sustained*
  run of ack timeouts trips the normal `ExceedCommandFailureLimit` abort rather
  than being ignored.

This keeps the crawl moving on a one-off slow finalize while ensuring an
unacknowledged visit is recorded as unsuccessful and counted, not silently
passed. The `crawl_history` row for the `FinalizeCommand` records the
`finalize_incomplete` status, so the timeout is auditable after the fact.

The command-level timeout for `FinalizeCommand` is derived from the same
constant as the internal blocking bound and is kept strictly greater than it,
so the manager watchdog cannot kill a browser that is healthily waiting out its
own ack window.

## Changes

**Privileged socket API** (`Extension/bundled/privileged/sockets/{api.js,schema.json}`)
- Track accepted connections in a `connectionMap` (connectionId → streams).
- `sockets.sendResponse(connectionId, data, json)` writes a framed reply on
  the originating connection.
- `sockets.onDataReceived` also passes the `connectionId` to listeners.
- The reply output stream is opened **blocking** (`OPEN_BLOCKING`), and is
  **closed on disconnect** rather than leaked.
- `sendData` and `sendResponse` now share one `writeFramedMessage()` helper.

**Extension plumbing** (`Extension/src/{socket.ts,loggingdb.ts,types/browser.d.ts}`)
- `DataReceiver.onDataReceived` builds a connection-bound `respond()` closure
  and passes it to the callback.
- On `Finalize`, `loggingdb` waits the BrowserManager-supplied grace (during
  which `visit_id` stays valid), then sends `meta_information`, clears the
  visit, and replies `FinalizeAck`.

**Python side** (`openwpm/socket_interface.py`, `openwpm/commands/browser_commands.py`, `openwpm/browser_manager.py`)
- `ClientSocket.receive(timeout)` reads a framed reply. It buffers bytes on
  the instance, so a mid-frame timeout cannot desync the protocol, and it
  restores any socket timeout that was set before the call.
- `FinalizeCommand` sends the grace duration, then waits for a `FinalizeAck`
  whose `action` **and** `visit_id` match the current visit, with a bounded
  fallback timeout. On timeout it raises `FinalizeAckTimeout` instead of
  logging and proceeding.
- `BrowserManager` catches `FinalizeAckTimeout` and emits a new
  `FINALIZE_INCOMPLETE` status, which the command loop handles by marking the
  visit unsuccessful and incrementing `failure_count` **without** requiring a
  browser restart (see *Ack-timeout handling* above).

**Tests** (`test/test_socket_interface.py`, `test/test_finalize_ack.py`)
- New `pyonly` unit tests for `ClientSocket.receive` framing: single frame,
  two frames in one read, mid-frame timeout without desync, timeout
  restoration, peer-close, and byte-trickled reassembly.
- New `test/test_finalize_ack.py` (`pyonly`): `FinalizeCommand` sends the grace
  and `visit_id`; a matching `FinalizeAck` returns normally; a timeout raises
  `FinalizeAckTimeout` (and does so after roughly the deadline); a
  non-matching control message is discarded before a subsequent valid ack is
  accepted.

## How the Copilot review comments were addressed

| Copilot comment | Resolution |
| --- | --- |
| `receive()` resets socket timeout to `None`, clobbering any prior timeout | `receive()` now captures `gettimeout()` and restores it in `finally`. Test: `test_receive_restores_prior_socket_timeout`. |
| A timeout mid-frame desyncs the framing stream | `ClientSocket` now keeps an internal `_recv_buffer`; partial reads and over-reads are preserved across calls. Test: `test_partial_frame_timeout_does_not_desync`. |
| `FinalizeCommand` catches all exceptions and logs them as a timeout | Split into `socket.timeout` (the timeout path, which now raises `FinalizeAckTimeout` so the visit is marked unsuccessful) vs. `(RuntimeError, ValueError, struct.error)` (logged with `logger.exception`). |
| `FinalizeCommand` doesn't validate the ack matches the current visit | It now loops until it sees `action == "FinalizeAck"` **and** `visit_id == self.visit_id`, discarding (and logging) anything else, bounded by a shared deadline. |
| `FinalizeAck` sent before late records are flushed / `visit_id` cleared too early | Core of the redesign: the grace period moved into the extension, `visit_id` stays valid through it, and the ack is sent only after `meta_information` is handed to storage. |
| Closed connection leaks its output stream | On disconnect the paired output stream is closed before the `connectionMap` entry is dropped. |
| `sendResponse` frames by `data.length` (string length, not bytes) | See "Known limitation" below. |

## Critical review against Mozilla socket practices

I reviewed the privileged socket code against Mozilla's `nsITransport` /
`nsISocketTransport` contract (via Searchfox) and against OpenWPM's own
established socket patterns.

- **Reply stream blocking mode.** The first cut opened the reply stream with
  `transport.openOutputStream(0, 0, 0)`. Per
  [`nsITransport.idl`](https://searchfox.org/mozilla-central/source/netwerk/base/nsITransport.idl),
  flags `0` yields a **non-blocking** stream whose `write()` can throw
  `NS_BASE_STREAM_WOULD_BLOCK` — which the surrounding `try/catch` would
  silently swallow, dropping the ack. Correctly handling a non-blocking output
  stream means `nsIAsyncOutputStream` + `asyncWait` and a write queue. Since
  the existing outbound stream in `connect()` already uses
  `openOutputStream(OPEN_BLOCKING, …)` and the ack is a tiny payload to a
  localhost peer that is actively reading, a blocking write returns
  effectively instantly. The reply stream now uses `OPEN_BLOCKING`, matching
  the existing pattern; the value (`1 << 0`) is confirmed by `nsITransport.idl`.
- **Bidirectional use of one accepted transport.** Opening both an input and
  an output stream from the single `transport` handed to `onSocketAccepted` is
  the supported pattern for full-duplex use; the input stream stays
  non-blocking (required for `asyncWait`) and the two streams are independent.
- **Stream lifetime.** `nsIServerSocket` accepted connections own their
  streams; nothing closes them implicitly. The disconnect path now closes the
  output stream (the input stream is already closed by the peer at that
  point), preventing a per-visit-failure descriptor leak.
- **Framing consistency.** OpenWPM's existing `sendData` and the Python
  `socket_interface` both frame with a 4-byte big-endian length + 1-byte
  serialization tag. `sendResponse` reuses that exact format (now via a shared
  `writeFramedMessage` helper) so the Python `receive()` and `send()` stay
  symmetric.

## Known limitation (documented, not silently shipped)

`writeFramedMessage` derives the length prefix from `data.length`, a UTF-16
code-unit count, which equals the byte count only for ASCII. This is the
**pre-existing** framing already used by `sendData`. It is correct for every
message that travels this socket today — storage records (ASCII-escaped JSON)
and the control messages `Initialize` / `Finalize` / `FinalizeAck` (string
action + integer `visit_id` + boolean) are all ASCII. Making the framing
UTF-8-safe is worthwhile, but it must change `sendData` and `sendResponse`
**together** to keep the two senders consistent, so it is intentionally left
as a separate follow-up rather than introducing a divergence here. The
`writeFramedMessage` doc comment records this.

## Sources referenced

- **`netwerk/base/nsITransport.idl`** (Searchfox, mozilla-central) — confirmed
  `OPEN_BLOCKING = 1<<0` / `OPEN_UNBUFFERED = 1<<1` and that flags `0` produces
  a non-blocking stream. This is what drove switching the reply stream to
  `OPEN_BLOCKING` and rejecting the original `openOutputStream(0,0,0)`.
- **OpenWPM's existing socket code** (`api.js` `connect()` / `sendData`,
  `socket_interface.py` `send` / `_handle_conn` / `_parse`) — used as the
  reference for stream flags, the wire format, and the serialization tags.
  This is why `sendResponse` mirrors `sendData` (shared helper, blocking
  stream) instead of introducing a parallel convention, and why the
  byte-length question is treated as a cross-cutting follow-up.
- **`git log` on `browser_commands.py`** — traced the `time.sleep` grace to
  `e338bb2` ("Command refactoring", #750) and `FinalizeCommand(sleep=5)` in
  `command_sequence.py`. Establishing that the grace keeps `visit_id` valid for
  in-flight events is what exposed the original PR's attribution regression and
  shaped the "move the grace into the extension" design.
- **Issues #1171 / #1172 / #1173** — confirmed the intended downstream
  consumer of this back-channel, keeping `sendResponse` / `respond()` generic
  rather than `FinalizeAck`-specific.

## Follow-up

- **#1220** — the finalize ack confirms the extension→`BrowserManager` handoff;
  two other teardown points (the log-socket shutdown `sleep(3)` in `mp_logger`
  and the storage-controller completion-queue poll) still use fixed timeouts
  and are tracked there for the same drain-and-confirm treatment.

## Test plan

- [x] `pytest -m pyonly test/test_socket_interface.py` — 6 new `pyonly` framing tests pass.
- [x] `pytest -m pyonly test/test_finalize_ack.py` — 5 `pyonly` tests pass (grace/`visit_id` message, ack returns normally, timeout raises `FinalizeAckTimeout`, deadline timing, stale-message discard).
- [x] `pytest test/test_simple_commands.py::test_get_site_visits_table_valid`
  and `::test_get_http_tables_valid` — full visit cycle incl. the
  `FinalizeAck` round trip, pass (headless + xvfb).
- [x] `pytest test/test_js_instrument.py -k "not failure"` — 6 tests pass;
  exercises async JS events, the most likely stragglers, attributed correctly.
- [x] `cd Extension && npm run build && npm run lint` — clean.
- [x] `pre-commit run` — clean on changed Python files.
