### PR TITLE
chore: gitignore HATER.md review-scratch artifact

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,6 +95,9 @@ node_modules
 
 datadir
 
+# Code-review scratch artifact (transient; never commit)
+HATER.md
+
 # === Crosslink managed (do not edit between markers) ===
 # .crosslink/ — machine-local state (never commit)
 .crosslink/issues.db


### PR DESCRIPTION
HATER.md is a transient code-review scratch file that should never be committed; this prevents it being accidentally snapshotted into a branch (it leaked into one PR already). One-line .gitignore addition.
