### PR TITLE
fix(extension): stop leaking Object.getPropertyDescriptor/getPropertyNames on the page-world Object

### DIFF
--- a/Extension/src/lib/js-instruments.ts
+++ b/Extension/src/lib/js-instruments.ts
@@ -51,19 +51,6 @@ export type SendMessagesToLogger = (
   messages: InstrumentMessage[],
 ) => void;
 
-declare global {
-  interface Object {
-    getPropertyDescriptor(
-      subject: any,
-      name: any,
-    ): PropertyDescriptor | undefined;
-  }
-
-  interface Object {
-    getPropertyNames(subject: any): string[];
-  }
-}
-
 interface CallContext {
   scriptUrl: string;
   scriptLine: string;
@@ -105,9 +92,11 @@ export function getInstrumentJS(
     set_prevented: "set(prevented)",
   };
 
-  // Rough implementations of Object.getPropertyDescriptor and Object.getPropertyNames
+  // Rough implementations of getPropertyDescriptor and getPropertyNames.
   // See http://wiki.ecmascript.org/doku.php?id=harmony:extended_object_api
-  Object.getPropertyDescriptor = function (subject, name) {
+  // These are kept module-local (not assigned onto the page-world `Object`)
+  // so the instrument does not leak detectable globals into the page.
+  function getPropertyDescriptor(subject: any, name: any) {
     if (subject === undefined) {
       throw new Error("Can't get property descriptor for undefined");
     }
@@ -118,9 +107,9 @@ export function getInstrumentJS(
       proto = Object.getPrototypeOf(proto);
     }
     return pd;
-  };
+  }
 
-  Object.getPropertyNames = function (subject) {
+  function getPropertyNames(subject: any) {
     if (subject === undefined) {
       throw new Error("Can't get property names for undefined");
     }
@@ -132,7 +121,7 @@ export function getInstrumentJS(
     }
     // FIXME: remove duplicate property names from props
     return props;
-  };
+  }
 
   // debounce - from Underscore v1.6.0
   function debounce(
@@ -548,7 +537,7 @@ export function getInstrumentJS(
     }
 
     // Store original descriptor in closure
-    const propDesc = Object.getPropertyDescriptor(object, propertyName);
+    const propDesc = getPropertyDescriptor(object, propertyName);
 
     // Property descriptor must exist unless we are instrumenting a nonExisting property
     if (
@@ -741,7 +730,7 @@ export function getInstrumentJS(
     if (logSettings.propertiesToInstrument === null) {
       propertiesToInstrument = [];
     } else if (logSettings.propertiesToInstrument.length === 0) {
-      propertiesToInstrument = Object.getPropertyNames(object);
+      propertiesToInstrument = getPropertyNames(object);
     } else {
       propertiesToInstrument = logSettings.propertiesToInstrument;
     }

--- a/test/test_js_instrument.py
+++ b/test/test_js_instrument.py
@@ -141,6 +141,66 @@ class TestJSInstrumentByPython(OpenWPMJSTest):  # noqa
         )
 
 
+class TestJSInstrumentNoObjectGlobalLeak(OpenWPMJSTest):
+    """The legacy instrument must not assign its getPropertyDescriptor /
+    getPropertyNames helpers as own properties of the page-world ``Object``
+    global (#1187).
+
+    The instrument is injected as a page-world ``<script>``, so anything it
+    assigns onto ``Object`` stays visible to page scripts after the instrument
+    runs. A one-liner like ``typeof Object.getPropertyDescriptor === "function"``
+    then detects OpenWPM even with empty settings -- a config-independent
+    fingerprinting tell named in Krumnow, Jonker & Karsch (arXiv:2205.08890).
+    The fix keeps both helpers as closure-locals inside the injected instrument.
+
+    The test page reads whether either name is an own property of the page-world
+    ``Object`` and encodes the booleans into the arguments of an instrumented
+    ``fetch`` call. Native ``Object`` carries neither helper, so a clean
+    instrument logs ``gpd-false`` / ``gpn-false``; the leaking instrument would
+    log ``gpd-true`` / ``gpn-true``.
+    """
+
+    TEST_PAGE = "instrument_no_object_global_leak.html"
+
+    METHOD_CALLS = {
+        (
+            "window.fetch",
+            "call",
+            '["https://gpd-false.example.com/gpn-false"]',
+        ),
+    }
+    GETS_AND_SETS: Set[Tuple[str, str, str]] = set()
+
+    def get_config(
+        self, data_dir: Optional[Path]
+    ) -> Tuple[ManagerParams, List[BrowserParams]]:
+        manager_params, browser_params = super().get_config(data_dir)
+        browser_params[0].prefs = {
+            "network.dns.localDomains": ("gpd-false.example.com,gpd-true.example.com")
+        }
+        browser_params[0].js_instrument_settings = [
+            {
+                "window": [
+                    "fetch",
+                ]
+            },
+        ]
+        return manager_params, browser_params
+
+    def test_instrument_object(self):
+        """The page-world Object exposes neither helper as an own property."""
+        db = self.visit("/js_instrument/%s" % self.TEST_PAGE)
+        top_url = f"{self.server.base}/js_instrument/{self.TEST_PAGE}"
+        self._check_calls(
+            db=db,
+            symbol_prefix="",
+            doc_url=top_url,
+            top_url=top_url,
+            expected_method_calls=self.METHOD_CALLS,
+            expected_gets_and_sets=self.GETS_AND_SETS,
+        )
+
+
 class TestJSInstrumentMockWindowProperty(OpenWPMJSTest):
     GETS_AND_SETS = {
         ("window.alreadyInstantiatedMockClassInstance", "get", "{}"),

--- a/test/test_pages/js_instrument/instrument_no_object_global_leak.html
+++ b/test/test_pages/js_instrument/instrument_no_object_global_leak.html
@@ -1,0 +1,44 @@
+<!doctype html>
+<html>
+  <head>
+    <title>
+      Test page for JS Instrument - legacy instrument must not leak
+      getPropertyDescriptor / getPropertyNames onto the page-world Object (#1187)
+    </title>
+  </head>
+  <body>
+    <h3>
+      Test that the legacy JavaScript instrument does not assign its
+      <code>getPropertyDescriptor</code> / <code>getPropertyNames</code> helpers
+      as own properties of the page-world <code>Object</code> global. Such
+      assignments are a config-independent fingerprinting tell (Krumnow, Jonker
+      &amp; Karsch, arXiv:2205.08890).
+    </h3>
+    <p>
+      The browser instruments <code>window.fetch</code> (configured python side)
+      so the instrument runs on this page. Native <code>Object</code> carries
+      neither helper, so a clean instrument leaves
+      <code>Object.getOwnPropertyNames(Object)</code> free of both names. We read
+      whether either name is an own property of <code>Object</code> and encode
+      the booleans into the arguments of an instrumented <code>fetch</code> call
+      so they land in the javascript table for the test to assert on.
+    </p>
+    <script type="text/javascript">
+      // Own-property checks on the page-world Object global. Post-fix both are
+      // false (helpers are closure-locals inside the injected instrument);
+      // pre-fix both are true (helpers were assigned onto Object).
+      const own = Object.getOwnPropertyNames(Object);
+      const gpd = own.indexOf("getPropertyDescriptor") !== -1;
+      const gpn = own.indexOf("getPropertyNames") !== -1;
+      // Encode the observed leak state into the fetch URL so it is logged as the
+      // call's argument. localDomains maps these hosts so the request does not
+      // hit the network.
+      const probe = "https://gpd-" + gpd + ".example.com/gpn-" + gpn;
+      try {
+        window.fetch(probe);
+      } catch (e) {
+        console.log("fetch probe threw (ignored): ", e);
+      }
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## The tell

Closes #1187 (quick win).

The legacy JavaScript instrument (`Extension/src/lib/js-instruments.ts`) assigned two non-standard helpers onto the **page-world** `Object` and never removed them:

```js
Object.getPropertyDescriptor = function (subject, name) { ... };
Object.getPropertyNames = function (subject) { ... };
```

Because the instrument is injected via a `<script>` element and runs in the page's principal, these assignments stay visible to page scripts. A one-liner

```js
typeof Object.getPropertyDescriptor === "function"
```

detects OpenWPM instrumentation **even with empty settings** — a config-independent tell, named as a leaked-globals detection vector in Krumnow, Jonker & Karsch (arXiv:2205.08890, §4.1).

## The fix (zero capture cost)

Pure refactor: both helpers are now **module-local functions** inside `getInstrumentJS` instead of being assigned onto the global `Object`, and the two call sites (the property-descriptor lookup and the property-name enumeration) call the locals. The implementations are byte-for-byte unchanged; only their location and how they're referenced changed. The `declare global` augmentation of `Object` is removed accordingly.

No behavior or capture change.

## Verification

- `grep -rn "Object.getPropertyDescriptor\|Object.getPropertyNames" Extension/src` returns only the new module-local definitions — no `Object.X =` assignment and no `Object.X(` call remain.
- The built `content.js` bundle contains no `Object.getProperty* =` assignment while still bundling both helper functions.
- Extension build clean; ESLint reports no issues.
- `test/test_js_instrument.py::TestJSInstrument::test_instrument_object` passes, confirming instrumentation capture is unchanged.

## Follow-up

A browser-side regression test asserting the page-world `Object` no longer carries these properties would need new test-page/harness wiring; left as a follow-up rather than over-building here.
