### PR TITLE
ci: auto-retry known-flaky tests via pytest-rerunfailures

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -23,6 +23,7 @@ dependencies:
 - pyarrow=24.0.0
 - pytest-asyncio=1.3.0
 - pytest-cov=7.1.0
+- pytest-rerunfailures=16.3
 - pytest=9.0.3
 - python=3.14.4
 - pyvirtualdisplay=3.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ addopts = "--strict-markers"
 markers = [
     "pyonly: marks a test as being python only and so server and xpi not needed",
     "slow: marks a test as slow (omit slow tests with '-m \"not slow\"')",
+    "flaky: known-flaky test auto-retried via pytest-rerunfailures; cite its tracking issue",
 ]
 
 [tool.isort]

--- a/scripts/environment-unpinned-dev.yaml
+++ b/scripts/environment-unpinned-dev.yaml
@@ -8,6 +8,7 @@ dependencies:
     - pip
     - pre-commit
     - pytest
+    - pytest-rerunfailures
     - mypy
     - pytest-asyncio
     - sphinx

--- a/test/test_crawl.py
+++ b/test/test_crawl.py
@@ -43,6 +43,8 @@ TEST_SITES = [
     reason="Makes remote connections",
 )
 @pytest.mark.slow
+# crosslink #16: transient flake, auto-retried instead of red-ing the whole shard
+@pytest.mark.flaky(reruns=4, reruns_delay=5)
 def test_browser_profile_coverage(default_params, task_manager_creator):
     """Test the coverage of the browser's profile.
 

--- a/test/test_extension.py
+++ b/test/test_extension.py
@@ -422,6 +422,8 @@ class ClickButtonCommand(BaseCommand):
     "CI" in os.environ and os.environ["CI"] == "true",
     reason="Flaky on CI",
 )
+# known-flaky: transient flake, auto-retried instead of red-ing the whole shard
+@pytest.mark.flaky(reruns=4, reruns_delay=5)
 def test_audio_fingerprinting(default_params, task_manager_creator):
     for browser_params in default_params[1]:
         browser_params.js_instrument = True

--- a/test/test_http_instrumentation.py
+++ b/test/test_http_instrumentation.py
@@ -1037,6 +1037,8 @@ def test_content_saving(http_params, xpi, server):
         assert v == ldb_content[k]
 
 
+# crosslink #15: transient flake, auto-retried instead of red-ing the whole shard
+@pytest.mark.flaky(reruns=4, reruns_delay=5)
 def test_cache_hits_recorded(http_params, task_manager_creator):
     """Verify all http responses are recorded, including cached responses
 


### PR DESCRIPTION
Closes crosslink #31.

## Problem

`pytest-split` shards mix flaky browser tests with reliable ones, so a single transient flake reds an entire test group and blocks otherwise-green PRs, forcing manual CI re-runs.

## Change

Decorate the known-flaky tests with `@pytest.mark.flaky(reruns=4, reruns_delay=5)` (via `pytest-rerunfailures`) so transient flakes self-heal in place rather than needing a human to re-trigger the job. A test that fails all 5 runs (1 + 4 reruns) is a real failure and still blocks the PR.

- Add `pytest-rerunfailures` to `environment.yaml` (pinned) and `scripts/environment-unpinned-dev.yaml` (unpinned), matching the other `pytest-*` test deps.
- Register the `flaky` marker in `pyproject.toml` (required because `addopts` uses `--strict-markers`).
- Decorate the three known flakies:
  - `test_cache_hits_recorded` (crosslink #15)
  - `test_browser_profile_coverage` (crosslink #16)
  - `test_audio_fingerprinting`

## Verification

- A throwaway test that fails on first run and passes on retry showed `R.` → `1 passed, 1 rerun`, confirming the rerun mechanism works (test then removed).
- `pytest --markers` lists the registered `flaky` marker with no `--strict-markers` error.
- All three decorated tests still collect cleanly.
