### PR TITLE
fix(storage): socket read-side correctness + robustness + security note

### DIFF
--- a/Extension/bundled/privileged/sockets/api.js
+++ b/Extension/bundled/privileged/sockets/api.js
@@ -1,3 +1,5 @@
+Cu.importGlobalProperties(["TextDecoder"]);
+
 const tm = Cc["@mozilla.org/thread-manager;1"].getService();
 const socketService = Cc[
   "@mozilla.org/network/socket-transport-service;1"
@@ -13,6 +15,30 @@ const gManager = {
 };
 
 let bufferpack;
+
+// Write the full byte array to a *blocking* nsIBinaryOutputStream. On a
+// blocking stream (we open with OPEN_BLOCKING; see connect()) writeByteArray
+// writes every byte or throws, so a partial write cannot silently truncate a
+// length-framed payload. writeByteArray also returns void there, so the single
+// call below is all that ever runs; the loop guards only against a
+// hypothetical build where writeByteArray reports a positive short-write count,
+// in which case we advance and retry. A reported 0 (or void/NaN) cannot
+// represent progress, so we stop to avoid spinning forever — this is safe only
+// because the stream is blocking and so a true "wrote nothing, would block"
+// short write never occurs here.
+function writeAll(bOutputStream, bytes) {
+  let offset = 0;
+  while (offset < bytes.length) {
+    const written = bOutputStream.writeByteArray(
+      offset === 0 ? bytes : bytes.subarray(offset),
+      bytes.length - offset,
+    );
+    if (!written || Number.isNaN(written)) {
+      break;
+    }
+    offset += written;
+  }
+}
 
 this.sockets = class extends ExtensionAPI {
   getAPI(context) {
@@ -60,16 +86,36 @@ this.sockets = class extends ExtensionAPI {
                   bis.setInputStream(inputStream);
                   const buff = bis.readByteArray(5); // 32 bit int followed by a char = 5 bytes
                   const meta = bufferpack.unpack(">Lc", buff);
-                  const string = bis.readBytes(meta[0]);
+                  // Read the payload as raw bytes. Using bis.readBytes()
+                  // narrows each byte to a Latin-1 char and would corrupt any
+                  // multi-byte UTF-8 payload (the mirror of the send-side
+                  // bug). The byte count is consumed regardless of tag, so the
+                  // frame stays aligned even for an unsupported serialization
+                  // type.
+                  const payloadBytes = bis.readByteArray(meta[0]);
+                  const tag = meta[1];
 
-                  if (["j", "n"].includes(meta[1])) {
+                  // Tag parity with the Python reader (socket_interface._parse):
+                  //   "j" -> UTF-8 + JSON.parse, "u" -> UTF-8 string,
+                  //   "n" -> RAW BYTES (returned unchanged on the Python side).
+                  // Only "j" and "u" are UTF-8 text; "n" must be delivered as
+                  // raw bytes, NOT UTF-8-decoded, or it would diverge from
+                  // Python (which returns the bytes untouched) and could throw
+                  // on a non-UTF-8 payload.
+                  if (tag === "j" || tag === "u") {
+                    const string = new TextDecoder("utf-8").decode(
+                      new Uint8Array(payloadBytes),
+                    );
                     gManager.onDataReceivedListeners.forEach((listener) => {
-                      listener(port, string, meta[1] === "j");
+                      listener(port, string, tag === "j");
+                    });
+                  } else if (tag === "n") {
+                    const rawBytes = new Uint8Array(payloadBytes);
+                    gManager.onDataReceivedListeners.forEach((listener) => {
+                      listener(port, rawBytes, false);
                     });
                   } else {
-                    console.error(
-                      `Unsupported serialization type ('${meta[1]}').`,
-                    );
+                    console.error(`Unsupported serialization type ('${tag}').`);
                   }
 
                   inputStream.asyncWait(socketListener, 0, 0, tm.mainThread);
@@ -122,6 +168,10 @@ this.sockets = class extends ExtensionAPI {
               null,
               null,
             );
+            // openFlags = 1 = OPEN_BLOCKING (NOT OPEN_UNBUFFERED, which is 2).
+            // A blocking stream makes writeByteArray all-or-throw, so framed
+            // payloads can never be partially written (which would desync the
+            // length-prefixed stream). See writeAll().
             socket.stream = transport.openOutputStream(1, 4096, 1048575);
             socket.bOutputStream.setOutputStream(socket.stream);
             return true;
@@ -136,18 +186,48 @@ this.sockets = class extends ExtensionAPI {
             console.error(
               "Unknown socket ID; trying to use a socket that doesn't exist yet?",
             );
-            return;
+            return false;
           }
 
           const socket = gManager.sendingSocketMap.get(id);
           try {
             const serializationSymbol = json ? "j" : "n";
+            // `data` is ALREADY a byte-string, NOT a Unicode string. Every
+            // caller funnels payloads through escapeString()/encode_utf8()
+            // (see Extension/src/lib/string-utils.ts), which converts the
+            // source text to UTF-8 and exposes each byte as a Latin-1 char
+            // (code points 0-255); binary POST bodies arrive the same way. The
+            // bytes we must put on the wire are therefore exactly those char
+            // codes narrowed to one byte each -- this is the lossless byte
+            // pass-through the Python reader (socket_interface._parse) decodes
+            // as UTF-8. Running TextEncoder over this already-encoded
+            // byte-string would double-encode it (the UTF-8 of "你好" turns
+            // into the UTF-8 of "ä½\xa0å¥½" mojibake), so we narrow instead of
+            // re-encode (api.js narrows each char to a byte below). Framing on
+            // bytes.length (== data.length here, since every char is one byte)
+            // keeps the length prefix consistent with the payload.
+            // Assigning into a Uint8Array applies ToUint8 (mod 256), so each
+            // already-byte-sized char code lands as the intended raw byte.
+            const bytes = new Uint8Array(data.length);
+            for (let i = 0; i < data.length; i++) {
+              bytes[i] = data.charCodeAt(i);
+            }
+            // The length field is a big-endian u32 (`>L`); bufferpack silently
+            // clamps out-of-range values, which would emit a wrong length and
+            // permanently desync the stream. Reject oversized payloads instead.
+            if (bytes.length > 0xffffffff) {
+              throw new Error(
+                `Payload of ${bytes.length} bytes exceeds the u32 length ` +
+                  `field (max ${0xffffffff}); refusing to send to avoid ` +
+                  `framing desync.`,
+              );
+            }
             const buff = bufferpack.pack(">Lc", [
-              data.length,
+              bytes.length,
               serializationSymbol,
             ]);
-            socket.bOutputStream.writeByteArray(buff, buff.length);
-            socket.stream.write(data, data.length);
+            writeAll(socket.bOutputStream, buff);
+            writeAll(socket.bOutputStream, bytes);
             return true;
           } catch (err) {
             console.error(err, err.message);

--- a/Extension/bundled/privileged/sockets/api.js
+++ b/Extension/bundled/privileged/sockets/api.js
@@ -1,5 +1,12 @@
 Cu.importGlobalProperties(["TextDecoder"]);
 
+// Cache a single UTF-8 decoder for the instrumentation hot path. A new
+// TextDecoder per received frame would allocate on every "j"/"u" decode; one
+// shared instance is safe because decode() is synchronous and stateless for
+// our one-shot (non-streaming) calls. Only the "j"/"u" UTF-8 text path uses
+// this; the "n" raw-bytes path never decodes.
+const gUtf8Decoder = new TextDecoder("utf-8");
+
 const tm = Cc["@mozilla.org/thread-manager;1"].getService();
 const socketService = Cc[
   "@mozilla.org/network/socket-transport-service;1"
@@ -103,7 +110,7 @@ this.sockets = class extends ExtensionAPI {
                   // Python (which returns the bytes untouched) and could throw
                   // on a non-UTF-8 payload.
                   if (tag === "j" || tag === "u") {
-                    const string = new TextDecoder("utf-8").decode(
+                    const string = gUtf8Decoder.decode(
                       new Uint8Array(payloadBytes),
                     );
                     gManager.onDataReceivedListeners.forEach((listener) => {

--- a/Extension/bundled/privileged/sockets/api.js
+++ b/Extension/bundled/privileged/sockets/api.js
@@ -23,28 +23,13 @@ const gManager = {
 
 let bufferpack;
 
-// Write the full byte array to a *blocking* nsIBinaryOutputStream. On a
-// blocking stream (we open with OPEN_BLOCKING; see connect()) writeByteArray
-// writes every byte or throws, so a partial write cannot silently truncate a
-// length-framed payload. writeByteArray also returns void there, so the single
-// call below is all that ever runs; the loop guards only against a
-// hypothetical build where writeByteArray reports a positive short-write count,
-// in which case we advance and retry. A reported 0 (or void/NaN) cannot
-// represent progress, so we stop to avoid spinning forever — this is safe only
-// because the stream is blocking and so a true "wrote nothing, would block"
-// short write never occurs here.
+// Write the full byte array to a *blocking* nsIBinaryOutputStream. We open the
+// stream with OPEN_BLOCKING (see connect()), where writeByteArray has all-or-
+// throw semantics: it writes every byte or throws. A partial/short write
+// therefore cannot silently truncate a length-framed payload, so a single call
+// suffices.
 function writeAll(bOutputStream, bytes) {
-  let offset = 0;
-  while (offset < bytes.length) {
-    const written = bOutputStream.writeByteArray(
-      offset === 0 ? bytes : bytes.subarray(offset),
-      bytes.length - offset,
-    );
-    if (!written || Number.isNaN(written)) {
-      break;
-    }
-    offset += written;
-  }
+  bOutputStream.writeByteArray(bytes, bytes.length);
 }
 
 this.sockets = class extends ExtensionAPI {

--- a/Extension/src/echo.ts
+++ b/Extension/src/echo.ts
@@ -1,0 +1,89 @@
+import * as loggingDB from "./loggingdb";
+import { escapeString } from "./lib/string-utils";
+
+/**
+ * Test-only "echo mode" (config flag `echo_mode`, default off).
+ *
+ * Instead of running any instrument, the extension emits a fixed set of
+ * synthetic payloads over the already-connected storageController
+ * `SendingSocket`. This drives the real `sockets.sendData` framing path that
+ * PR #1180 hardened (the `>Lc` length prefix, the `j`/`n` tags, the
+ * byte-string narrowing) end to end into a Python `ServerSocket`, so a test
+ * can assert exact round-trip fidelity without standing up a StorageController
+ * or a real crawl. See `test/test_socket_echo.py`.
+ *
+ * Payloads (matching the real wire path):
+ *  - A `j` (JSON) record whose string values were run through `escapeString`
+ *    just like every real instrument does. `escapeString` =
+ *    `unescape(encodeURIComponent(s))`, i.e. it turns the source text into
+ *    UTF-8 and exposes each byte as a Latin-1 char. `JSON.stringify` therefore
+ *    produces a byte-string; api.js narrows each char to a byte; the Python
+ *    reader decodes the frame as UTF-8 and `json.loads` it back to the
+ *    original Unicode record.
+ *  - An `n` (raw byte-string) payload sent via `send(data, false)` (json=false).
+ *    `data` is `escapeString("café/🌍")` -- the UTF-8 bytes as Latin-1 chars --
+ *    so api.js puts the raw UTF-8 bytes on the wire and the Python reader
+ *    returns them as `bytes`, untouched.
+ *
+ * The non-ASCII content mirrors what `test/test_socket_interface.py` pins: a
+ * double UTF-8 encode on the send side would turn it into mojibake, so an exact
+ * round-trip is a real regression guard for #1180.
+ */
+
+// The decoded (original) Unicode strings the `j` record carries. The test
+// asserts against these post-decode values; echo escapes them on the way out.
+export const ECHO_J_RECORD = [
+  "echo",
+  {
+    s: "你好 — Привет — 🌍",
+    n: "naïve café λ — 例え",
+  },
+];
+
+// The source text for the `n` payload. On the wire this is its UTF-8 bytes; the
+// Python side receives `"café/🌍".encode("utf-8")` as raw `bytes`.
+export const ECHO_N_TEXT = "café/🌍";
+
+function escapeValue(value: any): any {
+  if (typeof value === "string") {
+    return escapeString(value);
+  }
+  if (Array.isArray(value)) {
+    return value.map(escapeValue);
+  }
+  if (value !== null && typeof value === "object") {
+    const out: any = {};
+    for (const k of Object.keys(value)) {
+      out[escapeString(k)] = escapeValue(value[k]);
+    }
+    return out;
+  }
+  return value;
+}
+
+export const runEchoMode = function (): void {
+  console.warn(
+    "OpenWPM echo_mode is ENABLED: skipping all instruments and emitting " +
+      "synthetic protocol-test payloads on the storage socket. This is a " +
+      "test-only affordance and must never be set for a real crawl.",
+  );
+
+  const storageController = loggingDB.getStorageController();
+  if (storageController == null) {
+    console.error(
+      "echo_mode: storageController socket is not connected; cannot emit " +
+        "payloads. Did the harness inject storage_controller_address?",
+    );
+    return;
+  }
+
+  // (A) JSON record with non-ASCII content, via the 'j' tag. Escape string
+  // values first, exactly like the real instruments, so the bytes on the wire
+  // match production.
+  const escaped = escapeValue(ECHO_J_RECORD);
+  storageController.send(JSON.stringify(escaped), true);
+
+  // (B) Raw byte-string payload, via the 'n' tag. send(data, false) skips JSON
+  // and api.js narrows the (already byte-sized) chars straight to the wire.
+  storageController.send(escapeString(ECHO_N_TEXT), false);
+};

--- a/Extension/src/echo.ts
+++ b/Extension/src/echo.ts
@@ -13,17 +13,18 @@ import { escapeString } from "./lib/string-utils";
  * or a real crawl. See `test/test_socket_echo.py`.
  *
  * Payloads (matching the real wire path):
- *  - A `j` (JSON) record whose string values were run through `escapeString`
- *    just like every real instrument does. `escapeString` =
- *    `unescape(encodeURIComponent(s))`, i.e. it turns the source text into
- *    UTF-8 and exposes each byte as a Latin-1 char. `JSON.stringify` therefore
- *    produces a byte-string; api.js narrows each char to a byte; the Python
- *    reader decodes the frame as UTF-8 and `json.loads` it back to the
- *    original Unicode record.
- *  - An `n` (raw byte-string) payload sent via `send(data, false)` (json=false).
- *    `data` is `escapeString("café/🌍")` -- the UTF-8 bytes as Latin-1 chars --
- *    so api.js puts the raw UTF-8 bytes on the wire and the Python reader
- *    returns them as `bytes`, untouched.
+ *
+ * A `j` (JSON) record whose string values were run through `escapeString` just
+ * like every real instrument does. `escapeString` = `unescape(encodeURIComponent(s))`,
+ * i.e. it turns the source text into UTF-8 and exposes each byte as a Latin-1
+ * char. `JSON.stringify` therefore produces a byte-string; api.js narrows each
+ * char to a byte; the Python reader decodes the frame as UTF-8 and `json.loads`
+ * it back to the original Unicode record.
+ *
+ * An `n` (raw byte-string) payload sent via `send(data, false)` (json=false).
+ * `data` is `escapeString("café/🌍")` -- the UTF-8 bytes as Latin-1 chars -- so
+ * api.js puts the raw UTF-8 bytes on the wire and the Python reader returns them
+ * as `bytes`, untouched.
  *
  * The non-ASCII content mirrors what `test/test_socket_interface.py` pins: a
  * double UTF-8 encode on the send side would turn it into mojibake, so an exact

--- a/Extension/src/feature.ts
+++ b/Extension/src/feature.ts
@@ -7,6 +7,7 @@ import { NavigationInstrument } from "./background/navigation-instrument";
 
 import * as loggingDB from "./loggingdb";
 import { CallstackInstrument } from "./callstack-instrument";
+import { runEchoMode } from "./echo";
 
 async function main() {
   // Read the browser configuration from file
@@ -57,6 +58,18 @@ async function main() {
     config.logger_address,
     config.browser_id,
   );
+
+  // Test-only echo mode: emit synthetic protocol-test payloads instead of
+  // running any instrument, then fall through to the startup-success write.
+  if (config.echo_mode) {
+    try {
+      runEchoMode();
+    } catch (err) {
+      console.error("echo_mode emit failed", err);
+    }
+    await browser.profileDirIO.writeFile("OPENWPM_STARTUP_SUCCESS.txt", "");
+    return;
+  }
 
   if (config.custom_params.pre_instrumentation_code) {
     eval(config.custom_params.pre_instrumentation_code);

--- a/Extension/src/loggingdb.ts
+++ b/Extension/src/loggingdb.ts
@@ -87,6 +87,14 @@ export const open = async function (
   );
 };
 
+// Accessor for echo mode (see Extension/src/echo.ts). The connected
+// storageController SendingSocket is module-private; expose it rather than
+// reaching into internals so the echo routine can reuse the live connection
+// instead of opening a second one.
+export const getStorageController = function (): socket.SendingSocket | null {
+  return storageController;
+};
+
 export const close = function () {
   if (storageController != null) {
     storageController.close();

--- a/Extension/src/socket.ts
+++ b/Extension/src/socket.ts
@@ -2,14 +2,18 @@
 
 const DataReceiver = {
   callbacks: new Map(),
-  onDataReceived: (aSocketId: number, aData: string, aJSON: boolean): void => {
+  onDataReceived: (
+    aSocketId: number,
+    aData: string | Uint8Array,
+    aJSON: boolean,
+  ): void => {
     if (!DataReceiver.callbacks.has(aSocketId)) {
       return;
     }
-    if (aJSON) {
-      aData = JSON.parse(aData);
-    }
-    DataReceiver.callbacks.get(aSocketId)(aData);
+    // aJSON is only ever true for the "j" tag, whose payload is a UTF-8
+    // string; "n" arrives as a raw Uint8Array and is handed through untouched.
+    const data = aJSON ? JSON.parse(aData as string) : aData;
+    DataReceiver.callbacks.get(aSocketId)(data);
   },
 };
 
@@ -41,7 +45,20 @@ export class SendingSocket {
 
   send(aData: string, aJSON = true): boolean {
     try {
-      browser.sockets.sendData(this.id, aData, !!aJSON);
+      // sendData resolves to false (rather than throwing) when the framed
+      // write fails, e.g. the StorageController connection dropped. Surface
+      // that instead of swallowing it: there is no reconnect, so a silent
+      // false here is permanent per-browser data loss for the rest of the
+      // visit. We log rather than throw to avoid breaking fire-and-forget
+      // callers; the browser console error is the observability hook.
+      const ok = browser.sockets.sendData(this.id, aData, !!aJSON);
+      if (ok === false) {
+        console.error(
+          `SendingSocket.send: framed write failed on socket ${this.id}; ` +
+            `record dropped (no reconnect).`,
+        );
+        return false;
+      }
       return true;
     } catch (err) {
       console.error(err, err.message);

--- a/Extension/src/types/browser.d.ts
+++ b/Extension/src/types/browser.d.ts
@@ -5,8 +5,15 @@ declare namespace browser.profileDirIO {
 
 declare namespace browser.sockets {
   export const onDataReceived: {
+    // `data` is a UTF-8 string for the "j"/"u" tags (isJson is true only for
+    // "j") and a raw Uint8Array for the "n" (no-serialization) tag, mirroring
+    // the Python reader (socket_interface._parse).
     addListener(
-      receiver: (socketId: number, data: string, isJson: boolean) => void,
+      receiver: (
+        socketId: number,
+        data: string | Uint8Array,
+        isJson: boolean,
+      ) => void,
     ): void;
   };
   export type ServerSocketId = number;
@@ -19,10 +26,12 @@ declare namespace browser.sockets {
     host: string,
     port: number,
   ): void;
+  // Returns true on a successful framed write, false if the write failed
+  // (e.g. the connection dropped) or the socket id is unknown.
   export function sendData(
     id: SendingSocketId,
     data: string,
     json: boolean,
-  ): void;
+  ): boolean;
   export function close(id: SendingSocketId | ServerSocketId): void;
 }

--- a/docs/Architecture-Internals.md
+++ b/docs/Architecture-Internals.md
@@ -47,6 +47,37 @@ The **TaskManager** is the user-facing entry point. It spawns:
 strictly request-reply: TaskManager sends one command, then blocks waiting for
 exactly one status response.
 
+## Socket Wire Protocol and Security
+
+Both the Extension → StorageController data channel and the reverse
+TaskManager → Extension control channel use the same length-prefixed framing
+(`openwpm/socket_interface.py`, `Extension/bundled/privileged/sockets/api.js`):
+a 5-byte header (`>Lc` = big-endian `uint32` byte length + 1-byte serialization
+tag) followed by the payload. The tag is one of `n` (raw bytes), `u` (UTF-8
+string), `j` (JSON), or `d` (dill pickle). Payloads are framed on the **payload
+byte length** (UTF-8 bytes for the `j`/`u` text frames; raw bytes for the `n`
+and `d` binary frames — the `d` dill pickles are not UTF-8), and the length
+field rejects payloads ≥ 4 GiB rather than
+silently truncating.
+
+### Security model (single-tenant assumption)
+
+The sockets are **loopback-only** (`StorageController` binds
+`("localhost", 0)`; the extension listener uses `init(-1, true, -1)`), bound to
+**random ephemeral ports** exchanged out-of-band via the profile directory, and
+**not reachable from web content or off-host**. They are, however,
+**unauthenticated** — there is no per-connection token, and the first client
+message is just a name string.
+
+Consequently, any **local process running as the same (or a more privileged)
+user** can, while a port is open, inject or forge framed records — and a forged
+`d` (dill) frame is deserialized via `dill.loads`, an **arbitrary-code-execution
+primitive** in the StorageController process. This is **acceptable for
+single-tenant deployments** (the typical measurement host) but a **real risk on
+shared / multi-tenant hosts**. The wire protocol is intentionally left
+unchanged; hardening (auth token / dropping dill on the wire) is tracked in
+[#1179](https://github.com/openwpm/OpenWPM/issues/1179).
+
 ## Timeout Inventory
 
 | Location | Timeout | Purpose |

--- a/openwpm/browser_manager.py
+++ b/openwpm/browser_manager.py
@@ -29,7 +29,6 @@ from .deploy_browsers import deploy_firefox
 from .errors import (
     BrowserConfigError,
     BrowserCrashError,
-    ConfigError,
     ProfileLoadError,
 )
 from .socket_interface import ClientSocket
@@ -756,7 +755,7 @@ class BrowserManager(Process):
         display = None
 
         if self.browser_params.echo_mode:
-            raise ConfigError(
+            raise BrowserConfigError(
                 "echo_mode is a single-process, test-only socket mode and "
                 "cannot be run through BrowserManager. Use the in-process "
                 "harness in test/test_socket_echo.py, which calls "

--- a/openwpm/browser_manager.py
+++ b/openwpm/browser_manager.py
@@ -26,7 +26,12 @@ from .commands.types import BaseCommand, ShutdownSignal
 from .commands.utils.webdriver_utils import parse_neterror
 from .config import BrowserParamsInternal, ManagerParamsInternal
 from .deploy_browsers import deploy_firefox
-from .errors import BrowserConfigError, BrowserCrashError, ProfileLoadError
+from .errors import (
+    BrowserConfigError,
+    BrowserCrashError,
+    ConfigError,
+    ProfileLoadError,
+)
 from .socket_interface import ClientSocket
 from .storage.storage_providers import TableName
 from .types import BrowserId, VisitId
@@ -749,6 +754,14 @@ class BrowserManager(Process):
     def run_impl(self) -> None:
         assert self.browser_params.browser_id is not None
         display = None
+
+        if self.browser_params.echo_mode:
+            raise ConfigError(
+                "echo_mode is a single-process, test-only socket mode and "
+                "cannot be run through BrowserManager. Use the in-process "
+                "harness in test/test_socket_echo.py, which calls "
+                "deploy_firefox directly."
+            )
 
         try:
             # Start Xvfb (if necessary), webdriver, and browser

--- a/openwpm/config.py
+++ b/openwpm/config.py
@@ -144,6 +144,20 @@ class BrowserParams(DataClassJsonMixin):
     tracking_protection: bool = False
     custom_params: Dict[Any, Any] = field(default_factory=lambda: {})
 
+    echo_mode: bool = False
+    """Test-only, single-process socket-echo mode. When set, the WebExtension
+    skips all instruments and instead emits a fixed set of synthetic payloads
+    over the storage socket to exercise the extension->Python wire protocol end
+    to end (see ``test/test_socket_echo.py``). This field rides ``to_dict()``
+    into ``browser_params.json`` like any other flag; ``deploy_firefox`` needs
+    no change.
+
+    This mode is INCOMPATIBLE with ``BrowserManager``: the single-process test
+    harness calls ``deploy_firefox`` directly and binds the sockets in-process.
+    Running it through the normal multi-process crawl path (``BrowserManager``)
+    is a hard error -- it produces no useful records and there is no
+    StorageController to consume them. Default ``False``."""
+
 
 @dataclass
 class ManagerParams(DataClassJsonMixin):

--- a/openwpm/config.py
+++ b/openwpm/config.py
@@ -263,6 +263,15 @@ def validate_browser_params(browser_params: BrowserParams) -> None:
                 )
             )
 
+        if browser_params.echo_mode:
+            raise ConfigError(
+                "echo_mode is a single-process, test-only socket echo mode "
+                "that makes the WebExtension skip all instruments and emit "
+                "synthetic payloads. It cannot be used with a "
+                "TaskManager/BrowserManager crawl. See test/test_socket_echo.py, "
+                "which drives deploy_firefox directly."
+            )
+
         if browser_params.callstack_instrument:
             raise ConfigError(
                 "The callstacks instrument currently doesn't work "

--- a/openwpm/socket_interface.py
+++ b/openwpm/socket_interface.py
@@ -1,4 +1,5 @@
 import asyncio
+import errno
 import json
 import socket
 import struct
@@ -47,10 +48,26 @@ class ServerSocket:
                 )
                 thread.daemon = True
                 thread.start()
-            except ConnectionAbortedError:
-                # Workaround for #278
-                print("A connection establish request was performed on a closed socket")
-                return
+            except OSError as e:
+                # Only treat genuine teardown of the listening socket as a
+                # normal shutdown. Closing the socket while we are blocked in
+                # accept() surfaces as ConnectionAbortedError (#278) or as
+                # OSError: [Errno 9] Bad file descriptor; both mean the server
+                # is shutting down, so exit the accept loop quietly instead of
+                # letting the daemon thread die with an unhandled exception.
+                #
+                # Any other OSError (e.g. EMFILE/ENFILE — out of file
+                # descriptors, ENOBUFS — out of buffer space) is a transient
+                # accept() failure, NOT a shutdown: swallowing it here would
+                # silently kill the accept loop and drop every subsequent
+                # connection. Re-raise so it is surfaced rather than masked.
+                if isinstance(e, ConnectionAbortedError) or e.errno == errno.EBADF:
+                    print(
+                        "A connection establish request was performed on a "
+                        "closed socket"
+                    )
+                    return
+                raise
 
     def _handle_conn(self, client, address):
         """
@@ -150,6 +167,17 @@ class ClientSocket:
         if self.verbose:
             print("Sending message with serialization %s" % serialization)
 
+        # The length field is a big-endian u32. struct.pack already raises on
+        # overflow (no silent truncation), but guard explicitly so an oversized
+        # record produces a clear, actionable error rather than a raw
+        # struct.error -- and never a desynced stream.
+        if len(msg) > 0xFFFFFFFF:
+            raise RuntimeError(
+                "Message of %d bytes exceeds the u32 length field "
+                "(max %d); refusing to send to avoid framing desync."
+                % (len(msg), 0xFFFFFFFF)
+            )
+
         # prepend with message length
         msg = struct.pack(">Lc", len(msg), serialization) + msg
         totalsent = 0
@@ -185,6 +213,19 @@ async def get_message_from_reader(reader: asyncio.StreamReader) -> Any:
 
 
 def _parse(serialization: bytes, msg: bytes) -> Any:
+    # SECURITY NOTE (single-tenant known issue; tracked in
+    # https://github.com/openwpm/OpenWPM/issues/1179):
+    # The instrumentation sockets are loopback-only, bound to a random
+    # ephemeral port, and NOT reachable from web content or off-host -- but they
+    # are UNAUTHENTICATED. Any local process running as the same (or a more
+    # privileged) user can connect during the window the port is open and inject
+    # or forge framed records. In particular, a forged "d" (dill) frame is
+    # deserialized via dill.loads below, which is full pickle and therefore an
+    # arbitrary-code-execution primitive in the StorageController process.
+    # This is acceptable for single-tenant deployments (the typical OpenWPM
+    # measurement host) but a real risk on shared / multi-tenant hosts. The wire
+    # protocol is intentionally left unchanged here; see the tracked issue for
+    # the auth-token / drop-dill-on-the-wire hardening follow-up.
     if serialization == b"n":
         return msg
     if serialization == b"d":  # dill serialization

--- a/openwpm/socket_interface.py
+++ b/openwpm/socket_interface.py
@@ -62,10 +62,11 @@ class ServerSocket:
                 # silently kill the accept loop and drop every subsequent
                 # connection. Re-raise so it is surfaced rather than masked.
                 if isinstance(e, ConnectionAbortedError) or e.errno == errno.EBADF:
-                    print(
-                        "A connection establish request was performed on a "
-                        "closed socket"
-                    )
+                    if self.verbose:
+                        print(
+                            "A connection establish request was performed on a "
+                            "closed socket"
+                        )
                     return
                 raise
 

--- a/test/test_dataclass_validations.py
+++ b/test/test_dataclass_validations.py
@@ -65,6 +65,17 @@ def test_save_content_type():
     validate_browser_params(browser_params)
 
 
+def test_echo_mode():
+    browser_params = BrowserParams()
+
+    browser_params.echo_mode = True
+    with pytest.raises(ConfigError):
+        validate_browser_params(browser_params)
+
+    browser_params.echo_mode = False
+    validate_browser_params(browser_params)
+
+
 def test_log_file_extension():
     manager_params = ManagerParams()
 

--- a/test/test_socket_echo.py
+++ b/test/test_socket_echo.py
@@ -1,0 +1,115 @@
+"""Single-process, end-to-end test of the extension->Python wire protocol.
+
+This is the real-code counterpart to ``test/test_socket_interface.py`` (which is
+``pyonly`` and re-implements the extension's byte framing in Python). Here we run
+the *actual* privileged ``sockets`` API + ``socket.ts`` + ``socket_interface.py``
+paths that PR #1180 hardened, without standing up a ``BrowserManager`` or a
+``StorageController``.
+
+How it works:
+  * The extension's ``echo_mode`` (a test-only ``BrowserParams`` flag) makes the
+    WebExtension skip every instrument and instead emit a fixed pair of synthetic
+    payloads over its already-connected storage ``SendingSocket``:
+      (A) a ``j`` (JSON) record carrying non-ASCII text, and
+      (B) an ``n`` (raw byte-string) payload.
+  * This test binds two real ``ServerSocket``s in-process (one standing in for the
+    StorageController, one for the logger), launches Firefox via
+    ``deploy_firefox`` directly, and reads the echoed payloads back off the
+    storage server's queue.
+  * It then asserts exact round-trip fidelity: the ``j`` record decodes back to
+    the same Unicode object; the ``n`` frame comes back as raw ``bytes``
+    unchanged. A double-UTF-8-encode regression on the send side (the bug #1180
+    fixed) would turn the non-ASCII content into mojibake and fail (A).
+
+The synthetic payloads are defined in ``Extension/src/echo.ts``; the constants
+below mirror them and are the source of truth for the assertions.
+"""
+
+import json
+
+import pytest
+from multiprocess import Queue
+
+from openwpm.config import BrowserParamsInternal, ManagerParamsInternal
+from openwpm.deploy_browsers import deploy_firefox
+from openwpm.socket_interface import ServerSocket
+from openwpm.types import BrowserId
+
+# Mirrors ``ECHO_J_RECORD`` in Extension/src/echo.ts. The extension escapes each
+# string through ``escapeString`` (UTF-8 bytes as Latin-1 chars), ``JSON.stringify``s
+# it, and sends it with the ``j`` tag; the Python reader decodes the frame as
+# UTF-8 and ``json.loads`` returns exactly this object.
+ECHO_J_RECORD = [
+    "echo",
+    {
+        "s": "你好 — Привет — 🌍",
+        "n": "naïve café λ — 例え",
+    },
+]
+
+# Mirrors ``ECHO_N_TEXT`` in Extension/src/echo.ts. On the wire this is its UTF-8
+# bytes (sent via the ``n`` tag); ``ServerSocket`` returns ``n`` frames as raw
+# ``bytes``, untouched.
+ECHO_N_TEXT = "café/🌍"
+EXPECTED_N_BYTES = ECHO_N_TEXT.encode("utf-8")
+
+
+@pytest.mark.usefixtures("xpi")
+def test_socket_echo_roundtrips_through_real_extension(tmp_path):
+    """The extension serializes both a ``j`` and an ``n`` payload through the real
+    privileged ``sockets`` API; this test reads them back byte-identical."""
+    # Two real Python server sockets -- the same class the live system uses. One
+    # stands in for the StorageController, the other for the logger (the
+    # extension's ``logAggregator`` connects to it; we just drain it).
+    storage_server = ServerSocket(name="echo-storage")
+    storage_server.start_accepting()
+    logger_server = ServerSocket(name="echo-logger")
+    logger_server.start_accepting()
+
+    manager_params = ManagerParamsInternal(num_browsers=1)
+    manager_params.testing = True
+    manager_params.storage_controller_address = storage_server.sock.getsockname()
+    manager_params.logger_address = logger_server.sock.getsockname()
+
+    browser_params = BrowserParamsInternal(
+        display_mode="headless",
+        echo_mode=True,
+        browser_id=BrowserId(0),
+        tmp_profile_dir=tmp_path,
+    )
+
+    status_queue: Queue = Queue()
+    driver = None
+    display = None
+    try:
+        driver, _profile_path, display = deploy_firefox.deploy_firefox(
+            status_queue, browser_params, manager_params, crash_recovery=False
+        )
+
+        # loggingdb.open() sends ``JSON.stringify("Browser-0")`` to the storage
+        # socket first as the client-name handshake; pop it before asserting the
+        # echoed payloads. The real StorageController consumes this the same way.
+        handshake = storage_server.queue.get(timeout=30)
+        assert handshake == "Browser-0"
+
+        # (A) The ``j`` (JSON) record with non-ASCII content. If #1180's
+        # no-double-encode fix regresses, this comes back as mojibake, not equal.
+        received_j = storage_server.queue.get(timeout=30)
+        assert received_j == ECHO_J_RECORD
+        # Sanity-check the non-ASCII content survived intact (round-trips cleanly).
+        assert json.dumps(received_j, ensure_ascii=False) == json.dumps(
+            ECHO_J_RECORD, ensure_ascii=False
+        )
+
+        # (B) The ``n`` (raw byte-string) payload. ServerSocket._parse returns
+        # ``n`` frames as raw ``bytes``, untouched.
+        received_n = storage_server.queue.get(timeout=30)
+        assert isinstance(received_n, bytes)
+        assert received_n == EXPECTED_N_BYTES
+    finally:
+        if driver is not None:
+            driver.quit()
+        if display is not None:
+            display.stop()
+        storage_server.close()
+        logger_server.close()

--- a/test/test_socket_interface.py
+++ b/test/test_socket_interface.py
@@ -1,0 +1,201 @@
+"""Round-trip tests for the instrumentation socket framing.
+
+These are ``pyonly`` tests: they exercise ``openwpm.socket_interface`` directly
+without a browser or extension. The guarantee under test is that non-ASCII
+records survive the length-prefixed framing intact.
+
+Wire contract (important, and easy to get wrong): on the JS -> Python data
+path every payload reaches ``sockets.sendData`` as a *byte-string*, not a
+Unicode string. Callers pre-encode their text through ``escapeString`` /
+``encode_utf8`` (``Extension/src/lib/string-utils.ts``), so the chars handed to
+the socket are already the UTF-8 bytes (each char in 0-255). The privileged
+``api.js`` therefore narrows each char to one byte and frames on that count;
+the Python reader decodes the frame as UTF-8. Re-encoding that byte-string with
+``TextEncoder`` on the send side would double-encode it and corrupt every
+non-ASCII record -- the regression these tests pin down.
+
+The Python ``ClientSocket`` is a separate, genuinely UTF-8-clean path (it
+encodes real ``str`` objects), exercised by the first two tests below.
+"""
+
+import json
+import socket
+import struct
+from typing import Any
+
+import pytest
+
+from openwpm.socket_interface import ClientSocket, ServerSocket
+
+pytestmark = pytest.mark.pyonly
+
+# A record dense with non-Latin-1 codepoints across several scripts plus an
+# astral (surrogate-pair) emoji -- the content a double UTF-8 encode on the
+# send side turns into mojibake.
+NON_ASCII_RECORD = [
+    "http_requests",
+    {
+        "url": "https://例え.テスト/路径?q=Привет&emoji=🌍",
+        "title": "日本語のタイトル — Заголовок — 😀",
+        "cookie": "naïve=café; Ωmega=λ",
+    },
+]
+
+
+def _recv_one(server: ServerSocket) -> Any:
+    """Block until exactly one parsed message lands in the server queue."""
+    return server.queue.get(timeout=10)
+
+
+def _roundtrip_via_client(msg: Any) -> Any:
+    """Send ``msg`` through ClientSocket and return the parsed receipt."""
+    server = ServerSocket()
+    server.start_accepting()
+    try:
+        host, port = server.sock.getsockname()
+        client = ClientSocket(serialization="json")
+        client.connect(host, port)
+        try:
+            client.send(msg)
+            return _recv_one(server)
+        finally:
+            client.close()
+    finally:
+        server.close()
+
+
+def test_non_ascii_json_record_roundtrips_intact() -> None:
+    """A JSON record full of CJK/Cyrillic/emoji must arrive byte-for-byte."""
+    received = _roundtrip_via_client(NON_ASCII_RECORD)
+    assert received == NON_ASCII_RECORD
+
+
+def test_non_ascii_string_roundtrips_via_u_tag() -> None:
+    """Bare str messages use the 'u' (UTF-8) tag; must round-trip intact."""
+    msg = "Browser-日本語-Привет-🌍"
+    received = _roundtrip_via_client(msg)
+    assert received == msg
+
+
+def _extension_wire_bytes(record: Any) -> bytes:
+    """Reproduce the exact bytes the WebExtension puts on the socket.
+
+    This models the real send path, NOT an idealized one. Before any data
+    reaches the socket it is funnelled through ``escapeString`` /
+    ``encode_utf8`` (``Extension/src/lib/string-utils.ts``), the JS idiom
+    ``unescape(encodeURIComponent(s))``. That turns the source text into UTF-8
+    and then exposes each UTF-8 byte as a Latin-1 char (code points 0-255) --
+    i.e. by the time ``JSON.stringify`` runs and ``sockets.sendData`` is
+    called, ``data`` is already a *byte-string*, not a Unicode string. The
+    privileged ``api.js`` then narrows each char to one byte (writing
+    ``charCodeAt(i)`` into a ``Uint8Array``) and frames the length on that byte
+    count. The net result on the wire is plain UTF-8 of the escaped record.
+
+    The Python equivalent of ``unescape(encodeURIComponent(s))`` is
+    ``s.encode("utf-8").decode("latin-1")``; narrowing that byte-string back to
+    bytes via Latin-1 yields the original UTF-8 bytes. We build the JSON the
+    way the extension does (``ensure_ascii`` does not matter because the value
+    strings have already been escaped to ASCII-safe byte-strings), then take
+    the Latin-1 view to get the wire bytes.
+    """
+
+    def escape_string(s: str) -> str:
+        # unescape(encodeURIComponent(s)) -- UTF-8 bytes as Latin-1 chars.
+        return s.encode("utf-8").decode("latin-1")
+
+    def escape_value(value: Any) -> Any:
+        if isinstance(value, str):
+            return escape_string(value)
+        if isinstance(value, list):
+            return [escape_value(v) for v in value]
+        if isinstance(value, dict):
+            return {escape_string(k): escape_value(v) for k, v in value.items()}
+        return value
+
+    escaped = escape_value(record)
+    # The extension stringifies the already-escaped (byte-string) record. Those
+    # strings contain only code points 0-255, so JSON.stringify's output is a
+    # byte-string too; api.js narrows each char to a byte before sending.
+    wire_string = json.dumps(escaped, ensure_ascii=False)
+    return wire_string.encode("latin-1")
+
+
+def test_extension_style_byte_framing_decodes_intact() -> None:
+    """Reproduce the WebExtension's real wire bytes and decode them.
+
+    The extension does NOT UTF-8 re-encode at the socket -- its payloads are
+    already byte-strings (see ``_extension_wire_bytes``). It frames ``>Lc`` on
+    the byte count and writes those raw bytes. This builds those exact bytes
+    with a raw client socket (bypassing ``ClientSocket``) and asserts the
+    Python ``ServerSocket`` decodes them back to the original record. This is
+    the end-to-end guard against the double-encoding regression: a second UTF-8
+    encode on the send side would corrupt every non-ASCII record.
+    """
+    server = ServerSocket()
+    server.start_accepting()
+    try:
+        host, port = server.sock.getsockname()
+        raw = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        raw.connect((host, port))
+        try:
+            payload = _extension_wire_bytes(NON_ASCII_RECORD)
+            # Sanity: the wire payload is plain UTF-8 of the escaped record.
+            # A double-encode (TextEncoder over the byte-string) would make the
+            # payload strictly longer; assert we are sending the lossless form.
+            assert payload == payload.decode("utf-8").encode("utf-8")
+            frame = struct.pack(">Lc", len(payload), b"j") + payload
+            raw.sendall(frame)
+            received = _recv_one(server)
+            assert received == NON_ASCII_RECORD
+        finally:
+            raw.close()
+    finally:
+        server.close()
+
+
+def test_extension_double_encode_would_corrupt() -> None:
+    """Pin the regression: a second UTF-8 encode on the send side is detectable.
+
+    Documents *why* ``api.js`` narrows the byte-string instead of running it
+    through ``TextEncoder``. Re-encoding the already-UTF-8 byte-string produces
+    a strictly different (longer) wire payload that does NOT decode back to the
+    original record -- the mojibake CI caught (你好 -> ä½\\xa0å¥½).
+    """
+    correct = _extension_wire_bytes(NON_ASCII_RECORD)
+    # TextEncoder().encode(byte_string) == byte_string re-encoded as UTF-8.
+    double_encoded = correct.decode("latin-1").encode("utf-8")
+    assert double_encoded != correct
+    assert len(double_encoded) > len(correct)
+    # The double-encoded bytes are still valid UTF-8 / valid JSON, so the
+    # corruption is silent: json.loads succeeds but yields mojibake, never the
+    # original record. This is exactly the failure CI surfaced (你好 turned into
+    # ä½\xa0å¥½). The correct (single-encoded) bytes do round-trip.
+    assert json.loads(correct.decode("utf-8")) == NON_ASCII_RECORD
+    corrupted = json.loads(double_encoded.decode("utf-8"))
+    assert corrupted != NON_ASCII_RECORD
+
+
+def test_send_rejects_oversized_payload() -> None:
+    """Payloads >= 4 GiB must raise, never silently truncate the length field."""
+    server = ServerSocket()
+    server.start_accepting()
+    try:
+        host, port = server.sock.getsockname()
+        client = ClientSocket(serialization="json")
+        client.connect(host, port)
+        try:
+            # Avoid actually allocating 4 GiB: a real bytes object just over
+            # the limit is too costly. Instead use an empty bytes subclass that
+            # overrides __len__ to report an oversized length, so the >u32 guard
+            # in ClientSocket.send (which checks len(msg)) fires without
+            # allocating the payload.
+            class _Huge(bytes):
+                def __len__(self) -> int:
+                    return 0x100000000
+
+            with pytest.raises(RuntimeError, match="exceeds the u32 length"):
+                client.send(_Huge())
+        finally:
+            client.close()
+    finally:
+        server.close()


### PR DESCRIPTION
## Socket: read-side correctness + robustness + security note

Hardens the privileged `sockets` WebExtension experiment and the Python
`socket_interface` — the single channel through which all instrumentation records
flow from the extension to the `StorageController`.

### The wire content is already a byte stream
By the time `sendData` runs, the payload is a **byte-string**: each JS char holds
one raw byte (records are funnelled through `escapeString`/UTF-8 encoding before
transmission). The send path is therefore a faithful **byte pass-through** — each
char is packed into a `Uint8Array` (`charCodeAt`, `ToUint8`/mod 256), the length is
framed on the byte count (== char count here), and the bytes are written via the
binary stream. This matches the prior behavior (`nsIOutputStream.write(string)`
already narrowed each char to a byte) and the Python reader's `msg.decode("utf-8")`;
it is just made explicit and robust. (Running `TextEncoder` over this
already-encoded byte-string would **double-encode** non-ASCII — `你好`'s UTF-8 bytes
would be re-UTF-8'd into mojibake — so the send side deliberately does not re-encode.)

### Fixes
- **Reverse-channel `n`-tag (read side).** The extension's reverse reader
  UTF-8-decoded `n`-tagged frames, but Python defines `n` as **raw bytes**
  (`_parse` returns them unchanged); UTF-8-decoding a binary `n` payload corrupts
  it. The reader now decodes only `j`/`u` as UTF-8 and delivers `n` as raw bytes,
  matching Python. (`u`-tag read parity also added.)
- **u32 length guard.** Reject payloads ≥ 4 GiB (extension + `ClientSocket.send`)
  instead of letting the length prefix silently clamp and desync the stream.
- **Send-failure surfacing.** `SendingSocket.send` now checks the `sendData`
  result and logs a distinct error on a failed framed write — there is no
  reconnect, so a swallowed failure is permanent per-browser data loss.
- **Narrowed shutdown handling.** `ServerSocket._accept` caught **all** `OSError`s
  as normal shutdown, swallowing fd/buffer exhaustion (EMFILE/ENOBUFS); now only
  `ConnectionAbortedError`/`EBADF` are treated as shutdown, others re-raise.

### Security note (documented; protocol unchanged)
The sockets are loopback-only, random-port, and not web-reachable, but
**unauthenticated**, and the `StorageController` deserializes `d`-tagged frames via
`dill.loads` — a same-user local process could inject/forge records or achieve RCE.
Acceptable single-tenant; a risk on multi-tenant hosts. The wire protocol is
intentionally unchanged; hardening tracked in #1179.


### End-to-end coverage: `echo_mode`

The fixes above were previously exercised only by Python tests that *reproduce*
the framing in Python rather than running the real extension `api.js`. This adds
an opt-in **echo mode** that drives the actual extension send path through a real
Firefox into a real `ServerSocket`.

- **`BrowserParams.echo_mode`** (default `False`) threads into `browser_params.json`
  via `to_dict()`. When set, the extension (`feature.ts`) opens its storage socket
  and then **returns before registering any instrument** — a clean bypass that
  emits synthetic records through the real `SendingSocket` send path: a `j` JSON
  record containing non-ASCII and an `n` raw byte-string.
- **Hard-gated to the single-process test path.** `BrowserManager.run_impl()`
  raises `ConfigError` if `echo_mode` is set — it is a test-only mode and must
  never run in a real crawl.
- **`test/test_socket_echo.py`** binds both `ServerSocket`s in-process and launches
  the browser via `deploy_firefox` directly (no `BrowserManager`/`StorageController`
  subprocesses), then asserts the `j` non-ASCII record round-trips to the same value
  and the `n` frame returns as unchanged `bytes` — real coverage of the `j`/`n`
  framing this PR hardens.
