### PR TITLE
chore(extension): remove dead commented-out referrer capture in http_responses [#1185]

### DIFF
--- a/Extension/src/background/http-instrument.ts
+++ b/Extension/src/background/http-instrument.ts
@@ -648,15 +648,10 @@ export class HttpInstrument {
     const requestMethod = details.method;
     update.method = escapeString(requestMethod);
 
-    // TODO: Refactor to corresponding webext logic or discard
-    // (request headers are not available in http response event listener object,
-    // but the referrer property of the corresponding request could be queried)
-    //
-    // let referrer = "";
-    // if (details.referrer) {
-    //   referrer = details.referrer.spec;
-    // }
-    // update.referrer = escapeString(referrer);
+    // Note: referrer is captured request-side on http_requests (see
+    // onBeforeSendHeadersHandler). It is reachable from an http_responses row
+    // by joining to http_requests on (visit_id, request_id), so it is
+    // intentionally not duplicated onto the response record.
 
     const responseStatus = details.statusCode;
     update.response_status = responseStatus;


### PR DESCRIPTION
## Summary

Removes the dead commented-out referrer-capture block in the `http_responses` handler in `Extension/src/background/http-instrument.ts`.

The block would have written `update.referrer` onto the response record, but the `http_responses` table has no `referrer` column in `schema.sql` (nor in `parquet_schema.py`), so it could never have populated anything.

## Why this is not a data gap

`referrer` is captured request-side on `http_requests` (column `referrer TEXT NOT NULL`), populated from the `Referer` request header in `onBeforeSendHeadersHandler`. Referrer is a property of the request, so that is its natural home. For any response, the referrer is recoverable by joining `http_responses` to `http_requests` on `(visit_id, request_id)` — both tables carry those columns.

The dead block is replaced with a short note documenting where referrer lives, so future readers do not mistake it for a missing capture.

## Verification

- `npm run build` compiles cleanly
- `npm run lint` (ESLint) reports no issues
- No schema change, no behavior change

Closes #1185
