### PR TITLE
fix(js-instrument): don't abort instrumentation when a target fails to resolve (#1171)

### DIFF
--- a/Extension/src/lib/js-instruments.ts
+++ b/Extension/src/lib/js-instruments.ts
@@ -757,11 +757,28 @@ export function getInstrumentJS(eventId: string, sendMessagesToLogger) {
     // More details about how this function is invoked are in
     // content/javascript-instrument-content-scope.ts
     JSInstrumentRequests.forEach(function (item) {
-      instrumentObject(
-        eval(item.object),
-        item.instrumentedName,
-        item.logSettings,
-      );
+      // Resolve the target object. Some configured objects don't exist in
+      // every scope (e.g. Worker-only globals on a window), in which case
+      // eval throws. Catch per-request so one bad target doesn't abort
+      // instrumentation of all subsequent requests (issue #1171).
+      let targetObject;
+      try {
+        targetObject = eval(item.object);
+      } catch (error) {
+        console.warn(
+          `OpenWPM: Could not resolve instrument target '${item.object}', skipping:`,
+          error,
+        );
+        return;
+      }
+      try {
+        instrumentObject(targetObject, item.instrumentedName, item.logSettings);
+      } catch (error) {
+        logErrorToConsole(error, {
+          object: item.object,
+          instrumentedName: item.instrumentedName,
+        });
+      }
     });
   }
 

--- a/test/test_js_instrument.py
+++ b/test/test_js_instrument.py
@@ -394,3 +394,32 @@ class TestJSInstrumentRecursiveProperties(OpenWPMJSTest):
             expected_method_calls=self.METHOD_CALLS,
             expected_gets_and_sets=self.GETS_AND_SETS,
         )
+
+
+class TestJSInstrumentRequestAfterFailingTarget(OpenWPMJSTest):
+    # Regression test for issue #1171: a request whose `object` string fails
+    # to evaluate (e.g. a Worker-only global configured for a window scope)
+    # must not abort instrumentation of subsequent requests. Here the valid
+    # `window.test` object follows a failing target and must still be
+    # instrumented.
+
+    GETS_AND_SETS = {
+        ("window.test.prop1", "get", "default1"),
+    }
+
+    METHOD_CALLS: Set[Tuple[str, str, str]] = set()
+
+    TEST_PAGE = "instrument_request_after_failing_target.html"
+
+    def test_instrument_object(self):
+        """A failing instrument target must not abort subsequent requests."""
+        db = self.visit("/js_instrument/%s" % self.TEST_PAGE)
+        top_url = f"{self.server.base}/js_instrument/{self.TEST_PAGE}"
+        self._check_calls(
+            db=db,
+            symbol_prefix="",
+            doc_url=top_url,
+            top_url=top_url,
+            expected_method_calls=self.METHOD_CALLS,
+            expected_gets_and_sets=self.GETS_AND_SETS,
+        )

--- a/test/test_pages/js_instrument/instrument_request_after_failing_target.html
+++ b/test/test_pages/js_instrument/instrument_request_after_failing_target.html
@@ -1,0 +1,54 @@
+<!doctype html>
+<html>
+  <head>
+    <title>Test page for JS Instrument - request after a failing target (issue #1171)</title>
+  </head>
+  <body>
+    <h3>Test page for JS Instrument - request after a failing target</h3>
+    <p>
+      This page passes a list of instrumentation requests where the first
+      request's `object` string fails to evaluate (it references a global that
+      does not exist, mimicking Worker-only globals configured for a window
+      scope). The subsequent request targets a valid object. A correct
+      implementation must still instrument the valid object even though the
+      earlier request threw.
+      <br />
+      NOTE: The platform config option `manager_params.testing` must be set to
+      True otherwise the instrumentJS method won't be exposed to this test
+      script.
+    </p>
+    <script type="text/javascript" , src="./utils.js"></script>
+    <script type="text/javascript">
+      // A valid object to be instrumented *after* a failing target.
+      window.test = {};
+      window.test.prop1 = "default1";
+
+      function interactWithTestObjects() {
+        // Trigger a get on the property of the valid object.
+        console.log("window.test.prop1", window.test.prop1);
+      }
+
+      console.log("Instrumenting a failing target followed by a valid one!");
+      // `object` values are strings; the real instrumentJS path eval()s them.
+      window.instrumentJS([
+        {
+          // This global does not exist on window -> eval throws.
+          object: "window['DoesNotExistGlobal'].prototype",
+          instrumentedName: "DoesNotExistGlobal",
+          logSettings: getLogSettings({
+            propertiesToInstrument: ["someProp"],
+          }),
+        },
+        {
+          object: "window.test",
+          instrumentedName: "window.test",
+          logSettings: getLogSettings({
+            propertiesToInstrument: ["prop1"],
+          }),
+        },
+      ]);
+
+      interactWithTestObjects();
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary

Fixes #1171.

The legacy JS instrument iterates over all configured instrumentation requests and calls `eval(item.object)` for each one. When a configured object does not exist in the current scope — for example a Worker-only global such as `Client` or `DedicatedWorkerGlobalScope` configured for a window scope — `eval` throws. Because the iteration used a single `forEach` with no per-request error handling, that exception aborted the **entire** loop, so every request after the failing one (including very common targets like `Navigator`) was silently never instrumented.

This is why, as the reporter observed, configuring a large collection (e.g. a fingerprinting collection containing Worker-only globals) resulted in only a handful of APIs actually appearing in the `javascript` table, even though the configured objects were valid per the schema.

## Fix

In `Extension/src/lib/js-instruments.ts`, resolve each request's target object in its own `try`/`catch` and skip only the failing request (logging a warning), and likewise guard the `instrumentObject` call. A single unresolvable or failing target can no longer prevent the rest of the collection from being instrumented.

## Test

Adds `TestJSInstrumentRequestAfterFailingTarget` plus a test page that passes an instrumentation list whose first request's `object` string fails to evaluate, followed by a valid object. The test asserts the valid object is still instrumented.

- Fails on `master` (valid object never instrumented — loop aborted).
- Passes with this change.

Verified locally: FAIL-before / PASS-after, existing JS instrument tests still pass, extension lint/prettier clean, and Python pre-commit (isort/black/mypy) clean.
