### PR TITLE
chore: major JS/TS deps upgrade (babel 8, eslint 10, TypeScript 6)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,13 @@ HATER.md
 #   .claude/settings.json         — Claude Code project settings
 #   .claude/settings.local.json is per-developer, ignore separately if needed
 # === End crosslink managed ===
+
+# Crosslink machine-local runtime state not covered by the managed block above.
+# Mirrors .crosslink/.gitignore so these are never committed from any branch
+# (the inner .gitignore isn't present on every branch in a stacked workflow).
+.crosslink/.active-issue
+.crosslink/.last-hydrated-ref
+.crosslink/.promoted-uuids
+.crosslink/promotion-log.json
+.crosslink/hub-v3-shadow-stats.json
+.crosslink/sentinel.log

--- a/Extension/package-lock.json
+++ b/Extension/package-lock.json
@@ -7,17 +7,17 @@
       "name": "@openwpm/webext-firefox",
       "license": "MPL-2.0",
       "devDependencies": {
-        "@babel/cli": "^7.28.6",
-        "@babel/core": "^7.29.0",
-        "@babel/preset-env": "^7.29.5",
-        "@eslint/js": "^9.0.0",
+        "@babel/cli": "^8.0.1",
+        "@babel/core": "^8.0.1",
+        "@babel/preset-env": "^8.0.1",
+        "@eslint/js": "^10.0.1",
         "@microsoft/eslint-plugin-sdl": "^1.1.0",
         "@types/download": "^8.0.5",
         "@types/firefox-webext-browser": "^143.0.0",
         "ajv": "^8.20.0",
         "body-parser": "^2.3.0",
         "download": "^8.0.0",
-        "eslint": "^9",
+        "eslint": "^10.5.0",
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-html": "^8.1.4",
         "eslint-plugin-import": "^2.32.0",
@@ -25,14 +25,14 @@
         "eslint-plugin-mozilla": "^4.4.0",
         "eslint-plugin-prettier": "^5.5.6",
         "eslint-plugin-promise": "^7.3.0",
-        "eslint-plugin-unicorn": "^64.0.0",
+        "eslint-plugin-unicorn": "^67.0.0",
         "express": "^5.2.1",
         "globals": "^17.6.0",
         "prettier": "^3.8.4",
         "safe-compare": "^1.1.4",
         "ts-loader": "^9.6.1",
         "typedoc": "^0.28.19",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "typescript-eslint": "^8.61.1",
         "web-ext": "^10.4.0",
         "webpack": "^5.107.2",
@@ -43,85 +43,81 @@
       }
     },
     "node_modules/@babel/cli": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.29.7.tgz",
-      "integrity": "sha512-/75HwRbAYPqXv/Ax1h7Fg3IZfXgdU98jnA8H93/m/QBaPV3Hp5ICoLqzGYye1yHBCgpmXvtqgSUN8oOKX5tojQ==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/cli/-/cli-8.0.1.tgz",
+      "integrity": "sha512-cttmeKZGho8XpXNz3nvGMjEnpDW5qkPVGNW2buav2byKxArJnBROsJrLA7CioPQhjzsZ26aZRqg+Gvpk+FHGEg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.28",
-        "commander": "^6.2.0",
+        "commander": "^14.0.2",
         "convert-source-map": "^2.0.0",
-        "fs-readdir-recursive": "^1.1.0",
-        "glob": "^7.2.0",
-        "make-dir": "^2.1.0",
-        "slash": "^2.0.0"
+        "glob": "^13.0.0",
+        "slash": "^5.1.0"
       },
       "bin": {
-        "babel": "bin/babel.js",
-        "babel-external-helpers": "bin/babel-external-helpers.js"
+        "babel": "bin/babel.js"
       },
       "engines": {
-        "node": ">=6.9.0"
+        "node": "^22.18.0 || >=24.11.0"
       },
       "optionalDependencies": {
-        "@nicolo-ribaudo/chokidar-2": "2.1.8-no-fsevents.3",
         "chokidar": "^3.6.0"
       },
       "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
+        "@babel/core": "^8.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
-      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-8.0.0.tgz",
+      "integrity": "sha512-dYYg153EyN2Ekbqw2zAsbd6/JR+9N2SEoC7YV2GyyqMM7x9bLDTjBD6XBhSMLH0wtIVyJj03jWNriQhaN+eoCw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.29.7",
-        "js-tokens": "^4.0.0",
-        "picocolors": "^1.1.1"
+        "@babel/helper-validator-identifier": "^8.0.0",
+        "js-tokens": "^10.0.0"
       },
       "engines": {
-        "node": ">=6.9.0"
+        "node": "^22.18.0 || >=24.11.0"
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
-      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-8.0.0.tgz",
+      "integrity": "sha512-DOjnob/cXOUgDOozCDeq/aK2p5y8dUIVdf6tNhEV1HQRd6I8aQ4f4fbtHRVEvb6lP3BGomrKHiS8ICAASSVQSw==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=6.9.0"
+        "node": "^22.18.0 || >=24.11.0"
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
-      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-8.0.1.tgz",
+      "integrity": "sha512-5FgxM4dLQpMJHSiVATk8foW263dVHQHBVpXYiimNECVWG01f4nFyEbQixeT6Mwvg7TayREJ2gpKl3o2RoMdnqw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.7",
-        "@babel/generator": "^7.29.7",
-        "@babel/helper-compilation-targets": "^7.29.7",
-        "@babel/helper-module-transforms": "^7.29.7",
-        "@babel/helpers": "^7.29.7",
-        "@babel/parser": "^7.29.7",
-        "@babel/template": "^7.29.7",
-        "@babel/traverse": "^7.29.7",
-        "@babel/types": "^7.29.7",
-        "@jridgewell/remapping": "^2.3.5",
+        "@babel/code-frame": "^8.0.0",
+        "@babel/generator": "^8.0.0",
+        "@babel/helper-compilation-targets": "^8.0.0",
+        "@babel/helpers": "^8.0.0",
+        "@babel/parser": "^8.0.0",
+        "@babel/template": "^8.0.0",
+        "@babel/traverse": "^8.0.0",
+        "@babel/types": "^8.0.0",
+        "@types/gensync": "^1.0.5",
         "convert-source-map": "^2.0.0",
-        "debug": "^4.1.0",
+        "empathic": "^2.0.1",
         "gensync": "^1.0.0-beta.2",
+        "import-meta-resolve": "^4.2.0",
         "json5": "^2.2.3",
-        "semver": "^6.3.1"
+        "obug": "^2.1.1",
+        "semver": "^7.7.3"
       },
       "engines": {
-        "node": ">=6.9.0"
+        "node": "^22.18.0 || >=24.11.0"
       },
       "funding": {
         "type": "opencollective",
@@ -129,1416 +125,1346 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
-      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-8.0.0.tgz",
+      "integrity": "sha512-NT9NrVwJsbSV6Y2FSstWa71EETOnzrjkL5/wX3D2mYHtKM+qvqB1DvR4D0Setb/gDBsHzRICifwEWMO8CnTF6g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.29.7",
-        "@babel/types": "^7.29.7",
+        "@babel/parser": "^8.0.0",
+        "@babel/types": "^8.0.0",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
+        "@types/jsesc": "^2.5.0",
         "jsesc": "^3.0.2"
       },
       "engines": {
-        "node": ">=6.9.0"
+        "node": "^22.18.0 || >=24.11.0"
       }
     },
     "node_modules/@babel/helper-annotate-as-pure": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.29.7.tgz",
-      "integrity": "sha512-OoK6239jHPuSQOoS0kfTVKn0b/rVTk0seKq4Gd2UMLtmOVLjDC0ki3e+c90Trqv2gMfvJFqkiljrr568+qddiw==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-8.0.0.tgz",
+      "integrity": "sha512-NSpMkMsvvZqzThJ0p1B02cbtA2ObEyfBvq950bmNkyxsxvcxwhvvCB036rKhlEnuBBo30bOrk13u3FzlKSoRrw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.29.7"
+        "@babel/types": "^8.0.0"
       },
       "engines": {
-        "node": ">=6.9.0"
+        "node": "^22.18.0 || >=24.11.0"
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
-      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-8.0.0.tgz",
+      "integrity": "sha512-JwculLABZvyPvyLBpwU/E/IbH2uM3mnxNtIJpxnIfb24y1PrdVxK5Dqjle4DpgqpGRnwgC7G8IkzPdSXZrO1Ew==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.29.7",
-        "@babel/helper-validator-option": "^7.29.7",
+        "@babel/compat-data": "^8.0.0",
+        "@babel/helper-validator-option": "^8.0.0",
         "browserslist": "^4.24.0",
-        "lru-cache": "^5.1.1",
-        "semver": "^6.3.1"
+        "lru-cache": "^11.0.0",
+        "semver": "^7.7.3"
       },
       "engines": {
-        "node": ">=6.9.0"
+        "node": "^22.18.0 || >=24.11.0"
       }
     },
     "node_modules/@babel/helper-create-class-features-plugin": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.29.7.tgz",
-      "integrity": "sha512-IY3ZD9Tmooqr3TUhc3DUWxiuo8xx1DWLhd5M7hQ+ZWJamqM2BbalrBJb2MisSLoYorOj75U03qULCxQTY9r3hg==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-8.0.1.tgz",
+      "integrity": "sha512-++t3ZktzlLmASAxIlxeXQK9Z2YwUafYGYcvGBFevqOqt16HozVHStUoQvWD09fzAZOb/uJGpUTBuGK41AJAuOA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.29.7",
-        "@babel/helper-member-expression-to-functions": "^7.29.7",
-        "@babel/helper-optimise-call-expression": "^7.29.7",
-        "@babel/helper-replace-supers": "^7.29.7",
-        "@babel/helper-skip-transparent-expression-wrappers": "^7.29.7",
-        "@babel/traverse": "^7.29.7",
-        "semver": "^6.3.1"
+        "@babel/helper-annotate-as-pure": "^8.0.0",
+        "@babel/helper-member-expression-to-functions": "^8.0.0",
+        "@babel/helper-optimise-call-expression": "^8.0.0",
+        "@babel/helper-replace-supers": "^8.0.1",
+        "@babel/helper-skip-transparent-expression-wrappers": "^8.0.0",
+        "@babel/traverse": "^8.0.0",
+        "semver": "^7.7.3"
       },
       "engines": {
-        "node": ">=6.9.0"
+        "node": "^22.18.0 || >=24.11.0"
       },
       "peerDependencies": {
-        "@babel/core": "^7.0.0"
+        "@babel/core": "^8.0.0"
       }
     },
     "node_modules/@babel/helper-create-regexp-features-plugin": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.29.7.tgz",
-      "integrity": "sha512-907Uymvqgg1dwUA+7IGwFAOSYzQOuzPXKNJ1yxzwPffzkYFg2q2eHi1fIOs6sXkG9NbIUMunnUlkYsfRFNvomg==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-8.0.1.tgz",
+      "integrity": "sha512-PydTbcVTiIfVweHMeY1u3MslaD/ZzvnaTNhJp+7ghofelLWshF66Ckc/ZsjStfvRQIKQ4uVG0yEJucyDtyrWgw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.29.7",
+        "@babel/helper-annotate-as-pure": "^8.0.0",
         "regexpu-core": "^6.3.1",
-        "semver": "^6.3.1"
+        "semver": "^7.7.3"
       },
       "engines": {
-        "node": ">=6.9.0"
+        "node": "^22.18.0 || >=24.11.0"
       },
       "peerDependencies": {
-        "@babel/core": "^7.0.0"
+        "@babel/core": "^8.0.0"
       }
     },
     "node_modules/@babel/helper-define-polyfill-provider": {
-      "version": "0.6.8",
-      "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.6.8.tgz",
-      "integrity": "sha512-47UwBLPpQi1NoWzLuHNjRoHlYXMwIJoBf7MFou6viC/sIHWYygpvr0B6IAyh5sBdA2nr2LPIRww8lfaUVQINBA==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-1.0.0.tgz",
+      "integrity": "sha512-9jzVaTeZyXRDKTgUnNzcPQMO8y0ga3o+Z4fKjNet9Fcx7slgKa83qRbz0EwROSd6qO6CoEe/HQszqSPKb5lhkw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-compilation-targets": "^7.28.6",
-        "@babel/helper-plugin-utils": "^7.28.6",
-        "debug": "^4.4.3",
-        "lodash.debounce": "^4.0.8",
-        "resolve": "^1.22.11"
+        "@babel/helper-compilation-targets": "^8.0.0",
+        "@babel/helper-plugin-utils": "^8.0.0",
+        "lodash.debounce": "^4.0.8"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
       },
       "peerDependencies": {
-        "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
+        "@babel/core": "^7.4.0 || ^8.0.0"
       }
     },
     "node_modules/@babel/helper-globals": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
-      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-8.0.0.tgz",
+      "integrity": "sha512-lLozHOM6sWWlxNo8CYqHy4MBZeTvHXNgVPBfPOGsjPKUzHC2Az9QwB6gxdQmpwHl6GlQtbGgS+lj5887guDiLw==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=6.9.0"
+        "node": "^22.18.0 || >=24.11.0"
       }
     },
     "node_modules/@babel/helper-member-expression-to-functions": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.29.7.tgz",
-      "integrity": "sha512-j+7JYmk1JYDtACIGj0QJqqWZjoUpMoEikQGADMaHgCMCSDqd2+P32rfcibUNrGOMWrlzK1WJBdxrB3JJQZwWtg==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-8.0.0.tgz",
+      "integrity": "sha512-xkXrMbtk87Gk7+oKBVmBc6EORg/Qwx++AHESldmHkpvG8wgccdhJJFwrzqlF382Fk8wfXhJHWE/g/43QvEGNPQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.29.7",
-        "@babel/types": "^7.29.7"
+        "@babel/traverse": "^8.0.0",
+        "@babel/types": "^8.0.0"
       },
       "engines": {
-        "node": ">=6.9.0"
+        "node": "^22.18.0 || >=24.11.0"
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
-      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-8.0.0.tgz",
+      "integrity": "sha512-NZ7mSS93o4ndX4KrbD7W8Sf3QT8Qe24PrnFyUcuOPDzK6faqDFKjY9RG7he7+I7FdiQ4llpnosFqzrXa+Vy3Ew==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.29.7",
-        "@babel/types": "^7.29.7"
+        "@babel/traverse": "^8.0.0",
+        "@babel/types": "^8.0.0"
       },
       "engines": {
-        "node": ">=6.9.0"
+        "node": "^22.18.0 || >=24.11.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
-      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-8.0.1.tgz",
+      "integrity": "sha512-UgAhl1kqiW5ciE0yCXqqvnb4H2n3IELJ7lIIQRezwDPilPEZX5i+Rvbja9MFTkwUn2biEiSMeV31aUzR4Lwakw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.29.7",
-        "@babel/helper-validator-identifier": "^7.29.7",
-        "@babel/traverse": "^7.29.7"
+        "@babel/helper-module-imports": "^8.0.0",
+        "@babel/helper-validator-identifier": "^8.0.0",
+        "@babel/traverse": "^8.0.0"
       },
       "engines": {
-        "node": ">=6.9.0"
+        "node": "^22.18.0 || >=24.11.0"
       },
       "peerDependencies": {
-        "@babel/core": "^7.0.0"
+        "@babel/core": "^8.0.0"
       }
     },
     "node_modules/@babel/helper-optimise-call-expression": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.29.7.tgz",
-      "integrity": "sha512-+kmGVjcT9RGYzoDwdwEqEvGgKe3BYq+O1iGzjFubaNgZHwYHP6lsF2Yghf4kEuv9BV7tYDZ913aBW9am6YKong==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-8.0.0.tgz",
+      "integrity": "sha512-3W6satvtPuCUkUx63S2jMoW9EQNYkADgs1HTfufmL7gCmAulHMKupA/12WNz4A0GMMFn/YnWWwqOT9IZrJHQjg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.29.7"
+        "@babel/types": "^8.0.0"
       },
       "engines": {
-        "node": ">=6.9.0"
+        "node": "^22.18.0 || >=24.11.0"
       }
     },
     "node_modules/@babel/helper-plugin-utils": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
-      "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-8.0.1.tgz",
+      "integrity": "sha512-3PKFgjTyPlhFhorfP+SjKQxLViIL++zWjFOO4hGriYU+Bsm983DxEM1JmDRJVWXV0O9npu+xXRqz7Pbd3mh70g==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=6.9.0"
+        "node": "^22.18.0 || >=24.11.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^8.0.0"
       }
     },
     "node_modules/@babel/helper-remap-async-to-generator": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.29.7.tgz",
-      "integrity": "sha512-16AMiW26DbXWBbr3B8wNozKM0ydMLB892vaOaJW/fPJdnT8vJk5sdkQcU/isqUxyCE0cEoa8wZOcbgDuC4b6Og==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-8.0.1.tgz",
+      "integrity": "sha512-baAKuLEMmu6BCSY3tuiU7qglM1qOZt6F1SrFScA241oNqksxkxfEZEKztlGRmoVns9AQ5UgArH7RsUEjxWnzgQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.29.7",
-        "@babel/helper-wrap-function": "^7.29.7",
-        "@babel/traverse": "^7.29.7"
+        "@babel/helper-annotate-as-pure": "^8.0.0",
+        "@babel/helper-wrap-function": "^8.0.0",
+        "@babel/traverse": "^8.0.0"
       },
       "engines": {
-        "node": ">=6.9.0"
+        "node": "^22.18.0 || >=24.11.0"
       },
       "peerDependencies": {
-        "@babel/core": "^7.0.0"
+        "@babel/core": "^8.0.0"
       }
     },
     "node_modules/@babel/helper-replace-supers": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.29.7.tgz",
-      "integrity": "sha512-atfGXWSeCiF4DnKZIfmJfQRkSw9b9gNNXR1kqKjbhG4pGYCOnkp8OcTB8E3NXjBu8NpheSnOeNKz8KT7UNFTmQ==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-8.0.1.tgz",
+      "integrity": "sha512-B1SZADIcy3tmH8CmWvj4SHi/oAPom4UL3uknTc2QRNsPVLFk/sPnZvQL/8kj7Y5omvjMqie0vklvs6XM4OLW5Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-member-expression-to-functions": "^7.29.7",
-        "@babel/helper-optimise-call-expression": "^7.29.7",
-        "@babel/traverse": "^7.29.7"
+        "@babel/helper-member-expression-to-functions": "^8.0.0",
+        "@babel/helper-optimise-call-expression": "^8.0.0",
+        "@babel/traverse": "^8.0.0"
       },
       "engines": {
-        "node": ">=6.9.0"
+        "node": "^22.18.0 || >=24.11.0"
       },
       "peerDependencies": {
-        "@babel/core": "^7.0.0"
+        "@babel/core": "^8.0.0"
       }
     },
     "node_modules/@babel/helper-skip-transparent-expression-wrappers": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.29.7.tgz",
-      "integrity": "sha512-brcMGQaVzIeUb+6/bs1Av0f8YuNNjKY2JyvfRCsFuFsdKccEQ5Ges2y74D74NZ1Rz8lKJ9ksJkfqwQFJ/iNEyQ==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-8.0.0.tgz",
+      "integrity": "sha512-xmCA9kP3IhySsqhzwIdWGlDN/1A4cCKNBO/uwZx/3YzmDoMePwno2Q5/Bq0q+tYaKbeF940YiKV/kaW8Mzvpjw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.29.7",
-        "@babel/types": "^7.29.7"
+        "@babel/traverse": "^8.0.0",
+        "@babel/types": "^8.0.0"
       },
       "engines": {
-        "node": ">=6.9.0"
+        "node": "^22.18.0 || >=24.11.0"
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
-      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-8.0.0.tgz",
+      "integrity": "sha512-6mJgmFFFIIO82vvoLt9XtRC7/TkzXfts1t/SpRX4IHSzMgqoPYCWesVu1udUPUWioAE/2fcG6WuI8zrkE1gwrg==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=6.9.0"
+        "node": "^22.18.0 || >=24.11.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
-      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.0.tgz",
+      "integrity": "sha512-kXxQVZHNOctSJJsqzmcbPSCEkM6oHNnDIkua7g9RCO9xRHj2eCiKvRx2KPdfWR9QxcGWnK/oArrtunmie3rL9g==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=6.9.0"
+        "node": "^22.18.0 || >=24.11.0"
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
-      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-8.0.0.tgz",
+      "integrity": "sha512-U4Dybxh4WESWHt5XhBeExi4DrY0/DNK1aHpQbsrQXCUbFHuMweT0TpLEWKvaraV2Y6fS+ZXunsZ8zIuZIgvF2Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=6.9.0"
+        "node": "^22.18.0 || >=24.11.0"
       }
     },
     "node_modules/@babel/helper-wrap-function": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.29.7.tgz",
-      "integrity": "sha512-iES0Skag9ERIF68aXadpO6dbXa03mNWK3sEqJaMnLNs/eC3l0lkImdfoy6Y09/SfkpawdAB4RjQ7PVA7TcVGdw==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-8.0.0.tgz",
+      "integrity": "sha512-Qpm8+wi5xfDkBfollanwriCcKniFfBmMmaKB01GVM6VGzKXo1fdxosZp04qEr5HM+LKhwr3hG1yRy8+ORsficA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.29.7",
-        "@babel/traverse": "^7.29.7",
-        "@babel/types": "^7.29.7"
+        "@babel/template": "^8.0.0",
+        "@babel/traverse": "^8.0.0",
+        "@babel/types": "^8.0.0"
       },
       "engines": {
-        "node": ">=6.9.0"
+        "node": "^22.18.0 || >=24.11.0"
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
-      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-8.0.0.tgz",
+      "integrity": "sha512-wfbi91pM3py96oIiJEz7qIpyXDytgr9zQC1HEWwlGNVRAEmItuU/0a41ZUKu1sJGyhhOIpc4t5vk4PYzt8wpsg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.29.7",
-        "@babel/types": "^7.29.7"
+        "@babel/template": "^8.0.0",
+        "@babel/types": "^8.0.0"
       },
       "engines": {
-        "node": ">=6.9.0"
+        "node": "^22.18.0 || >=24.11.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
-      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-8.0.0.tgz",
+      "integrity": "sha512-aLxAE+imI9bCcyaPrUDjBv3uSkWieifjLe0kuFOZF0zli0L6GCsTmsePnTr55adbIAgYz2zhN1vnFimCBUYcRQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.29.7"
+        "@babel/types": "^8.0.0"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
       },
       "engines": {
-        "node": ">=6.0.0"
+        "node": "^22.18.0 || >=24.11.0"
       }
     },
     "node_modules/@babel/plugin-bugfix-firefox-class-in-computed-class-key": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-firefox-class-in-computed-class-key/-/plugin-bugfix-firefox-class-in-computed-class-key-7.29.7.tgz",
-      "integrity": "sha512-j8SrR0zLZrRsC09DlszEx8FpMiwukKffYXMK0d5LmOglO7vGG6sz/BR/20yHqWH+Lnn31JTt2PE3hIWNgM2J6w==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-firefox-class-in-computed-class-key/-/plugin-bugfix-firefox-class-in-computed-class-key-8.0.1.tgz",
+      "integrity": "sha512-Ytgjjne4RnG3Oig7ik+NfY4ebRY30BPptVkkyu1f72eINJXRM3/bkU++tIc5aPvyLmo4KH20avq0xJ2o+9aEnw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7",
-        "@babel/traverse": "^7.29.7"
+        "@babel/helper-plugin-utils": "^8.0.1"
       },
       "engines": {
-        "node": ">=6.9.0"
+        "node": "^22.18.0 || >=24.11.0"
       },
       "peerDependencies": {
-        "@babel/core": "^7.0.0"
+        "@babel/core": "^8.0.0"
       }
     },
     "node_modules/@babel/plugin-bugfix-safari-class-field-initializer-scope": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-class-field-initializer-scope/-/plugin-bugfix-safari-class-field-initializer-scope-7.29.7.tgz",
-      "integrity": "sha512-r8j8escF+U2FUHo0KOhPUdMzUO+jp9fInva6+ACVAF3Y97Ev+5iNZwiqTghmzNeWwDkOPlYuTcfb1vDaoZKmAQ==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-class-field-initializer-scope/-/plugin-bugfix-safari-class-field-initializer-scope-8.0.1.tgz",
+      "integrity": "sha512-X7pAMBhuKluA7UfwZNvKN0XVVu/AGeo84Z75eJl85rcb8J2aBzLK92btahM1X5h0oi0QIrbe0qIMA/0+4Buk7w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7"
+        "@babel/helper-plugin-utils": "^8.0.1"
       },
       "engines": {
-        "node": ">=6.9.0"
+        "node": "^22.18.0 || >=24.11.0"
       },
       "peerDependencies": {
-        "@babel/core": "^7.0.0"
+        "@babel/core": "^8.0.0"
       }
     },
     "node_modules/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/-/plugin-bugfix-safari-id-destructuring-collision-in-function-expression-7.29.7.tgz",
-      "integrity": "sha512-GE1TFSiuFeGsCxmYXZl8HwoPrVlwe4rHPFE8weieGKZqnDORK+Ar3vgWMgW+AOxQ6/2TgLSKx9p6W7O4rC6qgQ==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/-/plugin-bugfix-safari-id-destructuring-collision-in-function-expression-8.0.1.tgz",
+      "integrity": "sha512-DJviKTxYfH0hFwnMiW4dnPyMGzS3Hrr4zUfXl1zwQ0QiGlGlNYklLoPSYEQr8S7nau0/K7NdQjTh0qbYuyFjCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7"
+        "@babel/helper-plugin-utils": "^8.0.1"
       },
       "engines": {
-        "node": ">=6.9.0"
+        "node": "^22.18.0 || >=24.11.0"
       },
       "peerDependencies": {
-        "@babel/core": "^7.0.0"
+        "@babel/core": "^8.0.0"
       }
     },
     "node_modules/@babel/plugin-bugfix-safari-rest-destructuring-rhs-array": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-rest-destructuring-rhs-array/-/plugin-bugfix-safari-rest-destructuring-rhs-array-7.29.7.tgz",
-      "integrity": "sha512-oBNVCvnO5tND+xSopWvV8WNGfpTfgP4Zr/YXXSj8zfmcPktp5Ku/aZlsIowgSD4fjmgHn6sGmB9APVsU5zOdhA==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-rest-destructuring-rhs-array/-/plugin-bugfix-safari-rest-destructuring-rhs-array-8.0.1.tgz",
+      "integrity": "sha512-DmR/N+B9+4PbURFj4+zdnWj49/PFAnK2bn8+E4ZAmwn3J5QCxnbG7Ep6aRfz9M8Aw+rBro0kIJQycvzFpl4buQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7",
-        "@babel/helper-skip-transparent-expression-wrappers": "^7.29.7"
+        "@babel/helper-plugin-utils": "^8.0.1",
+        "@babel/helper-skip-transparent-expression-wrappers": "^8.0.0"
       },
       "engines": {
-        "node": ">=6.9.0"
+        "node": "^22.18.0 || >=24.11.0"
       },
       "peerDependencies": {
-        "@babel/core": "^7.0.0"
+        "@babel/core": "^8.0.0"
       }
     },
     "node_modules/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/-/plugin-bugfix-v8-spread-parameters-in-optional-chaining-7.29.7.tgz",
-      "integrity": "sha512-QQt9qKHZ2sg/kivaLr7lnQr8HVrQDdBNSfCsTjiDxRuX/K5ORyKq+Bu8Xr0cDE3Dfkv0cw28Ve0EKyKMvulkOw==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/-/plugin-bugfix-v8-spread-parameters-in-optional-chaining-8.0.1.tgz",
+      "integrity": "sha512-x8bi0LFVD2xkULjfNn+hCMg16yAFHAM9fS/ThSFeYBi+0MP9K6qcY2BZb4urUwC7PYtEy5wPe6TKjOEjXrCGFA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7",
-        "@babel/helper-skip-transparent-expression-wrappers": "^7.29.7",
-        "@babel/plugin-transform-optional-chaining": "^7.29.7"
+        "@babel/helper-plugin-utils": "^8.0.1",
+        "@babel/helper-skip-transparent-expression-wrappers": "^8.0.0",
+        "@babel/plugin-transform-optional-chaining": "^8.0.1"
       },
       "engines": {
-        "node": ">=6.9.0"
+        "node": "^22.18.0 || >=24.11.0"
       },
       "peerDependencies": {
-        "@babel/core": "^7.13.0"
+        "@babel/core": "^8.0.0"
       }
     },
     "node_modules/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly/-/plugin-bugfix-v8-static-class-fields-redefine-readonly-7.29.7.tgz",
-      "integrity": "sha512-pn6QacGLgvCcwc+syUhKE/qSjV2D1IHDB84RNxWYSt1mW3K/SCtjinZ2p0cETJxAWBjPy3K/1lHwG5BjjPxNlw==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly/-/plugin-bugfix-v8-static-class-fields-redefine-readonly-8.0.1.tgz",
+      "integrity": "sha512-P8+RN2n7ts2s1vnE+lXdHYf+dhnmcGSen/kWzBsVluT9Sey5AqmcRXYWlHqgQxaNlKTD5YMa1tf5z4d1v8W88w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7",
-        "@babel/traverse": "^7.29.7"
+        "@babel/helper-plugin-utils": "^8.0.1"
       },
       "engines": {
-        "node": ">=6.9.0"
+        "node": "^22.18.0 || >=24.11.0"
       },
       "peerDependencies": {
-        "@babel/core": "^7.0.0"
-      }
-    },
-    "node_modules/@babel/plugin-proposal-private-property-in-object": {
-      "version": "7.21.0-placeholder-for-preset-env.2",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.0-placeholder-for-preset-env.2.tgz",
-      "integrity": "sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-syntax-import-assertions": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-assertions/-/plugin-syntax-import-assertions-7.29.7.tgz",
-      "integrity": "sha512-/An1OCBN93thpBAGyfsK2pcf0jvju1SAtKkL2Ny++B5Sy6sqgzXDQH1cZxWbF96Wuk+bn41MDA9bLd4VVAw6rw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-syntax-import-attributes": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.29.7.tgz",
-      "integrity": "sha512-zGYcYfq/WmZ4V+kBIXQon9dSSc8ircGZqw9ZaNhhGj9nZkeBu1jHLBDQqYYi5WA9uawvA2sIMbry2nCFhf5Djg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-syntax-unicode-sets-regex": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-unicode-sets-regex/-/plugin-syntax-unicode-sets-regex-7.18.6.tgz",
-      "integrity": "sha512-727YkEAPwSIQTv5im8QHz3upqp92JTWhidIC81Tdx4VJYIte/VndKf1qKrfnnhPLiPghStWfvC/iFaMCQu7Nqg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-create-regexp-features-plugin": "^7.18.6",
-        "@babel/helper-plugin-utils": "^7.18.6"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0"
+        "@babel/core": "^8.0.0"
       }
     },
     "node_modules/@babel/plugin-transform-arrow-functions": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.29.7.tgz",
-      "integrity": "sha512-N7zArUXWzAMzm+/N0uPBeVB3Fam5lMxtUwMmDK5f/IBBS7a7p1qeUoxd/6CckXoxUdgsntq1Dh8xNW06maZbDQ==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-8.0.1.tgz",
+      "integrity": "sha512-o/gr7kRlq3PKLLuYth4udOsrC7geBerti+QtwPeyxMOsEQO1d8kDHqk9r2PtMx2y9i8FG7tzyTerfv1yMLSMsQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7"
+        "@babel/helper-plugin-utils": "^8.0.1"
       },
       "engines": {
-        "node": ">=6.9.0"
+        "node": "^22.18.0 || >=24.11.0"
       },
       "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
+        "@babel/core": "^8.0.0"
       }
     },
     "node_modules/@babel/plugin-transform-async-generator-functions": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.29.7.tgz",
-      "integrity": "sha512-d98gXZkgswvkyohMBABkhm3GeXhYj8psWfwQ2C7gtfrKGTykQa/iOIi+JJhwMjPlZ6Vm2XN+DCf3Es1EoG4ZLA==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-8.0.1.tgz",
+      "integrity": "sha512-kqnSMF1YHBzuiQrl68675i5Ma1oljvo+SJsNEZFZVBu5BUrVIZm9KId3ui2PdtLK2sv2zM8sJnjPDfgLxQlEqQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7",
-        "@babel/helper-remap-async-to-generator": "^7.29.7",
-        "@babel/traverse": "^7.29.7"
+        "@babel/helper-plugin-utils": "^8.0.1",
+        "@babel/helper-remap-async-to-generator": "^8.0.1",
+        "@babel/traverse": "^8.0.0"
       },
       "engines": {
-        "node": ">=6.9.0"
+        "node": "^22.18.0 || >=24.11.0"
       },
       "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
+        "@babel/core": "^8.0.0"
       }
     },
     "node_modules/@babel/plugin-transform-async-to-generator": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.29.7.tgz",
-      "integrity": "sha512-pcUb2SS+RMo9TWVBwKGI5ShtoG7R+zBsFmCKDa6fe8c+hPr3XJlZgoE5j6i8W7gDjhyvy+85vmYexanvXh3d1w==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-8.0.1.tgz",
+      "integrity": "sha512-e1jmmEU4p2Lx64sA1+EF8e8/RxPuegzbXcEbmFp5alDyLE+f2ViUpZ77bRWMXzihTwgVVmn/TOpqDbAuS5g1Ew==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.29.7",
-        "@babel/helper-plugin-utils": "^7.29.7",
-        "@babel/helper-remap-async-to-generator": "^7.29.7"
+        "@babel/helper-module-imports": "^8.0.0",
+        "@babel/helper-plugin-utils": "^8.0.1",
+        "@babel/helper-remap-async-to-generator": "^8.0.1"
       },
       "engines": {
-        "node": ">=6.9.0"
+        "node": "^22.18.0 || >=24.11.0"
       },
       "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
+        "@babel/core": "^8.0.0"
       }
     },
     "node_modules/@babel/plugin-transform-block-scoped-functions": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.29.7.tgz",
-      "integrity": "sha512-cUSmjh72N+rN4PrkFlN1dJwNCwjVp5d38/CQrEsFggkD10UiFlBFgdH3tv5dNsLuHY+3S8db2xCHjhZcv5WgvA==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-8.0.1.tgz",
+      "integrity": "sha512-0V97/gcf7LIgPieEiK1YT0eXa18XJFSLOTZjzEZhA9SJIqZhD/IwGUrCitBzXSmnGCP7hchwC6svHtJ/Eidcpg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7"
+        "@babel/helper-plugin-utils": "^8.0.1"
       },
       "engines": {
-        "node": ">=6.9.0"
+        "node": "^22.18.0 || >=24.11.0"
       },
       "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
+        "@babel/core": "^8.0.0"
       }
     },
     "node_modules/@babel/plugin-transform-block-scoping": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.29.7.tgz",
-      "integrity": "sha512-ONyr4+AZhKh8yKWInVxU9AXA9EbsyeLcL6V0dJy6M2/62vuvpGm29zzuymbTpdc451GEpDIdAyPLP3r+P61yKQ==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-8.0.1.tgz",
+      "integrity": "sha512-HxiQvKsSCs2jOmMhjDrooHaZYOy6W8bqwXp/zjdgPjsNrda6tK9/CH3a/cVIeg6ge3hSS02ALqvqgIo4rTsuSg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7"
+        "@babel/helper-plugin-utils": "^8.0.1"
       },
       "engines": {
-        "node": ">=6.9.0"
+        "node": "^22.18.0 || >=24.11.0"
       },
       "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
+        "@babel/core": "^8.0.0"
       }
     },
     "node_modules/@babel/plugin-transform-class-properties": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-properties/-/plugin-transform-class-properties-7.29.7.tgz",
-      "integrity": "sha512-GtcpjFvanPfzNQi3eTitsCqtRRmmqzpy/A+yhTR1HaZo1Ly3EA8ZXxlPyHdR8/IuRMYc3E4wdGBewB2QKQjAaA==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-properties/-/plugin-transform-class-properties-8.0.1.tgz",
+      "integrity": "sha512-tORnYiVhIHnKj90TgbSZXrO24f9oEpA6MgFxpIDSKKlHv7AzBIRhkMlYevanueLNYaQXqZWarfCgXM4bWTfNiw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-create-class-features-plugin": "^7.29.7",
-        "@babel/helper-plugin-utils": "^7.29.7"
+        "@babel/helper-create-class-features-plugin": "^8.0.1",
+        "@babel/helper-plugin-utils": "^8.0.1"
       },
       "engines": {
-        "node": ">=6.9.0"
+        "node": "^22.18.0 || >=24.11.0"
       },
       "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
+        "@babel/core": "^8.0.0"
       }
     },
     "node_modules/@babel/plugin-transform-class-static-block": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-static-block/-/plugin-transform-class-static-block-7.29.7.tgz",
-      "integrity": "sha512-kibJgmEdX2iMwsHY2tSZNDgj8PwIlCQz7FK9KuGKO8zsuoUwSEhoNnNVp/emKWrbY4HeO6kkXfdMqRKKKXBm2A==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-static-block/-/plugin-transform-class-static-block-8.0.1.tgz",
+      "integrity": "sha512-NEVK+L0Le8h8tJ+IK0CGS5y9Yi1ZHxLj6M5PeanhMFuq9aSo0XI+Wtmbuyop6fTNukOm7ORNntf/kwid891vqQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-create-class-features-plugin": "^7.29.7",
-        "@babel/helper-plugin-utils": "^7.29.7"
+        "@babel/helper-create-class-features-plugin": "^8.0.1",
+        "@babel/helper-plugin-utils": "^8.0.1"
       },
       "engines": {
-        "node": ">=6.9.0"
+        "node": "^22.18.0 || >=24.11.0"
       },
       "peerDependencies": {
-        "@babel/core": "^7.12.0"
+        "@babel/core": "^8.0.0"
       }
     },
     "node_modules/@babel/plugin-transform-classes": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.29.7.tgz",
-      "integrity": "sha512-qV0OGGBVacduzQHE649JyCneOFI/maT+YKsO+K4Yi3xv2wTPNjM/W2o2gdzMwEAZz7fXNTHAe0NcSg30bIN69g==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-8.0.1.tgz",
+      "integrity": "sha512-phwyCES8kIMAdVOFw25ztmgAvkl2G+TvUv7azUYyrlR1Qoo3eLJC/MU3MGUKFZ4BWtsJ1NTJM1lKRLzKbswg7w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.29.7",
-        "@babel/helper-compilation-targets": "^7.29.7",
-        "@babel/helper-globals": "^7.29.7",
-        "@babel/helper-plugin-utils": "^7.29.7",
-        "@babel/helper-replace-supers": "^7.29.7",
-        "@babel/traverse": "^7.29.7"
+        "@babel/helper-annotate-as-pure": "^8.0.0",
+        "@babel/helper-compilation-targets": "^8.0.0",
+        "@babel/helper-globals": "^8.0.0",
+        "@babel/helper-plugin-utils": "^8.0.1",
+        "@babel/helper-replace-supers": "^8.0.1",
+        "@babel/traverse": "^8.0.0"
       },
       "engines": {
-        "node": ">=6.9.0"
+        "node": "^22.18.0 || >=24.11.0"
       },
       "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
+        "@babel/core": "^8.0.0"
       }
     },
     "node_modules/@babel/plugin-transform-computed-properties": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.29.7.tgz",
-      "integrity": "sha512-RK7/IyU5phpuCdBAuig5VkzG/EnbDaui5SQGdU9BFrHdV+mV4cUjLMQ9lJDjLNtWHsqtiefpGZUXQP2BiTYMsA==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-8.0.1.tgz",
+      "integrity": "sha512-i4l3OGLO8DUDcwdnyraOvILbhqdUf4QgfzhVxSOSzRy49XKXrY7pwaSg9gDSKmhZfNPrEMciBSJSciQh/CjB1A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7",
-        "@babel/template": "^7.29.7"
+        "@babel/helper-plugin-utils": "^8.0.1"
       },
       "engines": {
-        "node": ">=6.9.0"
+        "node": "^22.18.0 || >=24.11.0"
       },
       "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
+        "@babel/core": "^8.0.0"
       }
     },
     "node_modules/@babel/plugin-transform-destructuring": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.29.7.tgz",
-      "integrity": "sha512-iPX8aD6H9zV5s7ZsqTdNocPN/MGQ5sSMnElKrktxjJRMnB2jN/1p2+R7GkfD6CAYoVFqy5A4XnSIUeGgJzIWpg==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-8.0.1.tgz",
+      "integrity": "sha512-RtR8uLDl0QcCmqMNIkM8gmDeYZ3rS0ZH+sa+I6sfc09yFoqfp9AEPgBstq9KyfVb0lFCVSRFfJXCI70FIl5ccw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7",
-        "@babel/traverse": "^7.29.7"
+        "@babel/helper-plugin-utils": "^8.0.1"
       },
       "engines": {
-        "node": ">=6.9.0"
+        "node": "^22.18.0 || >=24.11.0"
       },
       "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
+        "@babel/core": "^8.0.0"
       }
     },
     "node_modules/@babel/plugin-transform-dotall-regex": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.29.7.tgz",
-      "integrity": "sha512-3qc18hsD2RdZiyJNDNc7HQpv6xbncwh8FYtxNFFzclSyh/trPD9KkVR9BDECUjDLvb7yJVF15GfYUuC+LMkkiQ==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-8.0.1.tgz",
+      "integrity": "sha512-czOUoSaZljJ92yu+bYlXqb/UBN8K9daNCob/B6/7nthSvfGP6YhCnfqD64XWfyb2dN4ypxALNplApoJrsMd4fw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-create-regexp-features-plugin": "^7.29.7",
-        "@babel/helper-plugin-utils": "^7.29.7"
+        "@babel/helper-create-regexp-features-plugin": "^8.0.1",
+        "@babel/helper-plugin-utils": "^8.0.1"
       },
       "engines": {
-        "node": ">=6.9.0"
+        "node": "^22.18.0 || >=24.11.0"
       },
       "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
+        "@babel/core": "^8.0.0"
       }
     },
     "node_modules/@babel/plugin-transform-duplicate-keys": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.29.7.tgz",
-      "integrity": "sha512-6IvRRriEMqnBwD6chtxdLpMYCHWEzN+oL5cyQtjykya19UgzbmKhxmhZgKC/LHxS2nYr9Q/qYPZ5Lr6jOL9+yQ==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-8.0.1.tgz",
+      "integrity": "sha512-kNnVLkxFUEcTtCyB5PFVQ5Xoy88Bk1lU/ZgDu97CW8eNhRH2Wsiy8Sq5l5dFnwtIUYjzsXHU77jUy1W5AtGSIw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7"
+        "@babel/helper-plugin-utils": "^8.0.1"
       },
       "engines": {
-        "node": ">=6.9.0"
+        "node": "^22.18.0 || >=24.11.0"
       },
       "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
+        "@babel/core": "^8.0.0"
       }
     },
     "node_modules/@babel/plugin-transform-duplicate-named-capturing-groups-regex": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-named-capturing-groups-regex/-/plugin-transform-duplicate-named-capturing-groups-regex-7.29.7.tgz",
-      "integrity": "sha512-2wiIyo2BjtgU7HufSeDnL9L2O7zr8jmhFKuSr65VpRkUiRKRNpb0mdlk56+XPPKoIrfHqzbMuglDvZun0RISsA==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-named-capturing-groups-regex/-/plugin-transform-duplicate-named-capturing-groups-regex-8.0.1.tgz",
+      "integrity": "sha512-Tv43P47o6fuHgBL7HLHQg3WKXohW9CEUGjLtnCDW27yJLK0zKUdTTqREbZbycNHA83hewMjde5tF6ekrHu9bAA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-create-regexp-features-plugin": "^7.29.7",
-        "@babel/helper-plugin-utils": "^7.29.7"
+        "@babel/helper-create-regexp-features-plugin": "^8.0.1",
+        "@babel/helper-plugin-utils": "^8.0.1"
       },
       "engines": {
-        "node": ">=6.9.0"
+        "node": "^22.18.0 || >=24.11.0"
       },
       "peerDependencies": {
-        "@babel/core": "^7.0.0"
+        "@babel/core": "^8.0.0"
       }
     },
     "node_modules/@babel/plugin-transform-dynamic-import": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dynamic-import/-/plugin-transform-dynamic-import-7.29.7.tgz",
-      "integrity": "sha512-giOlEm/EFjfjr+te9NsdjkUo2v4f8rS/SXPumRVHAtbNcyNlvtREkU1dZzaIDclNpnaVhlCqRdFKhJBjBikzLg==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dynamic-import/-/plugin-transform-dynamic-import-8.0.1.tgz",
+      "integrity": "sha512-AS9GlgKc43tJNRu7yOvLaTko4qmdOb+8M69uNS8i421WLO20eVez7LdG5khKdi8E0LIQpYzzzdGIrdXWnO753g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7"
+        "@babel/helper-plugin-utils": "^8.0.1"
       },
       "engines": {
-        "node": ">=6.9.0"
+        "node": "^22.18.0 || >=24.11.0"
       },
       "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
+        "@babel/core": "^8.0.0"
       }
     },
     "node_modules/@babel/plugin-transform-explicit-resource-management": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-explicit-resource-management/-/plugin-transform-explicit-resource-management-7.29.7.tgz",
-      "integrity": "sha512-Rstj7coNz8sE+7Ju7ihpHLI564lsK5pUpNNlvptCIC/16E/S5hbl6n3kESPKdNRmqEWlpn5xpS5Q2dvXBsySLw==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-explicit-resource-management/-/plugin-transform-explicit-resource-management-8.0.1.tgz",
+      "integrity": "sha512-VzDIYwBlLCpV6mJfloRdJm8HmYnMqs7O+bGha8yfg2kP7jAdxeCw6yZBVBeaKKQUThtSU52iy+3lB7DhYsbOBA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7",
-        "@babel/plugin-transform-destructuring": "^7.29.7"
+        "@babel/helper-plugin-utils": "^8.0.1",
+        "@babel/plugin-transform-destructuring": "^8.0.1"
       },
       "engines": {
-        "node": ">=6.9.0"
+        "node": "^22.18.0 || >=24.11.0"
       },
       "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
+        "@babel/core": "^8.0.0"
       }
     },
     "node_modules/@babel/plugin-transform-exponentiation-operator": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.29.7.tgz",
-      "integrity": "sha512-zFpMOTLZBdW5LfObqcSbL6kefg4R4eLdmvS0wbN9M6D5Mym/sKm9toOoWyVOa+xDjvCnuWcHls2YonXwHvH3CQ==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-8.0.1.tgz",
+      "integrity": "sha512-DsZvUUklUmDQ7d2vp+VjqgUWD51mGxhZZ1FPdPP9Hcj0vsgGUKX+zEBGp/vzB1O5PZUxWT/Euq5fu39M9dm9wg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7"
+        "@babel/helper-plugin-utils": "^8.0.1"
       },
       "engines": {
-        "node": ">=6.9.0"
+        "node": "^22.18.0 || >=24.11.0"
       },
       "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
+        "@babel/core": "^8.0.0"
       }
     },
     "node_modules/@babel/plugin-transform-export-namespace-from": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-export-namespace-from/-/plugin-transform-export-namespace-from-7.29.7.tgz",
-      "integrity": "sha512-24B2nOy2TeJSMheqwPD4DDQOV/elLSIlKxjZt4i05H5AgdPdWR3n18HnNrcJ+j76WJd9gbwb9jPjNYUy6RautA==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-export-namespace-from/-/plugin-transform-export-namespace-from-8.0.1.tgz",
+      "integrity": "sha512-bFzznm46bvWGaTYKle3iolbBJ+oPBfUjwCPesxlFE3SQ7DaY9EHf/8Y5ZzrodKJi8JDdcAyaVWaDUSVyhULh0g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7"
+        "@babel/helper-plugin-utils": "^8.0.1"
       },
       "engines": {
-        "node": ">=6.9.0"
+        "node": "^22.18.0 || >=24.11.0"
       },
       "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
+        "@babel/core": "^8.0.0"
       }
     },
     "node_modules/@babel/plugin-transform-for-of": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.29.7.tgz",
-      "integrity": "sha512-zeSIHh0+E1Um1WJRXCFlHQYu2ieJNdivLLjlBEp+dIBu3S51n+SZZmIXjxnItw6pz56Cn+KvK68BIBVsxq2JiQ==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-8.0.1.tgz",
+      "integrity": "sha512-rpeXtgELjpIBQH/+YmyFlD9timPEVCyqY+TNednzoeoTYvXSBEeUvYnYE+BK8rB8m6hHiNK7aL9QWKhGifEJCw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7",
-        "@babel/helper-skip-transparent-expression-wrappers": "^7.29.7"
+        "@babel/helper-plugin-utils": "^8.0.1",
+        "@babel/helper-skip-transparent-expression-wrappers": "^8.0.0"
       },
       "engines": {
-        "node": ">=6.9.0"
+        "node": "^22.18.0 || >=24.11.0"
       },
       "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
+        "@babel/core": "^8.0.0"
       }
     },
     "node_modules/@babel/plugin-transform-function-name": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.29.7.tgz",
-      "integrity": "sha512-otRWaHXE6fbAGkePvaj/kvs3HsqXfPhlnzwSOlnFgbqCPMd975dW+4wZ00WFBt+/YlBGcJwNrARQTOJOb4ZrIg==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-8.0.1.tgz",
+      "integrity": "sha512-H1L/JfPf3CqmubuaiZaquXKQ8MRs4YWSsgRllkTviM8TafcCNnlvc4/fJZ3rXP8HmFM+/Bg+TlsPehUI9BtDFA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-compilation-targets": "^7.29.7",
-        "@babel/helper-plugin-utils": "^7.29.7",
-        "@babel/traverse": "^7.29.7"
+        "@babel/helper-compilation-targets": "^8.0.0",
+        "@babel/helper-plugin-utils": "^8.0.1"
       },
       "engines": {
-        "node": ">=6.9.0"
+        "node": "^22.18.0 || >=24.11.0"
       },
       "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
+        "@babel/core": "^8.0.0"
       }
     },
     "node_modules/@babel/plugin-transform-json-strings": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-json-strings/-/plugin-transform-json-strings-7.29.7.tgz",
-      "integrity": "sha512-RRnE2+eon1rJAq8MnoF1b5kTpY1vU88twHcvcKMrsqP/jxIRqDVs9iJB5fqPuqyeFAW0wJo4MlUIPpQCq/aRsg==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-json-strings/-/plugin-transform-json-strings-8.0.1.tgz",
+      "integrity": "sha512-Mowp8X0J6p7ZehLU82B5e65te2uuSeDHyxrEROwEAS2VKXNXssfw5ZMqhY7k9iXTsOv1Xs/49G3lDCj9Vvw8qQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7"
+        "@babel/helper-plugin-utils": "^8.0.1"
       },
       "engines": {
-        "node": ">=6.9.0"
+        "node": "^22.18.0 || >=24.11.0"
       },
       "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
+        "@babel/core": "^8.0.0"
       }
     },
     "node_modules/@babel/plugin-transform-literals": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.29.7.tgz",
-      "integrity": "sha512-DZ/oLP21ZuWx1vKqnoNv6/tvEK48AQOBRai40CX9dTjGluvT/YZCyY3rryDtyUqCEoyNroy5KKPwX2iQCiRvyw==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-8.0.1.tgz",
+      "integrity": "sha512-ai7kfPRcfyUV1EszXoF1PvL3IuJoCuH08WSEPoRcJTWfZZ55VL/rcfvbVY16QLA3jjbzzSneQSoCtD3L6OyUjw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7"
+        "@babel/helper-plugin-utils": "^8.0.1"
       },
       "engines": {
-        "node": ">=6.9.0"
+        "node": "^22.18.0 || >=24.11.0"
       },
       "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
+        "@babel/core": "^8.0.0"
       }
     },
     "node_modules/@babel/plugin-transform-logical-assignment-operators": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-logical-assignment-operators/-/plugin-transform-logical-assignment-operators-7.29.7.tgz",
-      "integrity": "sha512-A0H91hh6W8MFRkp5TqJmMr39jzGD1A1E1Ysiv2O06Sfbhkapm+XyIzxWCEh5kqwOZ1/8QZ0dY3SeQ7XBqfJd5Q==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-logical-assignment-operators/-/plugin-transform-logical-assignment-operators-8.0.1.tgz",
+      "integrity": "sha512-Emvtr5zkEGyCNAmt+qKD5EUh8G0RbxV9EZWrDdX0LuVy5tBq1B3fOIslvVF9aCJmpnwS/AvAT53b9LxAZyXlng==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7"
+        "@babel/helper-plugin-utils": "^8.0.1"
       },
       "engines": {
-        "node": ">=6.9.0"
+        "node": "^22.18.0 || >=24.11.0"
       },
       "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
+        "@babel/core": "^8.0.0"
       }
     },
     "node_modules/@babel/plugin-transform-member-expression-literals": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.29.7.tgz",
-      "integrity": "sha512-hl1kwFZCCiDyfH25Xmco9jTrkPgnS9pmOzSG7W5I4SaGbLeqKv417hcU2RKmaxoPEgsoJh7ZPOrnPGq99bHoUg==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-8.0.1.tgz",
+      "integrity": "sha512-3Axi9abnyGsm/hh6DsKPZ1Cr9fTtKqS7w0Ig5g12mU269YclpH8pV3xMln2vPLexXgUp6S6L+I06d9/YOLfRKA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7"
+        "@babel/helper-plugin-utils": "^8.0.1"
       },
       "engines": {
-        "node": ">=6.9.0"
+        "node": "^22.18.0 || >=24.11.0"
       },
       "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
+        "@babel/core": "^8.0.0"
       }
     },
     "node_modules/@babel/plugin-transform-modules-amd": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.29.7.tgz",
-      "integrity": "sha512-fxtQoH3m5ywUSIfaH0FGCzWu4McsYon5bD3K4XnskC7f+OyQMj7rsOMi4NvvmJ83WwBAg4UCe+ov4VZlqEvyew==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-8.0.1.tgz",
+      "integrity": "sha512-FDdhET8y1YFDNRuoynqSf23WTzbBBpbIB2oRrlFX7YYm9uWtFvJDSD1r/epBSjfPkOjeaaLgRW9xNnt3JGx46A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-transforms": "^7.29.7",
-        "@babel/helper-plugin-utils": "^7.29.7"
+        "@babel/helper-module-transforms": "^8.0.1",
+        "@babel/helper-plugin-utils": "^8.0.1"
       },
       "engines": {
-        "node": ">=6.9.0"
+        "node": "^22.18.0 || >=24.11.0"
       },
       "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
+        "@babel/core": "^8.0.0"
       }
     },
     "node_modules/@babel/plugin-transform-modules-commonjs": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.29.7.tgz",
-      "integrity": "sha512-j0vCldybPC5b5dwCQOJ21uKtHzt7hxLygJTg9eF1ScfaikEDNfzn94XoW5Fi+seBR0nCyL23xaBFFkq7dTM8XQ==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-8.0.1.tgz",
+      "integrity": "sha512-PMuzulWrrzFNmY3lXSk/tV9NRb7y0eZZLJY4UEo2TKszroxvUZHAPPi+T9FDyrQhod+TQA+t+8/QYaaMpiEuhA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-transforms": "^7.29.7",
-        "@babel/helper-plugin-utils": "^7.29.7"
+        "@babel/helper-module-transforms": "^8.0.1",
+        "@babel/helper-plugin-utils": "^8.0.1"
       },
       "engines": {
-        "node": ">=6.9.0"
+        "node": "^22.18.0 || >=24.11.0"
       },
       "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
+        "@babel/core": "^8.0.0"
       }
     },
     "node_modules/@babel/plugin-transform-modules-systemjs": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.7.tgz",
-      "integrity": "sha512-TM2ZcQLoG2/y4HODiStCo10DibYhWhGWAwVv+EQKmG/7GFl0N+AAmUiXOMKM+aiJ9XBJ9AHVZBvTzMnJ2sM3cQ==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-8.0.1.tgz",
+      "integrity": "sha512-0NEHanXmnFEnfT2dLKTXnu7m8GXFsnxRgteBC2aH21hYMBwAgxu5dcTdi/Eg+ToI1HbZe0CHwz4XRLgRNQhYoQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-transforms": "^7.29.7",
-        "@babel/helper-plugin-utils": "^7.29.7",
-        "@babel/helper-validator-identifier": "^7.29.7",
-        "@babel/traverse": "^7.29.7"
+        "@babel/helper-module-transforms": "^8.0.1",
+        "@babel/helper-plugin-utils": "^8.0.1",
+        "@babel/helper-validator-identifier": "^8.0.0"
       },
       "engines": {
-        "node": ">=6.9.0"
+        "node": "^22.18.0 || >=24.11.0"
       },
       "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
+        "@babel/core": "^8.0.0"
       }
     },
     "node_modules/@babel/plugin-transform-modules-umd": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.29.7.tgz",
-      "integrity": "sha512-B4UkaTK3QpgCwJnrxKfMPKdo92CN7OKXAlpAAnM3UPu0Q0lCCk57ylA9AJbRy2v8dDKOPAAWcoR6CMyeoHwRCA==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-8.0.1.tgz",
+      "integrity": "sha512-XKTa2J2MdkmbVEeChq9f7Or0VYcsF0NyVBgytRyeN9F+J+ETAB2SHhfkG4toz/ssuU0i+h/QgJ6ddo5YakSQcA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-transforms": "^7.29.7",
-        "@babel/helper-plugin-utils": "^7.29.7"
+        "@babel/helper-module-transforms": "^8.0.1",
+        "@babel/helper-plugin-utils": "^8.0.1"
       },
       "engines": {
-        "node": ">=6.9.0"
+        "node": "^22.18.0 || >=24.11.0"
       },
       "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
+        "@babel/core": "^8.0.0"
       }
     },
     "node_modules/@babel/plugin-transform-named-capturing-groups-regex": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.29.7.tgz",
-      "integrity": "sha512-vuFoLwr4qnv2xbZ16SQd6uPcH5FNrLHhk/Jzo++0XJFcaDsr4gjJVg6j398oMHiC+83k/GiBzviwF5KBJkPUtQ==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-8.0.1.tgz",
+      "integrity": "sha512-zCHu+Jr2gTdJE48lN9SV/kXueCW2M79mKtKJc/ttfzzr/jvgdQdCd17RADMqFRQc/25MLxdtjTmlD0HSAMOlIQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-create-regexp-features-plugin": "^7.29.7",
-        "@babel/helper-plugin-utils": "^7.29.7"
+        "@babel/helper-create-regexp-features-plugin": "^8.0.1",
+        "@babel/helper-plugin-utils": "^8.0.1"
       },
       "engines": {
-        "node": ">=6.9.0"
+        "node": "^22.18.0 || >=24.11.0"
       },
       "peerDependencies": {
-        "@babel/core": "^7.0.0"
+        "@babel/core": "^8.0.0"
       }
     },
     "node_modules/@babel/plugin-transform-new-target": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.29.7.tgz",
-      "integrity": "sha512-fEo41GmsOUhOBlw8ioo6zvjX5Xc2Lqkzlyfqbpsk3eB6TReV18uhxZ0esfEokVbY2+PVJAQHNKxER6lGrzNd3A==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-8.0.1.tgz",
+      "integrity": "sha512-QSQxVg1x4PuOuhWUs4Y9u+x9Y+ER8z6G3tC+bDLBzvoOrNLJrEBQLRnwrTP8e5klihAw6Z+e9X5RjdAKcAGapA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7"
+        "@babel/helper-plugin-utils": "^8.0.1"
       },
       "engines": {
-        "node": ">=6.9.0"
+        "node": "^22.18.0 || >=24.11.0"
       },
       "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
+        "@babel/core": "^8.0.0"
       }
     },
     "node_modules/@babel/plugin-transform-nullish-coalescing-operator": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-nullish-coalescing-operator/-/plugin-transform-nullish-coalescing-operator-7.29.7.tgz",
-      "integrity": "sha512-idmp1dFaekP9GbcMvG24Kvw2BfhFZjHnNJCkV4WuIY4PskJzwI3f1N5OdgYke38T7rftO6ERulFRn2cFeZwRkg==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-nullish-coalescing-operator/-/plugin-transform-nullish-coalescing-operator-8.0.1.tgz",
+      "integrity": "sha512-AgCJAmQLF7+PtsK79wJqr4xJ2StHCXlz7JL5CVFP4HejJx25Tk6yl1ZrXvi0cKh3VGDVnfVxefxnrpsBirgpyQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7"
+        "@babel/helper-plugin-utils": "^8.0.1"
       },
       "engines": {
-        "node": ">=6.9.0"
+        "node": "^22.18.0 || >=24.11.0"
       },
       "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
+        "@babel/core": "^8.0.0"
       }
     },
     "node_modules/@babel/plugin-transform-numeric-separator": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-numeric-separator/-/plugin-transform-numeric-separator-7.29.7.tgz",
-      "integrity": "sha512-zR7fv/z14OjgHl4AgRtkDBvBMhIzCxqV/qN/2BCRC7LjFwvuzjYe7gDWxC4Wl/SNsLM6SE1IWvRPYMgSJaUvNw==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-numeric-separator/-/plugin-transform-numeric-separator-8.0.1.tgz",
+      "integrity": "sha512-it2DmUyLIA1GQUXlFDEnI+/G89mTgxndnAiZYpW8xYR6LboblfirMqiWJeTna5uypQJg7viTT4D1iEURRtFcfw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7"
+        "@babel/helper-plugin-utils": "^8.0.1"
       },
       "engines": {
-        "node": ">=6.9.0"
+        "node": "^22.18.0 || >=24.11.0"
       },
       "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
+        "@babel/core": "^8.0.0"
       }
     },
     "node_modules/@babel/plugin-transform-object-rest-spread": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-rest-spread/-/plugin-transform-object-rest-spread-7.29.7.tgz",
-      "integrity": "sha512-Ld98jn4c0smUywL57m7SgsHq3OpThOa6LqZJif3G6jYOovPleoFhVrBJ1WegRApSFB2wu4+RelAj9AC9G08Z4A==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-rest-spread/-/plugin-transform-object-rest-spread-8.0.1.tgz",
+      "integrity": "sha512-VmxkDu6bBdbxRzqn6E93hYucug4OVa6svSO19W//vVzNUGAmQzk3QRyHyyEtfcjSLR3NWfRsWwVM9zExLmd+2w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-compilation-targets": "^7.29.7",
-        "@babel/helper-plugin-utils": "^7.29.7",
-        "@babel/plugin-transform-destructuring": "^7.29.7",
-        "@babel/plugin-transform-parameters": "^7.29.7",
-        "@babel/traverse": "^7.29.7"
+        "@babel/helper-compilation-targets": "^8.0.0",
+        "@babel/helper-plugin-utils": "^8.0.1",
+        "@babel/plugin-transform-destructuring": "^8.0.1",
+        "@babel/plugin-transform-parameters": "^8.0.1"
       },
       "engines": {
-        "node": ">=6.9.0"
+        "node": "^22.18.0 || >=24.11.0"
       },
       "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
+        "@babel/core": "^8.0.0"
       }
     },
     "node_modules/@babel/plugin-transform-object-super": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.29.7.tgz",
-      "integrity": "sha512-Ea/diGcw0twB5IlZPO5sgET6fJsLJqPABqTuFWIR+iMPGPZJkATEIWx0wa+aEQ5UY1CBQyP/gkAiLEqn1vBiQA==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-8.0.1.tgz",
+      "integrity": "sha512-fDkPXRTRKGm25bAq01q82UM4ypPqdVXCwphUUm4t1dL01fGIG0v8KRvT+4BjhMAtRxtPuI34t5Vs7yjRgs3ZgQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7",
-        "@babel/helper-replace-supers": "^7.29.7"
+        "@babel/helper-plugin-utils": "^8.0.1",
+        "@babel/helper-replace-supers": "^8.0.1"
       },
       "engines": {
-        "node": ">=6.9.0"
+        "node": "^22.18.0 || >=24.11.0"
       },
       "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
+        "@babel/core": "^8.0.0"
       }
     },
     "node_modules/@babel/plugin-transform-optional-catch-binding": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-catch-binding/-/plugin-transform-optional-catch-binding-7.29.7.tgz",
-      "integrity": "sha512-sLsyndxK2VwX6yNUOakMb7Sh553ZTe/vVM1XJ+9Z5aW1ytsc8xOIwmyk05NNjN60vkc5/KqoTH6hB4V41LJhng==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-catch-binding/-/plugin-transform-optional-catch-binding-8.0.1.tgz",
+      "integrity": "sha512-b2OQ74uGliyATcasTjxGy2O/86UI/n+EN4juB4EMfEwTi9j9uq70PuP0L8fW77vfRY66gO/YoTo/WbIdQ/Si1g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7"
+        "@babel/helper-plugin-utils": "^8.0.1"
       },
       "engines": {
-        "node": ">=6.9.0"
+        "node": "^22.18.0 || >=24.11.0"
       },
       "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
+        "@babel/core": "^8.0.0"
       }
     },
     "node_modules/@babel/plugin-transform-optional-chaining": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-7.29.7.tgz",
-      "integrity": "sha512-6GM1dhvK3gNODkXcEcMCOLEDCLSoZ/sBbro2Ax8HURyasQ4NshagQixkRFdh5niI6E4gmA/jYI/4aT7rRos3ZQ==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-8.0.1.tgz",
+      "integrity": "sha512-WtRS1c94lZGpGHxYLXMEWeoMVcuv8nkiyr8BTs6OYZv7N3Y9xVE8nbdFIl4lDJH6aH8/pLhqAQOL69d/WI9WdA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7",
-        "@babel/helper-skip-transparent-expression-wrappers": "^7.29.7"
+        "@babel/helper-plugin-utils": "^8.0.1",
+        "@babel/helper-skip-transparent-expression-wrappers": "^8.0.0"
       },
       "engines": {
-        "node": ">=6.9.0"
+        "node": "^22.18.0 || >=24.11.0"
       },
       "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
+        "@babel/core": "^8.0.0"
       }
     },
     "node_modules/@babel/plugin-transform-parameters": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.29.7.tgz",
-      "integrity": "sha512-ZDOBqV/qLYJI0YElr8DcENEyARsFQeESqWXH6gZlghYXuPPjvweuDhP4VyEi4BlUBlLRFZVjxoZDMjxhLW766g==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-8.0.1.tgz",
+      "integrity": "sha512-IIwRqroW0CYQwR6+3pnmu27z+H98poScWdnov8z6osumMeEsFxAFBBsDS2CFk2jFpPlGqVr89jK/HXO6i5DzxQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7"
+        "@babel/helper-plugin-utils": "^8.0.1"
       },
       "engines": {
-        "node": ">=6.9.0"
+        "node": "^22.18.0 || >=24.11.0"
       },
       "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
+        "@babel/core": "^8.0.0"
       }
     },
     "node_modules/@babel/plugin-transform-private-methods": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-methods/-/plugin-transform-private-methods-7.29.7.tgz",
-      "integrity": "sha512-/6Rz4DK1ETDEM/bWHsPHcaEe7ZaT1EqSXjtSP/L0DijOYuaUhiRiOKcwpZ8P7zR4xXEHc2ITdiCgBm9Tpyv9ug==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-methods/-/plugin-transform-private-methods-8.0.1.tgz",
+      "integrity": "sha512-TrFCGcXaVDh6S5IRhmLSRTY9H80VTCMQWnZtzBRg4RWg3KCLmdmsmj4M15kZAPZfoPkWL/SJb4em3Py/vOiX8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-create-class-features-plugin": "^7.29.7",
-        "@babel/helper-plugin-utils": "^7.29.7"
+        "@babel/helper-create-class-features-plugin": "^8.0.1",
+        "@babel/helper-plugin-utils": "^8.0.1"
       },
       "engines": {
-        "node": ">=6.9.0"
+        "node": "^22.18.0 || >=24.11.0"
       },
       "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
+        "@babel/core": "^8.0.0"
       }
     },
     "node_modules/@babel/plugin-transform-private-property-in-object": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-property-in-object/-/plugin-transform-private-property-in-object-7.29.7.tgz",
-      "integrity": "sha512-+BNo06dnrzdNNqCm1X6YUaVv0DKk8Q+JYcoZfOkLhYWNCXzlwTSRq8zGWayT1csjcpNXV9CQTBRRbmTLZac5cA==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-property-in-object/-/plugin-transform-private-property-in-object-8.0.1.tgz",
+      "integrity": "sha512-e+yfOqSYBZaf3PARpiQkjZrpWYgmcFLhK+1tevh2CpHR1O9/36IdyPnAZusESX5nzVV/XZTDAtQBRLa8HPT5Dw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.29.7",
-        "@babel/helper-create-class-features-plugin": "^7.29.7",
-        "@babel/helper-plugin-utils": "^7.29.7"
+        "@babel/helper-annotate-as-pure": "^8.0.0",
+        "@babel/helper-create-class-features-plugin": "^8.0.1",
+        "@babel/helper-plugin-utils": "^8.0.1"
       },
       "engines": {
-        "node": ">=6.9.0"
+        "node": "^22.18.0 || >=24.11.0"
       },
       "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
+        "@babel/core": "^8.0.0"
       }
     },
     "node_modules/@babel/plugin-transform-property-literals": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.29.7.tgz",
-      "integrity": "sha512-bOMRLQuI0A5ZqHq3OWJ89/rXpJ/NJrbVhXiP4zwPGMs6kpcVsuTUNjwoE30K0Qm3mf48a/TnRYYD6vPNqcg6jA==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-8.0.1.tgz",
+      "integrity": "sha512-Z/qx4cxUtYR1nt7XWRutObPxDks98fEYsjWbVeKEqZH6y3AGknmgzCqmHf2FHWZCl1DfoPeuJY+3hZ+35D+2tg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7"
+        "@babel/helper-plugin-utils": "^8.0.1"
       },
       "engines": {
-        "node": ">=6.9.0"
+        "node": "^22.18.0 || >=24.11.0"
       },
       "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
+        "@babel/core": "^8.0.0"
       }
     },
     "node_modules/@babel/plugin-transform-regenerator": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.29.7.tgz",
-      "integrity": "sha512-rNNFV0DBAJp988xW2DOntfDoYn1eR8GGF5AT5vYc+rjyfaQkM242c9tZUHHPe7KYaiJizXPWhQTzzdbXySyhBw==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-8.0.1.tgz",
+      "integrity": "sha512-1WjCi/45Mn5e0uvz26FdvRe6bTAvN6WAtkHgIjl0w/LkBvrv4Y5bDR+8YY72r7cefXBfwYUXIHSoxQkrIfnjXQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7"
+        "@babel/helper-plugin-utils": "^8.0.1"
       },
       "engines": {
-        "node": ">=6.9.0"
+        "node": "^22.18.0 || >=24.11.0"
       },
       "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
+        "@babel/core": "^8.0.0"
       }
     },
     "node_modules/@babel/plugin-transform-regexp-modifiers": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regexp-modifiers/-/plugin-transform-regexp-modifiers-7.29.7.tgz",
-      "integrity": "sha512-mB5Fs0VWrJ42ZCmc8114v60qetdaUVNkj9PmSZRmanCZM3S9hm0CFRLjRmYIsuXav14l2jvZ+4T8iiCGnhj3nQ==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regexp-modifiers/-/plugin-transform-regexp-modifiers-8.0.1.tgz",
+      "integrity": "sha512-02ITRDBesPdTYU0oShAzERwEPzozOUQSXlz3qrt8JGuhalBJQv9z5NjgHJPC9sS3Fsam8gDtfAEpBnqZwUIdjQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-create-regexp-features-plugin": "^7.29.7",
-        "@babel/helper-plugin-utils": "^7.29.7"
+        "@babel/helper-create-regexp-features-plugin": "^8.0.1",
+        "@babel/helper-plugin-utils": "^8.0.1"
       },
       "engines": {
-        "node": ">=6.9.0"
+        "node": "^22.18.0 || >=24.11.0"
       },
       "peerDependencies": {
-        "@babel/core": "^7.0.0"
+        "@babel/core": "^8.0.0"
       }
     },
     "node_modules/@babel/plugin-transform-reserved-words": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.29.7.tgz",
-      "integrity": "sha512-5+YhdpVgmfSmwZyLMftfaiffLRMHjzIRHFHHLdibcSyJm2pasMrKHrO3Ptrt2DRshjvpgjEJJ1zVW14WPq/6QA==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-8.0.1.tgz",
+      "integrity": "sha512-+aykZi7ZP3U84veqfJXm3HhPZGddWFi64g7jr0ni6tb1zel+1ey+SL+IRKPoZXFyFqvYEsoqrmx4PyEJRlHl/Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7"
+        "@babel/helper-plugin-utils": "^8.0.1"
       },
       "engines": {
-        "node": ">=6.9.0"
+        "node": "^22.18.0 || >=24.11.0"
       },
       "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
+        "@babel/core": "^8.0.0"
       }
     },
     "node_modules/@babel/plugin-transform-shorthand-properties": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.29.7.tgz",
-      "integrity": "sha512-I+WYbGBAiCn7nA6xBrlgPH+MB7HWb4u8pv5S0Pv7OtwNvIFvCCb24YlttKEeUFVurfBCEaOTnuhlqsb7f0Z5Dg==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-8.0.1.tgz",
+      "integrity": "sha512-JddANd9yPVH8dYgVoNkqAH5BftnsDxFpG51Zas7sc6F3poz5QWcejHNGO8a/57IX5ByjGSzEmYk9Z7ZMa5MWaw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7"
+        "@babel/helper-plugin-utils": "^8.0.1"
       },
       "engines": {
-        "node": ">=6.9.0"
+        "node": "^22.18.0 || >=24.11.0"
       },
       "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
+        "@babel/core": "^8.0.0"
       }
     },
     "node_modules/@babel/plugin-transform-spread": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.29.7.tgz",
-      "integrity": "sha512-/u5K1QWada7tbYNqTjMh96718g9NTwh9tfPJMsSmVsQwGT447FskV+KcfeXkXq2GWki4EM/MuTdmBec+hOuVTQ==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-8.0.1.tgz",
+      "integrity": "sha512-O9Bw9FyxlSw1SlMg3S82/GKNZ0x77RPbHezotEy1JTlIM/vk6WO8jW1iF+iTiKLOXNvi+b+LZ9t77Gi+Q0FhGg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7",
-        "@babel/helper-skip-transparent-expression-wrappers": "^7.29.7"
+        "@babel/helper-plugin-utils": "^8.0.1",
+        "@babel/helper-skip-transparent-expression-wrappers": "^8.0.0"
       },
       "engines": {
-        "node": ">=6.9.0"
+        "node": "^22.18.0 || >=24.11.0"
       },
       "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
+        "@babel/core": "^8.0.0"
       }
     },
     "node_modules/@babel/plugin-transform-sticky-regex": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.29.7.tgz",
-      "integrity": "sha512-BCHzNYJGe9l7EpwwDBN/ztlL2NYFFq8hp9ddjtUEM9f2O7S7kKV/lL6Fwo7IF7NSkYhPK2vO+86nIGltA90MsA==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-8.0.1.tgz",
+      "integrity": "sha512-IsVP6WrZZQdaG2zLmeKwWiI+ua2NB5L1+f77C2/8z2NCDz7uxlIA/lnwocYOJk9PXcOC2sZgRls3LN4XpNduzQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7"
+        "@babel/helper-plugin-utils": "^8.0.1"
       },
       "engines": {
-        "node": ">=6.9.0"
+        "node": "^22.18.0 || >=24.11.0"
       },
       "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
+        "@babel/core": "^8.0.0"
       }
     },
     "node_modules/@babel/plugin-transform-template-literals": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.29.7.tgz",
-      "integrity": "sha512-NCSEJ4sLFU2gqAub45HYh4fus2yQ36rr6ei6vpU7NdoJqCpxvEG8E6eJpscGyXP3VHD2Ny+fSXr04k1hoUrFqA==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-8.0.1.tgz",
+      "integrity": "sha512-JXvtj5+BJA9Qv3prDzW2z2DkGTJNmG0BObTdUD03STiu1Jr4fNQkQy3hYZgPL46a2RjcuhwBMYf49BOuJ98gnA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7"
+        "@babel/helper-plugin-utils": "^8.0.1"
       },
       "engines": {
-        "node": ">=6.9.0"
+        "node": "^22.18.0 || >=24.11.0"
       },
       "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
+        "@babel/core": "^8.0.0"
       }
     },
     "node_modules/@babel/plugin-transform-typeof-symbol": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.29.7.tgz",
-      "integrity": "sha512-223mNGoTkBiTEWFoK+Q6Go3tueMRclO8vxxxxquNCYuNI4jWOofFKJRRDu6SDrB8Sgo1UEGW9T4GAQ8ZyRso1A==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-8.0.1.tgz",
+      "integrity": "sha512-+wJoxgxP2gtey0UMUOMhzMMji2XHO/Uu6MXUh/r5Yhc2jngKzK/wFxY2WNe4UCaRcMvCb4gcnB8wIgFXJsocXg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7"
+        "@babel/helper-plugin-utils": "^8.0.1"
       },
       "engines": {
-        "node": ">=6.9.0"
+        "node": "^22.18.0 || >=24.11.0"
       },
       "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
+        "@babel/core": "^8.0.0"
       }
     },
     "node_modules/@babel/plugin-transform-unicode-escapes": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.29.7.tgz",
-      "integrity": "sha512-jCfXxSjf94lf4E0hKE0AByxF6F3/pVFqRdUUNkDJhsY0m1ZKjnN6ZYyMeHNpzflxb/0q5b7t3p+BE+SLF1WOtA==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-8.0.1.tgz",
+      "integrity": "sha512-TAXJepIJ6vZphytTwcf+LuXi2M2ZWI43VCqNw+1ZZLPP/38Z1A8j4Mahvg8kqDgMOSM/cakk+hedTJCiw3jQuQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7"
+        "@babel/helper-plugin-utils": "^8.0.1"
       },
       "engines": {
-        "node": ">=6.9.0"
+        "node": "^22.18.0 || >=24.11.0"
       },
       "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
+        "@babel/core": "^8.0.0"
       }
     },
     "node_modules/@babel/plugin-transform-unicode-property-regex": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-property-regex/-/plugin-transform-unicode-property-regex-7.29.7.tgz",
-      "integrity": "sha512-OgZ+zoAJgZLUCunsTRQ5LAjOywDv5zzZ2/hQ5aMw1pGXyY2rtE8/chXYUmu3AlVHKpm10KEdG9aMwbI/K76ZGw==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-property-regex/-/plugin-transform-unicode-property-regex-8.0.1.tgz",
+      "integrity": "sha512-zjBN9tSMSuomNDfurL69Gf7+v4D2t5uI1mSZaYJDo88SKpbduhCXqtxH7Tx66iCF6caWYwnBzSM0tnCozmQq5Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-create-regexp-features-plugin": "^7.29.7",
-        "@babel/helper-plugin-utils": "^7.29.7"
+        "@babel/helper-create-regexp-features-plugin": "^8.0.1",
+        "@babel/helper-plugin-utils": "^8.0.1"
       },
       "engines": {
-        "node": ">=6.9.0"
+        "node": "^22.18.0 || >=24.11.0"
       },
       "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
+        "@babel/core": "^8.0.0"
       }
     },
     "node_modules/@babel/plugin-transform-unicode-regex": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.29.7.tgz",
-      "integrity": "sha512-7D/x/23/d/3VqZ0QA+LGbZMlGwZjztBygSWWWsfTPoQ1oQ6Q1P6Mr3d0kk42XabyUVw+fha3LqdRsFqeKqvCyA==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-8.0.1.tgz",
+      "integrity": "sha512-v0oO83cvT5lwbcIVRShpx4vaHD8AvM9IBowsQuTeP+kGmhh3recJQs33Bl6dlo3/2g9amlznLbFGn4VJbPCJqA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-create-regexp-features-plugin": "^7.29.7",
-        "@babel/helper-plugin-utils": "^7.29.7"
+        "@babel/helper-create-regexp-features-plugin": "^8.0.1",
+        "@babel/helper-plugin-utils": "^8.0.1"
       },
       "engines": {
-        "node": ">=6.9.0"
+        "node": "^22.18.0 || >=24.11.0"
       },
       "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
+        "@babel/core": "^8.0.0"
       }
     },
     "node_modules/@babel/plugin-transform-unicode-sets-regex": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-sets-regex/-/plugin-transform-unicode-sets-regex-7.29.7.tgz",
-      "integrity": "sha512-BLOhLht9DOJwIxlmp91wHvkXv1lguuHS3/FwUO8HL1H0u8s4hR1gASVFyilu9iGtcTRYqjTZmlsFFeQletntEg==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-sets-regex/-/plugin-transform-unicode-sets-regex-8.0.1.tgz",
+      "integrity": "sha512-MlQeyS0K7gh0XNeLBMS/3Z07HjDOKhA7xm2L18GyxOXyiFHI9E+ZuQ4mFYmcLjluXsE/Wf6dABIqZvKpKw0Z3w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-create-regexp-features-plugin": "^7.29.7",
-        "@babel/helper-plugin-utils": "^7.29.7"
+        "@babel/helper-create-regexp-features-plugin": "^8.0.1",
+        "@babel/helper-plugin-utils": "^8.0.1"
       },
       "engines": {
-        "node": ">=6.9.0"
+        "node": "^22.18.0 || >=24.11.0"
       },
       "peerDependencies": {
-        "@babel/core": "^7.0.0"
+        "@babel/core": "^8.0.0"
       }
     },
     "node_modules/@babel/preset-env": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.29.7.tgz",
-      "integrity": "sha512-GYzX36n1nsciIb0uyH0GHwxwtNwPQIcpxSeiVLDtG/B7jB5xXgchnmL1f/jCX5o+pwnaDBtO60ONSJhEBJfxYA==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-8.0.1.tgz",
+      "integrity": "sha512-tiwl69ZQGIbPif28GK8vI/Nm1nYdP+UHXWRnqXl0fjfBS7DWmAs2XvlpVkZyZjVVDxcprcbzCnN93SbuSgz8WQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.29.7",
-        "@babel/helper-compilation-targets": "^7.29.7",
-        "@babel/helper-plugin-utils": "^7.29.7",
-        "@babel/helper-validator-option": "^7.29.7",
-        "@babel/plugin-bugfix-firefox-class-in-computed-class-key": "^7.29.7",
-        "@babel/plugin-bugfix-safari-class-field-initializer-scope": "^7.29.7",
-        "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^7.29.7",
-        "@babel/plugin-bugfix-safari-rest-destructuring-rhs-array": "^7.29.7",
-        "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.29.7",
-        "@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": "^7.29.7",
-        "@babel/plugin-proposal-private-property-in-object": "7.21.0-placeholder-for-preset-env.2",
-        "@babel/plugin-syntax-import-assertions": "^7.29.7",
-        "@babel/plugin-syntax-import-attributes": "^7.29.7",
-        "@babel/plugin-syntax-unicode-sets-regex": "^7.18.6",
-        "@babel/plugin-transform-arrow-functions": "^7.29.7",
-        "@babel/plugin-transform-async-generator-functions": "^7.29.7",
-        "@babel/plugin-transform-async-to-generator": "^7.29.7",
-        "@babel/plugin-transform-block-scoped-functions": "^7.29.7",
-        "@babel/plugin-transform-block-scoping": "^7.29.7",
-        "@babel/plugin-transform-class-properties": "^7.29.7",
-        "@babel/plugin-transform-class-static-block": "^7.29.7",
-        "@babel/plugin-transform-classes": "^7.29.7",
-        "@babel/plugin-transform-computed-properties": "^7.29.7",
-        "@babel/plugin-transform-destructuring": "^7.29.7",
-        "@babel/plugin-transform-dotall-regex": "^7.29.7",
-        "@babel/plugin-transform-duplicate-keys": "^7.29.7",
-        "@babel/plugin-transform-duplicate-named-capturing-groups-regex": "^7.29.7",
-        "@babel/plugin-transform-dynamic-import": "^7.29.7",
-        "@babel/plugin-transform-explicit-resource-management": "^7.29.7",
-        "@babel/plugin-transform-exponentiation-operator": "^7.29.7",
-        "@babel/plugin-transform-export-namespace-from": "^7.29.7",
-        "@babel/plugin-transform-for-of": "^7.29.7",
-        "@babel/plugin-transform-function-name": "^7.29.7",
-        "@babel/plugin-transform-json-strings": "^7.29.7",
-        "@babel/plugin-transform-literals": "^7.29.7",
-        "@babel/plugin-transform-logical-assignment-operators": "^7.29.7",
-        "@babel/plugin-transform-member-expression-literals": "^7.29.7",
-        "@babel/plugin-transform-modules-amd": "^7.29.7",
-        "@babel/plugin-transform-modules-commonjs": "^7.29.7",
-        "@babel/plugin-transform-modules-systemjs": "^7.29.7",
-        "@babel/plugin-transform-modules-umd": "^7.29.7",
-        "@babel/plugin-transform-named-capturing-groups-regex": "^7.29.7",
-        "@babel/plugin-transform-new-target": "^7.29.7",
-        "@babel/plugin-transform-nullish-coalescing-operator": "^7.29.7",
-        "@babel/plugin-transform-numeric-separator": "^7.29.7",
-        "@babel/plugin-transform-object-rest-spread": "^7.29.7",
-        "@babel/plugin-transform-object-super": "^7.29.7",
-        "@babel/plugin-transform-optional-catch-binding": "^7.29.7",
-        "@babel/plugin-transform-optional-chaining": "^7.29.7",
-        "@babel/plugin-transform-parameters": "^7.29.7",
-        "@babel/plugin-transform-private-methods": "^7.29.7",
-        "@babel/plugin-transform-private-property-in-object": "^7.29.7",
-        "@babel/plugin-transform-property-literals": "^7.29.7",
-        "@babel/plugin-transform-regenerator": "^7.29.7",
-        "@babel/plugin-transform-regexp-modifiers": "^7.29.7",
-        "@babel/plugin-transform-reserved-words": "^7.29.7",
-        "@babel/plugin-transform-shorthand-properties": "^7.29.7",
-        "@babel/plugin-transform-spread": "^7.29.7",
-        "@babel/plugin-transform-sticky-regex": "^7.29.7",
-        "@babel/plugin-transform-template-literals": "^7.29.7",
-        "@babel/plugin-transform-typeof-symbol": "^7.29.7",
-        "@babel/plugin-transform-unicode-escapes": "^7.29.7",
-        "@babel/plugin-transform-unicode-property-regex": "^7.29.7",
-        "@babel/plugin-transform-unicode-regex": "^7.29.7",
-        "@babel/plugin-transform-unicode-sets-regex": "^7.29.7",
+        "@babel/compat-data": "^8.0.0",
+        "@babel/helper-compilation-targets": "^8.0.0",
+        "@babel/helper-plugin-utils": "^8.0.1",
+        "@babel/helper-validator-option": "^8.0.0",
+        "@babel/plugin-bugfix-firefox-class-in-computed-class-key": "^8.0.1",
+        "@babel/plugin-bugfix-safari-class-field-initializer-scope": "^8.0.1",
+        "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^8.0.1",
+        "@babel/plugin-bugfix-safari-rest-destructuring-rhs-array": "^8.0.1",
+        "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^8.0.1",
+        "@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": "^8.0.1",
+        "@babel/plugin-transform-arrow-functions": "^8.0.1",
+        "@babel/plugin-transform-async-generator-functions": "^8.0.1",
+        "@babel/plugin-transform-async-to-generator": "^8.0.1",
+        "@babel/plugin-transform-block-scoped-functions": "^8.0.1",
+        "@babel/plugin-transform-block-scoping": "^8.0.1",
+        "@babel/plugin-transform-class-properties": "^8.0.1",
+        "@babel/plugin-transform-class-static-block": "^8.0.1",
+        "@babel/plugin-transform-classes": "^8.0.1",
+        "@babel/plugin-transform-computed-properties": "^8.0.1",
+        "@babel/plugin-transform-destructuring": "^8.0.1",
+        "@babel/plugin-transform-dotall-regex": "^8.0.1",
+        "@babel/plugin-transform-duplicate-keys": "^8.0.1",
+        "@babel/plugin-transform-duplicate-named-capturing-groups-regex": "^8.0.1",
+        "@babel/plugin-transform-dynamic-import": "^8.0.1",
+        "@babel/plugin-transform-explicit-resource-management": "^8.0.1",
+        "@babel/plugin-transform-exponentiation-operator": "^8.0.1",
+        "@babel/plugin-transform-export-namespace-from": "^8.0.1",
+        "@babel/plugin-transform-for-of": "^8.0.1",
+        "@babel/plugin-transform-function-name": "^8.0.1",
+        "@babel/plugin-transform-json-strings": "^8.0.1",
+        "@babel/plugin-transform-literals": "^8.0.1",
+        "@babel/plugin-transform-logical-assignment-operators": "^8.0.1",
+        "@babel/plugin-transform-member-expression-literals": "^8.0.1",
+        "@babel/plugin-transform-modules-amd": "^8.0.1",
+        "@babel/plugin-transform-modules-commonjs": "^8.0.1",
+        "@babel/plugin-transform-modules-systemjs": "^8.0.1",
+        "@babel/plugin-transform-modules-umd": "^8.0.1",
+        "@babel/plugin-transform-named-capturing-groups-regex": "^8.0.1",
+        "@babel/plugin-transform-new-target": "^8.0.1",
+        "@babel/plugin-transform-nullish-coalescing-operator": "^8.0.1",
+        "@babel/plugin-transform-numeric-separator": "^8.0.1",
+        "@babel/plugin-transform-object-rest-spread": "^8.0.1",
+        "@babel/plugin-transform-object-super": "^8.0.1",
+        "@babel/plugin-transform-optional-catch-binding": "^8.0.1",
+        "@babel/plugin-transform-optional-chaining": "^8.0.1",
+        "@babel/plugin-transform-parameters": "^8.0.1",
+        "@babel/plugin-transform-private-methods": "^8.0.1",
+        "@babel/plugin-transform-private-property-in-object": "^8.0.1",
+        "@babel/plugin-transform-property-literals": "^8.0.1",
+        "@babel/plugin-transform-regenerator": "^8.0.1",
+        "@babel/plugin-transform-regexp-modifiers": "^8.0.1",
+        "@babel/plugin-transform-reserved-words": "^8.0.1",
+        "@babel/plugin-transform-shorthand-properties": "^8.0.1",
+        "@babel/plugin-transform-spread": "^8.0.1",
+        "@babel/plugin-transform-sticky-regex": "^8.0.1",
+        "@babel/plugin-transform-template-literals": "^8.0.1",
+        "@babel/plugin-transform-typeof-symbol": "^8.0.1",
+        "@babel/plugin-transform-unicode-escapes": "^8.0.1",
+        "@babel/plugin-transform-unicode-property-regex": "^8.0.1",
+        "@babel/plugin-transform-unicode-regex": "^8.0.1",
+        "@babel/plugin-transform-unicode-sets-regex": "^8.0.1",
         "@babel/preset-modules": "0.1.6-no-external-plugins",
-        "babel-plugin-polyfill-corejs2": "^0.4.15",
-        "babel-plugin-polyfill-corejs3": "^0.14.0",
-        "babel-plugin-polyfill-regenerator": "^0.6.6",
+        "babel-plugin-polyfill-corejs3": "^1.0.0-rc.2",
         "core-js-compat": "^3.48.0",
-        "semver": "^6.3.1"
+        "semver": "^7.7.3"
       },
       "engines": {
-        "node": ">=6.9.0"
+        "node": "^22.18.0 || >=24.11.0"
       },
       "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
+        "@babel/core": "^8.0.0"
       }
     },
     "node_modules/@babel/preset-modules": {
@@ -1556,51 +1482,37 @@
         "@babel/core": "^7.0.0-0 || ^8.0.0-0 <8.0.0"
       }
     },
-    "node_modules/@babel/runtime": {
+    "node_modules/@babel/preset-modules/node_modules/@babel/helper-plugin-utils": {
       "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
-      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
+      "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/template": {
+    "node_modules/@babel/preset-modules/node_modules/@babel/helper-string-parser": {
       "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
-      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.29.7",
-        "@babel/parser": "^7.29.7",
-        "@babel/types": "^7.29.7"
-      },
       "engines": {
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/traverse": {
+    "node_modules/@babel/preset-modules/node_modules/@babel/helper-validator-identifier": {
       "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
-      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.29.7",
-        "@babel/generator": "^7.29.7",
-        "@babel/helper-globals": "^7.29.7",
-        "@babel/parser": "^7.29.7",
-        "@babel/template": "^7.29.7",
-        "@babel/types": "^7.29.7",
-        "debug": "^4.3.1"
-      },
       "engines": {
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/types": {
+    "node_modules/@babel/preset-modules/node_modules/@babel/types": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
       "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
@@ -1612,6 +1524,64 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-8.0.0.tgz",
+      "integrity": "sha512-eAD0QW/AlbamBbw0FeGiwasbCVPq5ncW0HNVyLP3B9czqLyh4gvw+5JTSNt6le9+ziAU7mqDZsKTHf3jTb4chQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^8.0.0",
+        "@babel/parser": "^8.0.0",
+        "@babel/types": "^8.0.0"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-8.0.0.tgz",
+      "integrity": "sha512-bxTj/W2VclGE6CctlfQOpxg8MPDzXArRqkOBePw8EHfebcjF7fETWSS3BriEECo+UiU/Yblq+xUtSImFu7cTbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^8.0.0",
+        "@babel/generator": "^8.0.0",
+        "@babel/helper-globals": "^8.0.0",
+        "@babel/parser": "^8.0.0",
+        "@babel/template": "^8.0.0",
+        "@babel/types": "^8.0.0",
+        "obug": "^2.1.1"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-8.0.0.tgz",
+      "integrity": "sha512-K8ponJDxBwDHigkeFqaqT5wLGl4bTlwMafR8k7b5CPxr6Ww+UG9ls8Yx6Tcpboxu97eeGVEEyKcHmEyOwN1vSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^8.0.0",
+        "@babel/helper-validator-identifier": "^8.0.0"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
       }
     },
     "node_modules/@devicefarmer/adbkit": {
@@ -1764,44 +1734,44 @@
       }
     },
     "node_modules/@eslint/config-array": {
-      "version": "0.21.2",
-      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
-      "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
+      "version": "0.23.5",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.5.tgz",
+      "integrity": "sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/object-schema": "^2.1.7",
+        "@eslint/object-schema": "^3.0.5",
         "debug": "^4.3.1",
-        "minimatch": "^3.1.5"
+        "minimatch": "^10.2.4"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
     "node_modules/@eslint/config-helpers": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
-      "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.6.0.tgz",
+      "integrity": "sha512-ii6Bw9jJ2zi2cWA2Z+9/QZ/+3DX6kwaV5Q986D/CdP3Lap3w/pgQZ373FV7byY/i7L4IRH/G43I5dz1ClsCbpA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/core": "^0.17.0"
+        "@eslint/core": "^1.2.1"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
     "node_modules/@eslint/core": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
-      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.2.1.tgz",
+      "integrity": "sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@types/json-schema": "^7.0.15"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
     "node_modules/@eslint/eslintrc": {
@@ -1845,6 +1815,55 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/@eslint/eslintrc/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/espree": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
     "node_modules/@eslint/eslintrc/node_modules/globals": {
       "version": "14.0.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
@@ -1865,41 +1884,75 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@eslint/js": {
-      "version": "9.39.4",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
-      "integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
+    "node_modules/@eslint/eslintrc/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-10.0.1.tgz",
+      "integrity": "sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       },
       "funding": {
         "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "eslint": "^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": true
+        }
       }
     },
     "node_modules/@eslint/object-schema": {
-      "version": "2.1.7",
-      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
-      "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.5.tgz",
+      "integrity": "sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
-      "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.2.tgz",
+      "integrity": "sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/core": "^0.17.0",
+        "@eslint/core": "^1.2.1",
         "levn": "^0.4.1"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
     "node_modules/@fluent/syntax": {
@@ -2014,17 +2067,6 @@
         "@jridgewell/trace-mapping": "^0.3.24"
       }
     },
-    "node_modules/@jridgewell/remapping": {
-      "version": "2.3.5",
-      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
-      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/gen-mapping": "^0.3.5",
-        "@jridgewell/trace-mapping": "^0.3.24"
-      }
-    },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
@@ -2088,14 +2130,6 @@
       "peerDependencies": {
         "eslint": "^9"
       }
-    },
-    "node_modules/@nicolo-ribaudo/chokidar-2": {
-      "version": "2.1.8-no-fsevents.3",
-      "resolved": "https://registry.npmjs.org/@nicolo-ribaudo/chokidar-2/-/chokidar-2-2.1.8-no-fsevents.3.tgz",
-      "integrity": "sha512-s88O1aVtXftvp5bCPB7WnmXc5IwOZZ7YPuwNPt+GtOOXpPvad1LfbmjYv+qII7zP6RU2QGnqve27dnLycEnyEQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
     },
     "node_modules/@pinojs/redact": {
       "version": "0.4.0",
@@ -2263,6 +2297,13 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/esrecurse": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
+      "integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
@@ -2274,6 +2315,13 @@
       "version": "143.0.0",
       "resolved": "https://registry.npmjs.org/@types/firefox-webext-browser/-/firefox-webext-browser-143.0.0.tgz",
       "integrity": "sha512-865dYKMOP0CllFyHmgXV4IQgVL51OSQQCwSoihQ17EwugePKFSAZRc0EI+y7Ly4q7j5KyURlA7LgRpFieO4JOw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/gensync": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/gensync/-/gensync-1.0.5.tgz",
+      "integrity": "sha512-MbsRCT7mTikHwKZ0X+LVUTLRrZZRLipTuXEO9qOYO+zmjMVk81axyClMROf6uoPD9MRVu46bx8zoR0Ad9q3NAg==",
       "dev": true,
       "license": "MIT"
     },
@@ -2298,6 +2346,13 @@
       "dependencies": {
         "@types/unist": "*"
       }
+    },
+    "node_modules/@types/jsesc": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@types/jsesc/-/jsesc-2.5.1.tgz",
+      "integrity": "sha512-9VN+6yxLOPLOav+7PwjZbxiID2bVaeq0ED4qSQmdQTdjnXJSaCVKTR58t15oqH1H5t8Ng2ZX1SabJVoN9Q34bw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
@@ -2532,58 +2587,6 @@
         "typescript": ">=4.8.4 <6.1.0"
       }
     },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-      "version": "10.2.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
-      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "brace-expansion": "^5.0.5"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
-      "version": "7.8.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
-      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@typescript-eslint/utils": {
       "version": "8.61.1",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.61.1.tgz",
@@ -2624,19 +2627,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
-      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/@webassemblyjs/ast": {
@@ -2903,35 +2893,258 @@
         "node": ">=20.0.0"
       }
     },
-    "node_modules/addons-linter/node_modules/eslint-visitor-keys": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
-      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+    "node_modules/addons-linter/node_modules/@eslint/config-array": {
+      "version": "0.21.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
+      "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^2.1.7",
+        "debug": "^4.3.1",
+        "minimatch": "^3.1.5"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/addons-linter/node_modules/@eslint/config-helpers": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
+      "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/addons-linter/node_modules/@eslint/core": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
+      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/addons-linter/node_modules/@eslint/js": {
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
+      "integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      }
+    },
+    "node_modules/addons-linter/node_modules/@eslint/object-schema": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
+      "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/addons-linter/node_modules/@eslint/plugin-kit": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
+      "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/addons-linter/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/addons-linter/node_modules/brace-expansion": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/addons-linter/node_modules/eslint": {
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
+      "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.1",
+        "@eslint/config-array": "^0.21.2",
+        "@eslint/config-helpers": "^0.4.2",
+        "@eslint/core": "^0.17.0",
+        "@eslint/eslintrc": "^3.3.5",
+        "@eslint/js": "9.39.4",
+        "@eslint/plugin-kit": "^0.4.1",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.14.0",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^8.4.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
+        "esquery": "^1.5.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.5",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/addons-linter/node_modules/eslint-scope": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/addons-linter/node_modules/espree": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
-      "integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
+    "node_modules/addons-linter/node_modules/eslint/node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
-      "license": "BSD-2-Clause",
+      "license": "MIT",
       "dependencies": {
-        "acorn": "^8.16.0",
-        "acorn-jsx": "^5.3.2",
-        "eslint-visitor-keys": "^5.0.1"
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
       },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/addons-linter/node_modules/eslint/node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
       "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/addons-linter/node_modules/eslint/node_modules/espree": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/addons-linter/node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/addons-linter/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/addons-linter/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/addons-linter/node_modules/semver": {
@@ -3436,54 +3649,32 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/babel-plugin-polyfill-corejs2": {
-      "version": "0.4.17",
-      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.17.tgz",
-      "integrity": "sha512-aTyf30K/rqAsNwN76zYrdtx8obu0E4KoUME29B1xj+B3WxgvWkp943vYQ+z8Mv3lw9xHXMHpvSPOBxzAkIa94w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/compat-data": "^7.28.6",
-        "@babel/helper-define-polyfill-provider": "^0.6.8",
-        "semver": "^6.3.1"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
-      }
-    },
     "node_modules/babel-plugin-polyfill-corejs3": {
-      "version": "0.14.2",
-      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.14.2.tgz",
-      "integrity": "sha512-coWpDLJ410R781Npmn/SIBZEsAetR4xVi0SxLMXPaMO4lSf1MwnkGYMtkFxew0Dn8B3/CpbpYxN0JCgg8mn67g==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-1.0.0.tgz",
+      "integrity": "sha512-yIkslVjbmml2Xjb6XhFW7lISXHsqk6cesxTdDsXoMom4Lnb99DbD3OQbSOoM5Z+ASh8YXYaLAsRQrU2Jeh3Qig==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-define-polyfill-provider": "^0.6.8",
+        "@babel/helper-define-polyfill-provider": "^1.0.0",
         "core-js-compat": "^3.48.0"
       },
-      "peerDependencies": {
-        "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
-      }
-    },
-    "node_modules/babel-plugin-polyfill-regenerator": {
-      "version": "0.6.8",
-      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.6.8.tgz",
-      "integrity": "sha512-M762rNHfSF1EV3SLtnCJXFoQbbIIz0OyRwnCmV0KPC7qosSfCO0QLTSuJX3ayAebubhE6oYBAYPrBA5ljowaZg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-define-polyfill-provider": "^0.6.8"
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
       },
       "peerDependencies": {
-        "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
+        "@babel/core": "^7.4.0 || ^8.0.0"
       }
     },
     "node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -3620,14 +3811,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/braces": {
@@ -4076,29 +4269,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/clean-regexp": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/clean-regexp/-/clean-regexp-1.0.0.tgz",
-      "integrity": "sha512-GfisEZEJvzKrmGWkvfhgzcz/BllN1USeqD2V6tg14OAOgaCD2Z/PUEuxnAZ/nPvmaHRG7a8y77p1T/IRQ4D1Hw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "escape-string-regexp": "^1.0.5"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/clean-regexp/node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
     "node_modules/cli-boxes": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-3.0.0.tgz",
@@ -4250,13 +4420,13 @@
       }
     },
     "node_modules/commander": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
-      "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">= 6"
+        "node": ">=20"
       }
     },
     "node_modules/comment-parser": {
@@ -4877,6 +5047,19 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/detect-indent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-7.0.2.tgz",
+      "integrity": "sha512-y+8xyqdGLL+6sh0tVeHcfP/QDd8gUgbasolJJpY7NgeQGSZ739bDtSiaiDgtoicy+mtYB81dKLxO9xRhCyIB3A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/doctrine": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
@@ -5053,6 +5236,16 @@
       "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/empathic": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/empathic/-/empathic-2.0.1.tgz",
+      "integrity": "sha512-YGRs8knHhKHVShLkFET/rWAU8kmHbOV5LwN938RHI0pljAJ1Gf6SzXsSmRaEzcXTtOOmVqJ5+WtQPL5uigY50Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
     },
     "node_modules/encodeurl": {
       "version": "2.0.0",
@@ -5397,33 +5590,33 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.39.4",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
-      "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.5.0.tgz",
+      "integrity": "sha512-1y+7C+vi12bUK1IpZeaV3gsH9fHLBmPvYmPx42pvT/E9yG0IC8g3PUZZgp0+JLJl7ZDK0flc2gc+Aw9dpCvIsQ==",
       "dev": true,
       "license": "MIT",
+      "workspaces": [
+        "packages/*"
+      ],
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
-        "@eslint-community/regexpp": "^4.12.1",
-        "@eslint/config-array": "^0.21.2",
-        "@eslint/config-helpers": "^0.4.2",
-        "@eslint/core": "^0.17.0",
-        "@eslint/eslintrc": "^3.3.5",
-        "@eslint/js": "9.39.4",
-        "@eslint/plugin-kit": "^0.4.1",
+        "@eslint-community/regexpp": "^4.12.2",
+        "@eslint/config-array": "^0.23.5",
+        "@eslint/config-helpers": "^0.6.0",
+        "@eslint/core": "^1.2.1",
+        "@eslint/plugin-kit": "^0.7.2",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@humanwhocodes/retry": "^0.4.2",
         "@types/estree": "^1.0.6",
         "ajv": "^6.14.0",
-        "chalk": "^4.0.0",
         "cross-spawn": "^7.0.6",
         "debug": "^4.3.2",
         "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^8.4.0",
-        "eslint-visitor-keys": "^4.2.1",
-        "espree": "^10.4.0",
-        "esquery": "^1.5.0",
+        "eslint-scope": "^9.1.2",
+        "eslint-visitor-keys": "^5.0.1",
+        "espree": "^11.2.0",
+        "esquery": "^1.7.0",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
         "file-entry-cache": "^8.0.0",
@@ -5433,8 +5626,7 @@
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
-        "lodash.merge": "^4.6.2",
-        "minimatch": "^3.1.5",
+        "minimatch": "^10.2.4",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.3"
       },
@@ -5442,7 +5634,7 @@
         "eslint": "bin/eslint.js"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       },
       "funding": {
         "url": "https://eslint.org/donate"
@@ -5470,19 +5662,6 @@
       },
       "peerDependencies": {
         "eslint": ">=6.0.0"
-      }
-    },
-    "node_modules/eslint-compat-utils/node_modules/semver": {
-      "version": "7.8.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
-      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/eslint-config-prettier": {
@@ -5521,30 +5700,6 @@
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.1"
-      }
-    },
-    "node_modules/eslint-import-resolver-node/node_modules/resolve": {
-      "version": "2.0.0-next.7",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.7.tgz",
-      "integrity": "sha512-tqt+NBWwyaMgw3zDsnygx4CByWjQEJHOPMdslYhppaQSJUtL/D4JO9CcBBlhPoI8lz9oJIDXkwXfhF4aWqP8xQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "is-core-module": "^2.16.2",
-        "node-exports-info": "^1.6.0",
-        "object-keys": "^1.1.1",
-        "path-parse": "^1.0.7",
-        "supports-preserve-symlinks-flag": "^1.0.0"
-      },
-      "bin": {
-        "resolve": "bin/resolve"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/eslint-module-utils": {
@@ -5644,6 +5799,24 @@
         "eslint": "^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8 || ^9"
       }
     },
+    "node_modules/eslint-plugin-import/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/eslint-plugin-import/node_modules/brace-expansion": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
     "node_modules/eslint-plugin-import/node_modules/debug": {
       "version": "3.2.7",
       "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
@@ -5652,6 +5825,29 @@
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.1"
+      }
+    },
+    "node_modules/eslint-plugin-import/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/eslint-plugin-import/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
       }
     },
     "node_modules/eslint-plugin-jsdoc": {
@@ -5681,50 +5877,6 @@
       },
       "peerDependencies": {
         "eslint": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0"
-      }
-    },
-    "node_modules/eslint-plugin-jsdoc/node_modules/eslint-visitor-keys": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
-      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/eslint-plugin-jsdoc/node_modules/espree": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
-      "integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "acorn": "^8.16.0",
-        "acorn-jsx": "^5.3.2",
-        "eslint-visitor-keys": "^5.0.1"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/eslint-plugin-jsdoc/node_modules/semver": {
-      "version": "7.8.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
-      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/eslint-plugin-mozilla": {
@@ -5760,6 +5912,54 @@
         }
       }
     },
+    "node_modules/eslint-plugin-mozilla/node_modules/eslint-scope": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-plugin-mozilla/node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-plugin-mozilla/node_modules/espree": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
     "node_modules/eslint-plugin-n": {
       "version": "17.10.3",
       "resolved": "https://registry.npmjs.org/eslint-plugin-n/-/eslint-plugin-n-17.10.3.tgz",
@@ -5785,6 +5985,13 @@
       "peerDependencies": {
         "eslint": ">=8.23.0"
       }
+    },
+    "node_modules/eslint-plugin-n/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/eslint-plugin-n/node_modules/brace-expansion": {
       "version": "2.1.1",
@@ -5823,19 +6030,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/eslint-plugin-n/node_modules/semver": {
-      "version": "7.8.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
-      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/eslint-plugin-no-unsanitized": {
@@ -5931,28 +6125,45 @@
         "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7"
       }
     },
-    "node_modules/eslint-plugin-react/node_modules/resolve": {
-      "version": "2.0.0-next.7",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.7.tgz",
-      "integrity": "sha512-tqt+NBWwyaMgw3zDsnygx4CByWjQEJHOPMdslYhppaQSJUtL/D4JO9CcBBlhPoI8lz9oJIDXkwXfhF4aWqP8xQ==",
+    "node_modules/eslint-plugin-react/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/eslint-plugin-react/node_modules/brace-expansion": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "es-errors": "^1.3.0",
-        "is-core-module": "^2.16.2",
-        "node-exports-info": "^1.6.0",
-        "object-keys": "^1.1.1",
-        "path-parse": "^1.0.7",
-        "supports-preserve-symlinks-flag": "^1.0.0"
-      },
-      "bin": {
-        "resolve": "bin/resolve"
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/eslint-plugin-react/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
       },
       "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
+        "node": "*"
+      }
+    },
+    "node_modules/eslint-plugin-react/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
       }
     },
     "node_modules/eslint-plugin-security": {
@@ -5966,77 +6177,76 @@
       }
     },
     "node_modules/eslint-plugin-unicorn": {
-      "version": "64.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-64.0.0.tgz",
-      "integrity": "sha512-rNZwalHh8i0UfPlhNwg5BTUO1CMdKNmjqe+TgzOTZnpKoi8VBgsW7u9qCHIdpxEzZ1uwrJrPF0uRb7l//K38gA==",
+      "version": "67.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-67.0.0.tgz",
+      "integrity": "sha512-XEYhNfAFFFYQLq++53iqpgIPFqvjasf5lsUJuCdmd/QvbRfcLbmPTjcTyVEXc5yBudWIg08SSEGgqJtEojk1ug==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/helper-validator-identifier": "^7.29.7",
         "@eslint-community/eslint-utils": "^4.9.1",
+        "browserslist": "^4.28.2",
         "change-case": "^5.4.4",
         "ci-info": "^4.4.0",
-        "clean-regexp": "^1.0.0",
         "core-js-compat": "^3.49.0",
+        "detect-indent": "^7.0.2",
         "find-up-simple": "^1.0.1",
-        "globals": "^17.4.0",
+        "globals": "^17.6.0",
         "indent-string": "^5.0.0",
         "is-builtin-module": "^5.0.0",
         "jsesc": "^3.1.0",
         "pluralize": "^8.0.0",
-        "regexp-tree": "^0.1.27",
-        "regjsparser": "^0.13.0",
-        "semver": "^7.7.4",
+        "regjsparser": "^0.13.1",
+        "semver": "^7.8.4",
         "strip-indent": "^4.1.1"
       },
       "engines": {
-        "node": "^20.10.0 || >=21.0.0"
+        "node": ">=22"
       },
       "funding": {
         "url": "https://github.com/sindresorhus/eslint-plugin-unicorn?sponsor=1"
       },
       "peerDependencies": {
-        "eslint": ">=9.38.0"
+        "eslint": ">=10.4"
       }
     },
-    "node_modules/eslint-plugin-unicorn/node_modules/semver": {
-      "version": "7.8.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
-      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
+    "node_modules/eslint-plugin-unicorn/node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
+      "license": "MIT",
       "engines": {
-        "node": ">=10"
+        "node": ">=6.9.0"
       }
     },
     "node_modules/eslint-scope": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
-      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
+      "integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
+        "@types/esrecurse": "^4.3.1",
+        "@types/estree": "^1.0.8",
         "esrecurse": "^4.3.0",
         "estraverse": "^5.2.0"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/eslint-visitor-keys": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
-      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
@@ -6080,18 +6290,18 @@
       "license": "MIT"
     },
     "node_modules/espree": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
-      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
+      "integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "acorn": "^8.15.0",
+        "acorn": "^8.16.0",
         "acorn-jsx": "^5.3.2",
-        "eslint-visitor-keys": "^4.2.1"
+        "eslint-visitor-keys": "^5.0.1"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
@@ -6618,20 +6828,6 @@
         "node": ">=14.14"
       }
     },
-    "node_modules/fs-readdir-recursive": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz",
-      "integrity": "sha512-GNanXlVr2pf02+sPN40XN8HG+ePaNcvM0q5mZBd668Obwb0yD5GiUbZOFgwn8kGMY6I3mdyDJzieUy3PTYyTRA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/fs.realpath": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-      "dev": true,
-      "license": "ISC"
-    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -6870,22 +7066,18 @@
       }
     },
     "node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
       "dev": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
       },
       "engines": {
-        "node": "*"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -7318,6 +7510,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/import-fresh/node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/import-local": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.2.0.tgz",
@@ -7336,6 +7538,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/import-meta-resolve": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
+      "integrity": "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/imurmurhash": {
@@ -7372,18 +7585,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/inflight": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
-      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "once": "^1.3.0",
-        "wrappy": "1"
       }
     },
     "node_modules/inherits": {
@@ -8208,9 +8409,9 @@
       }
     },
     "node_modules/js-tokens": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -8338,19 +8539,6 @@
       "engines": {
         "node": ">=12",
         "npm": ">=6"
-      }
-    },
-    "node_modules/jsonwebtoken/node_modules/semver": {
-      "version": "7.8.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
-      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/jsx-ast-utils": {
@@ -8615,6 +8803,13 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/loose-envify/node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lowercase-keys": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
@@ -8626,13 +8821,13 @@
       }
     },
     "node_modules/lru-cache": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
       "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^3.0.2"
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/lunr": {
@@ -8820,16 +9015,19 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
       "dev": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
-        "node": "*"
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/minimist": {
@@ -8840,6 +9038,16 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/ms": {
@@ -8866,6 +9074,37 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/multimatch/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/multimatch/node_modules/brace-expansion": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/multimatch/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/natural-compare": {
@@ -8909,6 +9148,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/node-exports-info/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
       }
     },
     "node_modules/node-forge": {
@@ -9098,6 +9347,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
+      "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
       }
     },
     "node_modules/on-exit-leak-free": {
@@ -9307,19 +9570,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/package-json/node_modules/semver": {
-      "version": "7.8.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
-      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/pako": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
@@ -9367,6 +9617,38 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/parse-json/node_modules/@babel/code-frame": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/parse-json/node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/parse-json/node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/parse-statements": {
       "version": "1.0.11",
@@ -9448,16 +9730,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/path-is-absolute": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/path-key": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
@@ -9474,6 +9746,23 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
     },
     "node_modules/path-to-regexp": {
       "version": "8.4.2",
@@ -10018,6 +10307,28 @@
         "node": ">= 10.13.0"
       }
     },
+    "node_modules/rechoir/node_modules/resolve": {
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
@@ -10059,16 +10370,6 @@
       },
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/regexp-tree": {
-      "version": "0.1.27",
-      "resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.27.tgz",
-      "integrity": "sha512-iETxpjK6YoRWJG5o6hXLwvjYAoW+FEZn9os0PD/b6AP6xQwsa/Y7lCVgIixBbUPMfhu+i2LtdeAqVTgGlQarfA==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "regexp-tree": "bin/regexp-tree"
       }
     },
     "node_modules/regexp.prototype.flags": {
@@ -10193,14 +10494,16 @@
       }
     },
     "node_modules/resolve": {
-      "version": "1.22.12",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
-      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+      "version": "2.0.0-next.7",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.7.tgz",
+      "integrity": "sha512-tqt+NBWwyaMgw3zDsnygx4CByWjQEJHOPMdslYhppaQSJUtL/D4JO9CcBBlhPoI8lz9oJIDXkwXfhF4aWqP8xQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "is-core-module": "^2.16.1",
+        "is-core-module": "^2.16.2",
+        "node-exports-info": "^1.6.0",
+        "object-keys": "^1.1.1",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
       },
@@ -10227,7 +10530,7 @@
         "node": ">=8"
       }
     },
-    "node_modules/resolve-cwd/node_modules/resolve-from": {
+    "node_modules/resolve-from": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
       "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
@@ -10235,16 +10538,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/resolve-from": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/resolve-pkg-maps": {
@@ -10486,13 +10779,16 @@
       "license": "MIT"
     },
     "node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
+      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
       "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/send": {
@@ -10731,13 +11027,16 @@
       }
     },
     "node_modules/slash": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
-      "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
+      "integrity": "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=6"
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/sonic-boom": {
@@ -11139,13 +11438,13 @@
       }
     },
     "node_modules/strip-json-comments": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
-      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-5.0.3.tgz",
+      "integrity": "sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=8"
+        "node": ">=14.16"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -11526,19 +11825,6 @@
         "url": "https://github.com/sponsors/ota-meshi"
       }
     },
-    "node_modules/toml-eslint-parser/node_modules/eslint-visitor-keys": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
-      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
     "node_modules/trim-repeated": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/trim-repeated/-/trim-repeated-1.0.0.tgz",
@@ -11600,19 +11886,6 @@
         "loader-utils": {
           "optional": true
         }
-      }
-    },
-    "node_modules/ts-loader/node_modules/semver": {
-      "version": "7.8.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
-      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/tsconfig-paths": {
@@ -11788,49 +12061,10 @@
         "typescript": "5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x || 5.8.x || 5.9.x || 6.0.x"
       }
     },
-    "node_modules/typedoc/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/typedoc/node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/typedoc/node_modules/minimatch": {
-      "version": "10.2.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
-      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "brace-expansion": "^5.0.5"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -12076,19 +12310,6 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
-    "node_modules/update-notifier/node_modules/semver": {
-      "version": "7.8.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
-      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -12218,19 +12439,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/web-ext/node_modules/strip-json-comments": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-5.0.3.tgz",
-      "integrity": "sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/webpack": {
       "version": "5.107.2",
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.107.2.tgz",
@@ -12316,16 +12524,6 @@
         "webpack-dev-server": {
           "optional": true
         }
-      }
-    },
-    "node_modules/webpack-cli/node_modules/commander": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
-      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=20"
       }
     },
     "node_modules/webpack-merge": {
@@ -12729,13 +12927,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/yallist": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-      "dev": true,
-      "license": "ISC"
     },
     "node_modules/yaml": {
       "version": "2.9.0",

--- a/Extension/package.json
+++ b/Extension/package.json
@@ -9,17 +9,17 @@
     "start": "Start is required for the manual_test.py to run"
   },
   "devDependencies": {
-    "@babel/cli": "^7.28.6",
-    "@babel/core": "^7.29.0",
-    "@babel/preset-env": "^7.29.5",
-    "@eslint/js": "^9.0.0",
+    "@babel/cli": "^8.0.1",
+    "@babel/core": "^8.0.1",
+    "@babel/preset-env": "^8.0.1",
+    "@eslint/js": "^10.0.1",
     "@microsoft/eslint-plugin-sdl": "^1.1.0",
     "@types/download": "^8.0.5",
     "@types/firefox-webext-browser": "^143.0.0",
     "ajv": "^8.20.0",
     "body-parser": "^2.3.0",
     "download": "^8.0.0",
-    "eslint": "^9",
+    "eslint": "^10.5.0",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-html": "^8.1.4",
     "eslint-plugin-import": "^2.32.0",
@@ -27,14 +27,14 @@
     "eslint-plugin-mozilla": "^4.4.0",
     "eslint-plugin-prettier": "^5.5.6",
     "eslint-plugin-promise": "^7.3.0",
-    "eslint-plugin-unicorn": "^64.0.0",
+    "eslint-plugin-unicorn": "^67.0.0",
     "express": "^5.2.1",
     "globals": "^17.6.0",
     "prettier": "^3.8.4",
     "safe-compare": "^1.1.4",
     "ts-loader": "^9.6.1",
     "typedoc": "^0.28.19",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "typescript-eslint": "^8.61.1",
     "web-ext": "^10.4.0",
     "webpack": "^5.107.2",
@@ -77,6 +77,14 @@
   },
   "resolutions": {
     "lodash": "^4.17.21"
+  },
+  "overrides": {
+    "@microsoft/eslint-plugin-sdl": {
+      "eslint": "$eslint"
+    },
+    "eslint-plugin-import": {
+      "eslint": "$eslint"
+    }
   },
   "prettier": {
     "singleQuote": false,

--- a/Extension/src/background/cookie-instrument.ts
+++ b/Extension/src/background/cookie-instrument.ts
@@ -1,3 +1,4 @@
+import { DataReceiver } from "../lib/data-receiver";
 import { incrementedEventOrdinal } from "../lib/extension-session-event-ordinal";
 import { extensionSessionUuid } from "../lib/extension-session-uuid";
 import { boolToInt, escapeString } from "../lib/string-utils";
@@ -15,7 +16,7 @@ export const transformCookieObjectToMatchOpenWPMSchema = (cookie: Cookie) => {
   const expiryTime = cookie.expirationDate; // returns seconds
   let expiryTimeString;
   const maxInt64 = 9223372036854776000;
-  if (!cookie.expirationDate || expiryTime === maxInt64) {
+  if (expiryTime === undefined || expiryTime === maxInt64) {
     expiryTimeString = "9999-12-31T21:59:59.000Z";
   } else {
     const expiryTimeDate = new Date(expiryTime * 1000); // requires milliseconds
@@ -41,14 +42,20 @@ export const transformCookieObjectToMatchOpenWPMSchema = (cookie: Cookie) => {
 };
 
 export class CookieInstrument {
-  private readonly dataReceiver;
-  private onChangedListener;
+  private readonly dataReceiver: DataReceiver;
+  private onChangedListener:
+    | ((changeInfo: {
+        removed: boolean;
+        cookie: Cookie;
+        cause: OnChangedCause;
+      }) => Promise<void>)
+    | undefined;
 
-  constructor(dataReceiver) {
+  constructor(dataReceiver: DataReceiver) {
     this.dataReceiver = dataReceiver;
   }
 
-  public run(crawlID) {
+  public run(crawlID: number) {
     // Instrument cookie changes
     this.onChangedListener = async (changeInfo: {
       /** True if a cookie was removed. */
@@ -72,7 +79,7 @@ export class CookieInstrument {
     browser.cookies.onChanged.addListener(this.onChangedListener);
   }
 
-  public async saveAllCookies(crawlID) {
+  public async saveAllCookies(crawlID: number) {
     const allCookies = await browser.cookies.getAll({});
     await Promise.all(
       allCookies.map((cookie: Cookie) => {

--- a/Extension/src/background/cookie-instrument.ts
+++ b/Extension/src/background/cookie-instrument.ts
@@ -16,7 +16,7 @@ export const transformCookieObjectToMatchOpenWPMSchema = (cookie: Cookie) => {
   const expiryTime = cookie.expirationDate; // returns seconds
   let expiryTimeString;
   const maxInt64 = 9223372036854776000;
-  if (expiryTime === undefined || expiryTime === maxInt64) {
+  if (!expiryTime || expiryTime === maxInt64) {
     expiryTimeString = "9999-12-31T21:59:59.000Z";
   } else {
     const expiryTimeDate = new Date(expiryTime * 1000); // requires milliseconds

--- a/Extension/src/background/dns-instrument.ts
+++ b/Extension/src/background/dns-instrument.ts
@@ -1,3 +1,4 @@
+import { DataReceiver } from "../lib/data-receiver";
 import { DnsResolved } from "../schema";
 import { allTypes } from "./http-instrument";
 import {
@@ -14,18 +15,26 @@ import RequestFilter = browser.webRequest.RequestFilter;
 const DNS_ERROR_STRINGS = ["NS_ERROR_UNKNOWN_HOST"];
 
 export class DnsInstrument {
-  private readonly dataReceiver;
-  private onHeadersReceivedListener;
-  private onErrorOccurredListener;
+  private readonly dataReceiver: DataReceiver;
+  private onHeadersReceivedListener:
+    | ((details: WebRequestOnHeadersReceivedDetails) => void)
+    | undefined;
+  private onErrorOccurredListener:
+    | ((details: WebRequestOnErrorOccurredDetails) => void)
+    | undefined;
 
-  constructor(dataReceiver) {
+  constructor(dataReceiver: DataReceiver) {
     this.dataReceiver = dataReceiver;
   }
 
-  public run(crawlID) {
+  public run(crawlID: number) {
     const filter: RequestFilter = { urls: ["<all_urls>"], types: allTypes };
 
-    const requestStemsFromExtension = (details) => {
+    const requestStemsFromExtension = (
+      details:
+        | WebRequestOnHeadersReceivedDetails
+        | WebRequestOnErrorOccurredDetails,
+    ) => {
       return (
         details.originUrl &&
         details.originUrl.includes("moz-extension://") &&
@@ -92,7 +101,7 @@ export class DnsInstrument {
 
   private async onHeadersReceivedDnsHandler(
     details: WebRequestOnHeadersReceivedDetails,
-    crawlID,
+    crawlID: number,
   ) {
     // Create and populate DnsResolve object
     const dnsRecord = {} as DnsResolved;
@@ -118,7 +127,7 @@ export class DnsInstrument {
 
   private onErrorOccurredDnsHandler(
     details: WebRequestOnErrorOccurredDetails,
-    crawlID,
+    crawlID: number,
   ) {
     const dnsRecord = {} as DnsResolved;
     dnsRecord.browser_id = crawlID;

--- a/Extension/src/background/http-instrument.ts
+++ b/Extension/src/background/http-instrument.ts
@@ -440,25 +440,20 @@ export class HttpInstrument {
   private getDocumentUrlForRequest(
     details: WebRequestOnBeforeSendHeadersEventDetails,
   ) {
-    let url = "";
-
     if (details.type === "main_frame") {
       // Url of the top-level document itself.
-      url = details.url;
-    } else if (
-      Object.prototype.hasOwnProperty.call(details, "frameAncestors")
-    ) {
+      return details.url;
+    }
+    if (Object.prototype.hasOwnProperty.call(details, "frameAncestors")) {
       // In case of nested frames, retrieve url from top-most ancestor.
       // If frameAncestors == [], request comes from the top-level-document.
-      url = details.frameAncestors.length
+      return details.frameAncestors.length
         ? details.frameAncestors[details.frameAncestors.length - 1].url
         : details.documentUrl;
-    } else {
-      // type != 'main_frame' and frameAncestors == undefined
-      // For example service workers: https://bugzilla.mozilla.org/show_bug.cgi?id=1470537#c13
-      url = details.documentUrl;
     }
-    return url;
+    // type != 'main_frame' and frameAncestors == undefined
+    // For example service workers: https://bugzilla.mozilla.org/show_bug.cgi?id=1470537#c13
+    return details.documentUrl;
   }
 
   private async onBeforeRedirectHandler(

--- a/Extension/src/background/http-instrument.ts
+++ b/Extension/src/background/http-instrument.ts
@@ -53,16 +53,17 @@ export class HttpInstrument {
   private pendingResponses: {
     [requestId: string]: PendingResponse;
   } = {};
-  private onBeforeRequestListener: (
+  // Assigned in run(); guarded before use in cleanup().
+  private onBeforeRequestListener?: (
     details: browser.webRequest._OnBeforeRequestDetails,
   ) => BlockingResponse;
-  private onBeforeSendHeadersListener: (
-    details: WebRequestOnBeforeSendHeadersEventDetails,
+  private onBeforeSendHeadersListener?: (
+    details: browser.webRequest._OnBeforeSendHeadersDetails,
   ) => void;
-  private onBeforeRedirectListener: (
+  private onBeforeRedirectListener?: (
     details: browser.webRequest._OnBeforeRedirectDetails,
   ) => void;
-  private onCompletedListener: (
+  private onCompletedListener?: (
     details: browser.webRequest._OnCompletedDetails,
   ) => void;
 
@@ -73,9 +74,12 @@ export class HttpInstrument {
   public run(crawlID: number, saveContentOption: SaveContentOption) {
     const filter: RequestFilter = { urls: ["<all_urls>"], types: allTypes };
 
-    const requestStemsFromExtension = (details) => {
+    const requestStemsFromExtension = (details: {
+      originUrl?: string;
+    }): boolean => {
       return (
-        details.originUrl && details.originUrl.indexOf("moz-extension://") > -1
+        !!details.originUrl &&
+        details.originUrl.indexOf("moz-extension://") > -1
       );
     };
 
@@ -108,7 +112,12 @@ export class HttpInstrument {
         : ["requestBody"],
     );
 
-    this.onBeforeSendHeadersListener = (details) => {
+    this.onBeforeSendHeadersListener = (
+      baseDetails: browser.webRequest._OnBeforeSendHeadersDetails,
+    ) => {
+      // Firefox augments the event details with frameAncestors, which is not
+      // part of the upstream @types definition.
+      const details = baseDetails as WebRequestOnBeforeSendHeadersEventDetails;
       // Ignore requests made by extensions
       if (requestStemsFromExtension(details)) {
         return;
@@ -244,7 +253,7 @@ export class HttpInstrument {
     const tab =
       details.tabId > -1
         ? await browser.tabs.get(details.tabId)
-        : { windowId: undefined, incognito: undefined, url: undefined };
+        : { windowId: undefined, incognito: false, url: undefined };
 
     const update = {} as HttpRequest;
 
@@ -280,13 +289,13 @@ export class HttpInstrument {
         header_pair.push(escapeString(value));
         headers.push(header_pair);
         if (name === "Content-Type") {
-          encodingType = value;
+          encodingType = value ?? "";
           if (encodingType.includes("application/ocsp-request")) {
             isOcsp = true;
           }
         }
         if (name === "Referer") {
-          referrer = value;
+          referrer = value ?? "";
         }
       });
     }
@@ -458,7 +467,7 @@ export class HttpInstrument {
 
   private async onBeforeRedirectHandler(
     details: browser.webRequest._OnBeforeRedirectDetails,
-    crawlID,
+    crawlID: number,
     eventOrdinal: number,
   ) {
     /*
@@ -539,7 +548,7 @@ export class HttpInstrument {
     const tab =
       details.tabId > -1
         ? await browser.tabs.get(details.tabId)
-        : { windowId: undefined, incognito: undefined };
+        : { windowId: undefined, incognito: false };
     const httpRedirect: HttpRedirect = {
       incognito: boolToInt(tab.incognito),
       browser_id: crawlID,
@@ -586,13 +595,10 @@ export class HttpInstrument {
       update.content_hash = "<error>";
       dataReceiver.saveRecord("http_responses", update);
       */
+      const error = err instanceof Error ? err : new Error(String(err));
       this.dataReceiver.logError(
-        "Unable to retrieve response body." +
-          "Likely caused by a programming error. Error Message:" +
-          err.name +
-          err.message +
-          "\n" +
-          err.stack,
+        `Unable to retrieve response body. Likely caused by a programming error. ` +
+          `${error.name}: ${error.message}\n${error.stack ?? "(no stack available)"}`,
       );
       update.content_hash = "<error>";
       this.dataReceiver.saveRecord("http_responses", update);
@@ -602,9 +608,9 @@ export class HttpInstrument {
   // Instrument HTTP responses
   private async onCompletedHandler(
     details: browser.webRequest._OnCompletedDetails,
-    crawlID,
-    eventOrdinal,
-    saveContent,
+    crawlID: number,
+    eventOrdinal: number,
+    saveContent: SaveContentOption,
   ) {
     /*
     console.log(
@@ -618,7 +624,7 @@ export class HttpInstrument {
     const tab =
       details.tabId > -1
         ? await browser.tabs.get(details.tabId)
-        : { windowId: undefined, incognito: undefined };
+        : { windowId: undefined, incognito: false };
 
     const update = {} as HttpResponse;
 
@@ -672,18 +678,16 @@ export class HttpInstrument {
     }
   }
 
-  private jsonifyHeaders(headers: HttpHeaders) {
-    const resultHeaders = [];
+  private jsonifyHeaders(headers: HttpHeaders | undefined) {
+    const resultHeaders: string[][] = [];
     let location = "";
     if (headers) {
       headers.map((responseHeader) => {
         const { name, value } = responseHeader;
-        const header_pair = [];
-        header_pair.push(escapeString(name));
-        header_pair.push(escapeString(value));
+        const header_pair = [escapeString(name), escapeString(value)];
         resultHeaders.push(header_pair);
         if (name.toLowerCase() === "location") {
-          location = value;
+          location = value ?? "";
         }
       });
     }

--- a/Extension/src/background/javascript-instrument.ts
+++ b/Extension/src/background/javascript-instrument.ts
@@ -1,9 +1,24 @@
 import MessageSender = browser.runtime.MessageSender;
+import { DataReceiver } from "../lib/data-receiver";
 import { incrementedEventOrdinal } from "../lib/extension-session-event-ordinal";
 import { extensionSessionUuid } from "../lib/extension-session-uuid";
 import { boolToInt, escapeString, escapeUrl } from "../lib/string-utils";
 import { JavascriptOperation } from "../schema";
-import { JSInstrumentRequest } from "../lib/js-instruments";
+import {
+  JSInstrumentRequest,
+  JSLogMessageContent,
+} from "../lib/js-instruments";
+
+/**
+ * Message forwarded from the content script to the background page for each
+ * instrumented call/value observation. The content script stamps `timeStamp`
+ * before forwarding, so it is always present here.
+ */
+interface JsInstrumentationMessage {
+  namespace?: string;
+  type?: string;
+  data: JSLogMessageContent & { timeStamp: string };
+}
 
 export class JavascriptInstrument {
   /**
@@ -13,13 +28,17 @@ export class JavascriptInstrument {
    * @param data
    * @param sender
    */
-  private static processCallsAndValues(data, sender: MessageSender) {
+  private static processCallsAndValues(
+    data: JSLogMessageContent & { timeStamp: string },
+    sender: MessageSender,
+  ) {
+    const tab = sender.tab;
     const update = {} as JavascriptOperation;
     update.extension_session_uuid = extensionSessionUuid;
     update.event_ordinal = incrementedEventOrdinal();
     update.page_scoped_event_ordinal = data.ordinal;
-    update.window_id = sender.tab.windowId;
-    update.tab_id = sender.tab.id;
+    update.window_id = tab?.windowId;
+    update.tab_id = tab?.id;
     update.frame_id = sender.frameId;
     update.script_url = escapeUrl(data.scriptUrl);
     update.script_line = escapeString(data.scriptLine);
@@ -31,26 +50,29 @@ export class JavascriptInstrument {
     update.operation = escapeString(data.operation);
     update.value = escapeString(data.value);
     update.time_stamp = data.timeStamp;
-    update.incognito = boolToInt(sender.tab.incognito);
+    update.incognito = boolToInt(tab?.incognito ?? false);
 
     // document_url is the current frame's document href
     // top_level_url is the top-level frame's document href
     update.document_url = escapeUrl(sender.url);
-    update.top_level_url = escapeUrl(sender.tab.url);
+    update.top_level_url = escapeUrl(tab?.url);
 
-    if (data.operation === "call" && data.args.length > 0) {
+    if (data.operation === "call" && data.args && data.args.length > 0) {
       update.arguments = escapeString(JSON.stringify(data.args));
     }
 
     return update;
   }
-  private readonly dataReceiver;
-  private onMessageListener;
+  private readonly dataReceiver: DataReceiver;
+  private onMessageListener?: (
+    message: JsInstrumentationMessage,
+    sender: MessageSender,
+  ) => void;
   private configured: boolean = false;
   private pendingRecords: JavascriptOperation[] = [];
-  private crawlID;
+  private crawlID?: number;
 
-  constructor(dataReceiver) {
+  constructor(dataReceiver: DataReceiver) {
     this.dataReceiver = dataReceiver;
   }
 
@@ -58,7 +80,10 @@ export class JavascriptInstrument {
    * Start listening for messages from page/content/background scripts injected to instrument JavaScript APIs
    */
   public listen() {
-    this.onMessageListener = (message, sender) => {
+    this.onMessageListener = (
+      message: JsInstrumentationMessage,
+      sender: MessageSender,
+    ) => {
       if (
         message.namespace &&
         message.namespace === "javascript-instrumentation"
@@ -76,7 +101,10 @@ export class JavascriptInstrument {
    * @param message
    * @param sender
    */
-  public handleJsInstrumentationMessage(message, sender: MessageSender) {
+  public handleJsInstrumentationMessage(
+    message: JsInstrumentationMessage,
+    sender: MessageSender,
+  ) {
     switch (message.type) {
       case "logCall":
       case "logValue": {
@@ -102,7 +130,7 @@ export class JavascriptInstrument {
    *
    * @param crawlID
    */
-  public run(crawlID) {
+  public run(crawlID: number) {
     if (!this.onMessageListener) {
       this.listen();
     }

--- a/Extension/src/background/navigation-instrument.ts
+++ b/Extension/src/background/navigation-instrument.ts
@@ -1,3 +1,4 @@
+import { DataReceiver } from "../lib/data-receiver";
 import { incrementedEventOrdinal } from "../lib/extension-session-event-ordinal";
 import { extensionSessionUuid } from "../lib/extension-session-uuid";
 import { PendingNavigation } from "../lib/pending-navigation";
@@ -11,7 +12,7 @@ import {
 } from "../types/browser-web-navigation-event-details";
 
 export const transformWebNavigationBaseEventDetailsToOpenWPMSchema = async (
-  crawlID,
+  crawlID: number,
   details: WebNavigationBaseEventDetails,
 ): Promise<Navigation> => {
   const tab =
@@ -19,7 +20,7 @@ export const transformWebNavigationBaseEventDetailsToOpenWPMSchema = async (
       ? await browser.tabs.get(details.tabId)
       : {
           windowId: undefined,
-          incognito: undefined,
+          incognito: false,
           cookieStoreId: undefined,
           openerTabId: undefined,
           width: undefined,
@@ -50,21 +51,29 @@ export const transformWebNavigationBaseEventDetailsToOpenWPMSchema = async (
 };
 
 export class NavigationInstrument {
-  public static navigationId(processId, tabId, frameId): string {
+  public static navigationId(
+    processId: number | undefined,
+    tabId: number,
+    frameId: number,
+  ): string {
     return `${processId}-${tabId}-${frameId}`;
   }
-  private readonly dataReceiver;
-  private onBeforeNavigateListener;
-  private onCommittedListener;
+  private readonly dataReceiver: DataReceiver;
+  private onBeforeNavigateListener?: (
+    details: WebNavigationOnBeforeNavigateEventDetails,
+  ) => Promise<void>;
+  private onCommittedListener?: (
+    details: WebNavigationOnCommittedEventDetails,
+  ) => Promise<void>;
   private pendingNavigations: {
     [navigationId: string]: PendingNavigation;
   } = {};
 
-  constructor(dataReceiver) {
+  constructor(dataReceiver: DataReceiver) {
     this.dataReceiver = dataReceiver;
   }
 
-  public run(crawlID) {
+  public run(crawlID: number) {
     this.onBeforeNavigateListener = async (
       details: WebNavigationOnBeforeNavigateEventDetails,
     ) => {

--- a/Extension/src/callstack-instrument.ts
+++ b/Extension/src/callstack-instrument.ts
@@ -10,7 +10,7 @@ export class CallstackInstrument {
   }
   run(browser_id: number) {
     (browser as any).stackDump.onStackAvailable.addListener(
-      (request_id, call_stack) => {
+      (request_id: string, call_stack: string) => {
         const record = {
           browser_id,
           request_id,

--- a/Extension/src/content/javascript-instrument-content-scope.ts
+++ b/Extension/src/content/javascript-instrument-content-scope.ts
@@ -38,7 +38,7 @@ function insertScript(
   parent.removeChild(script);
 }
 
-function emitMsg(type, msg) {
+function emitMsg(type: string, msg: { timeStamp?: string }) {
   msg.timeStamp = new Date().toISOString();
   browser.runtime.sendMessage({
     namespace: "javascript-instrumentation",
@@ -50,9 +50,15 @@ function emitMsg(type, msg) {
 const eventId = Math.random().toString();
 
 // listen for messages from the script we are about to insert
-document.addEventListener(eventId, (e: CustomEvent) => {
+interface InstrumentMessage {
+  type: string;
+  content: { timeStamp?: string };
+}
+
+document.addEventListener(eventId, (e: Event) => {
   // pass these on to the background page
-  const msgs = e.detail;
+  const msgs = (e as CustomEvent<InstrumentMessage | InstrumentMessage[]>)
+    .detail;
   if (Array.isArray(msgs)) {
     msgs.forEach((msg) => {
       emitMsg(msg.type, msg.content);

--- a/Extension/src/content/javascript-instrument-page-scope.ts
+++ b/Extension/src/content/javascript-instrument-page-scope.ts
@@ -1,10 +1,22 @@
 // Code below is not a content script: no Firefox APIs should be used
-// Also, no webpack/es6 imports may be used in this file since the script
-// is exported as a page script as a string
+// Also, no runtime es6 imports may be used in this file since the script
+// is exported as a page script as a string. Type-only imports are erased by
+// the compiler and therefore safe.
+import type {
+  GetInstrumentJS,
+  InstrumentMessage,
+  JSInstrumentRequest,
+} from "../lib/js-instruments";
 
-export function pageScript(getInstrumentJS, jsInstrumentationSettings) {
+export function pageScript(
+  getInstrumentJS: GetInstrumentJS,
+  jsInstrumentationSettings: JSInstrumentRequest[],
+) {
   // messages the injected script
-  const sendMessagesToLogger = (eventId, messages) => {
+  const sendMessagesToLogger = (
+    eventId: string,
+    messages: InstrumentMessage[],
+  ) => {
     document.dispatchEvent(
       new CustomEvent(eventId, {
         detail: messages,
@@ -12,10 +24,11 @@ export function pageScript(getInstrumentJS, jsInstrumentationSettings) {
     );
   };
 
-  const eventId = document.currentScript.getAttribute("data-event-id");
-  const testing = document.currentScript.getAttribute("data-testing");
+  const currentScript = document.currentScript as HTMLScriptElement | null;
+  const eventId = currentScript?.getAttribute("data-event-id") ?? "";
+  const testing = currentScript?.getAttribute("data-testing");
   const instrumentJS = getInstrumentJS(eventId, sendMessagesToLogger);
-  let t0: number;
+  let t0 = 0;
   if (testing === "true") {
     console.log("OpenWPM: Currently testing");
     t0 = performance.now();
@@ -25,7 +38,8 @@ export function pageScript(getInstrumentJS, jsInstrumentationSettings) {
   if (testing === "true") {
     const t1 = performance.now();
     console.log(`Call to instrumentJS took ${t1 - t0} milliseconds.`);
-    (window as any).instrumentJS = instrumentJS;
+    (window as unknown as { instrumentJS: typeof instrumentJS }).instrumentJS =
+      instrumentJS;
     console.log(
       "OpenWPM: Content-side javascript instrumentation started with spec:",
       jsInstrumentationSettings,

--- a/Extension/src/lib/data-receiver.ts
+++ b/Extension/src/lib/data-receiver.ts
@@ -1,0 +1,16 @@
+/**
+ * Shared shape of the object instruments use to persist records and content.
+ *
+ * In production this is the `loggingdb` module namespace; the instruments only
+ * ever touch `saveRecord` / `saveContent`, so this narrow interface is enough
+ * to type their constructors without coupling to the full module.
+ */
+export interface DataReceiver {
+  saveRecord(instrument: string, record: object): void;
+  saveContent(content: string | Uint8Array, contentHash: string): Promise<void>;
+  logInfo(msg: string): void;
+  logDebug(msg: string): void;
+  logWarn(msg: string): void;
+  logError(msg: string): void;
+  logCritical(msg: string): void;
+}

--- a/Extension/src/lib/http-post-parser.ts
+++ b/Extension/src/lib/http-post-parser.ts
@@ -1,3 +1,4 @@
+import { DataReceiver } from "./data-receiver";
 import { escapeString, Uint8ToBase64 } from "./string-utils";
 
 export interface ParsedPostRequest {
@@ -8,11 +9,11 @@ export interface ParsedPostRequest {
 
 export class HttpPostParser {
   private readonly onBeforeRequestEventDetails: browser.webRequest._OnBeforeRequestDetails;
-  private readonly dataReceiver;
+  private readonly dataReceiver: DataReceiver;
 
   constructor(
     onBeforeRequestEventDetails: browser.webRequest._OnBeforeRequestDetails,
-    dataReceiver,
+    dataReceiver: DataReceiver,
   ) {
     this.onBeforeRequestEventDetails = onBeforeRequestEventDetails;
     this.dataReceiver = dataReceiver;
@@ -20,6 +21,9 @@ export class HttpPostParser {
 
   public parsePostRequest() {
     const requestBody = this.onBeforeRequestEventDetails.requestBody;
+    if (!requestBody) {
+      return {};
+    }
     if (requestBody.error) {
       this.dataReceiver.logError(
         "Exception: Upstream failed to parse POST: " + requestBody.error,

--- a/Extension/src/lib/js-instruments.ts
+++ b/Extension/src/lib/js-instruments.ts
@@ -20,9 +20,43 @@ export interface JSInstrumentRequest {
   logSettings: LogSettings;
 }
 
+/**
+ * The payload of a single instrumented call/value observation, as produced by
+ * `logCall` / `logValue` before it is forwarded to the background page.
+ */
+export interface JSLogMessageContent {
+  operation: string;
+  symbol: string;
+  value: string;
+  scriptUrl: string;
+  scriptLine: string;
+  scriptCol: string;
+  funcName: string;
+  scriptLocEval: string;
+  callStack: string;
+  ordinal: number;
+  args?: string[];
+  timeStamp?: string;
+}
+
+/** An envelope queued for delivery to the background page. */
+export interface InstrumentMessage {
+  type: string;
+  content: JSLogMessageContent;
+}
+
+/** Forwards a batch of queued messages out of the page scope. */
+export type SendMessagesToLogger = (
+  eventId: string,
+  messages: InstrumentMessage[],
+) => void;
+
 declare global {
   interface Object {
-    getPropertyDescriptor(subject: any, name: any): PropertyDescriptor;
+    getPropertyDescriptor(
+      subject: any,
+      name: any,
+    ): PropertyDescriptor | undefined;
   }
 
   interface Object {
@@ -30,7 +64,22 @@ declare global {
   }
 }
 
-export function getInstrumentJS(eventId: string, sendMessagesToLogger) {
+interface CallContext {
+  scriptUrl: string;
+  scriptLine: string;
+  scriptCol: string;
+  funcName: string;
+  scriptLocEval: string;
+  callStack: string;
+}
+
+/** Type of {@link getInstrumentJS}, used by the stringified page script. */
+export type GetInstrumentJS = typeof getInstrumentJS;
+
+export function getInstrumentJS(
+  eventId: string,
+  sendMessagesToLogger: SendMessagesToLogger,
+) {
   /*
    * Instrumentation helpers
    * (Inlined in order for jsInstruments to be easily exportable as a string)
@@ -39,7 +88,7 @@ export function getInstrumentJS(eventId: string, sendMessagesToLogger) {
   // Counter to cap # of calls logged for each script/api combination
   const maxLogCount = 500;
   // logCounter
-  const logCounter = new Object();
+  const logCounter: Record<string, number> = {};
   // Prevent logging of gets arising from logging
   let inLog = false;
   // To keep track of the original order of events
@@ -86,12 +135,16 @@ export function getInstrumentJS(eventId: string, sendMessagesToLogger) {
   };
 
   // debounce - from Underscore v1.6.0
-  function debounce(func, wait, immediate: boolean = false) {
-    let timeout;
-    let args;
-    let context;
-    let timestamp;
-    let result;
+  function debounce(
+    func: (...funcArgs: unknown[]) => unknown,
+    wait: number,
+    immediate: boolean = false,
+  ) {
+    let timeout: ReturnType<typeof setTimeout> | null = null;
+    let args: IArguments | null = null;
+    let context: unknown;
+    let timestamp: number;
+    let result: unknown;
 
     const later = function () {
       const last = Date.now() - timestamp;
@@ -100,13 +153,13 @@ export function getInstrumentJS(eventId: string, sendMessagesToLogger) {
       } else {
         timeout = null;
         if (!immediate) {
-          result = func.apply(context, args);
+          result = func.apply(context, args ? Array.from(args) : []);
           context = args = null;
         }
       }
     };
 
-    return function () {
+    return function (this: unknown) {
       context = this; // eslint-disable-line @typescript-eslint/no-this-alias
       args = arguments; // eslint-disable-line prefer-rest-params
       timestamp = Date.now();
@@ -115,7 +168,7 @@ export function getInstrumentJS(eventId: string, sendMessagesToLogger) {
         timeout = setTimeout(later, wait);
       }
       if (callNow) {
-        result = func.apply(context, args);
+        result = func.apply(context, args ? Array.from(args) : []);
         context = args = null;
       }
 
@@ -124,7 +177,10 @@ export function getInstrumentJS(eventId: string, sendMessagesToLogger) {
   }
 
   // Recursively generates a path for an element
-  function getPathToDomElement(element: any, visibilityAttr: boolean = false) {
+  function getPathToDomElement(
+    element: any,
+    visibilityAttr: boolean = false,
+  ): string | undefined {
     if (element === document.body) {
       return element.tagName;
     }
@@ -155,11 +211,12 @@ export function getInstrumentJS(eventId: string, sendMessagesToLogger) {
         siblingIndex++;
       }
     }
+    return undefined;
   }
 
   // Helper for JSONifying objects
   function serializeObject(
-    object,
+    object: unknown,
     stringifyFunctions: boolean = false,
   ): string {
     // Handle permissions errors
@@ -171,9 +228,14 @@ export function getInstrumentJS(eventId: string, sendMessagesToLogger) {
         return stringifyFunctions ? object.toString() : "FUNCTION";
       }
       if (typeof object !== "object") {
-        return object;
+        // Preserve the value's native type (number/boolean/string). The
+        // transport JSON.stringify downstream records e.g. 125 as `125`, not
+        // `"125"`. Do NOT wrap in String() — that coerces numeric call
+        // arguments to strings and corrupts captured data. The `: string`
+        // return type is a deliberate imprecision the callers rely on.
+        return object as string;
       }
-      const seenObjects = [];
+      const seenObjects: unknown[] = [];
       return JSON.stringify(object, function (key, value) {
         if (value === null) {
           return "null";
@@ -208,7 +270,7 @@ export function getInstrumentJS(eventId: string, sendMessagesToLogger) {
     }
   }
 
-  function updateCounterAndCheckIfOver(scriptUrl, symbol) {
+  function updateCounterAndCheckIfOver(scriptUrl: string, symbol: string) {
     const key = scriptUrl + "|" + symbol;
     if (key in logCounter && logCounter[key] >= maxLogCount) {
       return true;
@@ -223,9 +285,9 @@ export function getInstrumentJS(eventId: string, sendMessagesToLogger) {
   // For gets, sets, etc. on a single value
   function logValue(
     instrumentedVariableName: string,
-    value: any,
+    value: unknown,
     operation: string, // from JSOperation object please
-    callContext: any,
+    callContext: CallContext,
     logSettings: LogSettings,
   ) {
     if (inLog) {
@@ -269,7 +331,7 @@ export function getInstrumentJS(eventId: string, sendMessagesToLogger) {
   function logCall(
     instrumentedFunctionName: string,
     args: IArguments,
-    callContext: any,
+    callContext: CallContext,
     logSettings: LogSettings,
   ) {
     if (inLog) {
@@ -317,32 +379,40 @@ export function getInstrumentJS(eventId: string, sendMessagesToLogger) {
     inLog = false;
   }
 
-  function logErrorToConsole(error, context: any = false) {
-    console.error("OpenWPM: Error name: " + error.name);
-    console.error("OpenWPM: Error message: " + error.message);
-    console.error("OpenWPM: Error filename: " + error.fileName);
-    console.error("OpenWPM: Error line number: " + error.lineNumber);
-    console.error("OpenWPM: Error stack: " + error.stack);
+  function logErrorToConsole(error: unknown, context: unknown = false) {
+    // Firefox errors expose non-standard fileName/lineNumber fields.
+    const err = error as {
+      name?: string;
+      message?: string;
+      fileName?: string;
+      lineNumber?: number;
+      stack?: string;
+    };
+    console.error("OpenWPM: Error name: " + err.name);
+    console.error("OpenWPM: Error message: " + err.message);
+    console.error("OpenWPM: Error filename: " + err.fileName);
+    console.error("OpenWPM: Error line number: " + err.lineNumber);
+    console.error("OpenWPM: Error stack: " + err.stack);
     if (context) {
       console.error("OpenWPM: Error context: " + JSON.stringify(context));
     }
   }
 
   // Helper to get originating script urls
-  function getStackTrace() {
-    let stack;
+  function getStackTrace(): string {
+    let stack: string;
 
     try {
       throw new Error();
     } catch (err) {
-      stack = err.stack;
+      stack = err instanceof Error ? (err.stack ?? "") : "";
     }
 
     return stack;
   }
 
   // from http://stackoverflow.com/a/5202185
-  const rsplit = function (source: string, sep, maxsplit) {
+  const rsplit = function (source: string, sep: string, maxsplit: number) {
     const split = source.split(sep);
     return maxsplit
       ? [split.slice(0, -maxsplit).join(sep)].concat(split.slice(-maxsplit))
@@ -408,14 +478,17 @@ export function getInstrumentJS(eventId: string, sendMessagesToLogger) {
     } catch (e) {
       console.log(
         "OpenWPM: Error parsing the script context",
-        e.toString(),
+        String(e),
         callSite,
       );
       return empty_context;
     }
   }
 
-  function isObject(object, propertyName) {
+  function isObject(
+    object: Record<PropertyKey, unknown>,
+    propertyName: string,
+  ) {
     let property;
     try {
       property = object[propertyName];
@@ -439,7 +512,7 @@ export function getInstrumentJS(eventId: string, sendMessagesToLogger) {
     func: any,
     logSettings: LogSettings,
   ) {
-    return function () {
+    return function (this: unknown) {
       const callContext = getOriginatingScriptContext(logSettings.logCallStack);
       logCall(
         objectName + "." + methodName,
@@ -454,7 +527,7 @@ export function getInstrumentJS(eventId: string, sendMessagesToLogger) {
 
   // Log properties of prototypes and objects
   function instrumentObjectProperty(
-    object,
+    object: any,
     objectName: string,
     propertyName: string,
     logSettings: LogSettings,
@@ -492,12 +565,12 @@ export function getInstrumentJS(eventId: string, sendMessagesToLogger) {
     }
 
     // Property descriptor for undefined properties
-    let undefinedPropValue;
+    let undefinedPropValue: unknown;
     const undefinedPropDesc = {
       get: () => {
         return undefinedPropValue;
       },
-      set: (value) => {
+      set: (value: unknown) => {
         undefinedPropValue = value;
       },
       enumerable: false,
@@ -513,7 +586,7 @@ export function getInstrumentJS(eventId: string, sendMessagesToLogger) {
     Object.defineProperty(object, propertyName, {
       configurable: true,
       get: (function () {
-        return function () {
+        return function (this: any) {
           let origProperty;
           const callContext = getOriginatingScriptContext(
             logSettings.logCallStack,
@@ -593,7 +666,7 @@ export function getInstrumentJS(eventId: string, sendMessagesToLogger) {
         };
       })(),
       set: (function () {
-        return function (value) {
+        return function (this: any, value: unknown) {
           const callContext = getOriginatingScriptContext(
             logSettings.logCallStack,
           );
@@ -620,7 +693,7 @@ export function getInstrumentJS(eventId: string, sendMessagesToLogger) {
           if (originalSetter) {
             // if accessor property
             returnValue = originalSetter.call(this, value);
-          } else if ("value" in propDesc) {
+          } else if (propDesc && "value" in propDesc) {
             inLog = true;
             if (Object.prototype.isPrototypeOf.call(object, this)) {
               Object.defineProperty(this, propertyName, {
@@ -731,8 +804,11 @@ export function getInstrumentJS(eventId: string, sendMessagesToLogger) {
     }
   }
 
-  const sendFactory = function (eventId, $sendMessagesToLogger) {
-    let messages = [];
+  const sendFactory = function (
+    eventId: string,
+    $sendMessagesToLogger: SendMessagesToLogger,
+  ) {
+    let messages: InstrumentMessage[] = [];
     // debounce sending queued messages
     const send = debounce(function () {
       $sendMessagesToLogger(eventId, messages);
@@ -741,7 +817,7 @@ export function getInstrumentJS(eventId: string, sendMessagesToLogger) {
       messages = [];
     }, 100);
 
-    return function (msgType, msg) {
+    return function (msgType: string, msg: JSLogMessageContent) {
       // queue the message
       messages.push({ type: msgType, content: msg });
       send();

--- a/Extension/src/lib/pending-navigation.ts
+++ b/Extension/src/lib/pending-navigation.ts
@@ -6,8 +6,9 @@ import { Navigation } from "../schema";
 export class PendingNavigation {
   public readonly onBeforeNavigateEventNavigation: Promise<Navigation>;
   public readonly onCommittedEventNavigation: Promise<Navigation>;
-  public resolveOnBeforeNavigateEventNavigation: (details: Navigation) => void;
-  public resolveOnCommittedEventNavigation: (details: Navigation) => void;
+  // Assigned synchronously inside the Promise executors in the constructor.
+  public resolveOnBeforeNavigateEventNavigation!: (details: Navigation) => void;
+  public resolveOnCommittedEventNavigation!: (details: Navigation) => void;
   constructor() {
     this.onBeforeNavigateEventNavigation = new Promise((resolve) => {
       this.resolveOnBeforeNavigateEventNavigation = resolve;
@@ -29,7 +30,7 @@ export class PendingNavigation {
    *
    * @param ms
    */
-  public async resolvedWithinTimeout(ms) {
+  public async resolvedWithinTimeout(ms: number) {
     const resolved = await Promise.race([
       this.resolved(),
       new Promise((resolve) => setTimeout(resolve, ms)),

--- a/Extension/src/lib/pending-request.ts
+++ b/Extension/src/lib/pending-request.ts
@@ -6,10 +6,11 @@ import { WebRequestOnBeforeSendHeadersEventDetails } from "../types/browser-web-
 export class PendingRequest {
   public readonly onBeforeRequestEventDetails: Promise<browser.webRequest._OnBeforeRequestDetails>;
   public readonly onBeforeSendHeadersEventDetails: Promise<WebRequestOnBeforeSendHeadersEventDetails>;
-  public resolveOnBeforeRequestEventDetails: (
+  // Assigned synchronously inside the Promise executors in the constructor.
+  public resolveOnBeforeRequestEventDetails!: (
     details: browser.webRequest._OnBeforeRequestDetails,
   ) => void;
-  public resolveOnBeforeSendHeadersEventDetails: (
+  public resolveOnBeforeSendHeadersEventDetails!: (
     details: WebRequestOnBeforeSendHeadersEventDetails,
   ) => void;
   constructor() {
@@ -33,7 +34,7 @@ export class PendingRequest {
    *
    * @param ms
    */
-  public async resolvedWithinTimeout(ms) {
+  public async resolvedWithinTimeout(ms: number) {
     const resolved = await Promise.race([
       this.resolved(),
       new Promise((resolve) => setTimeout(resolve, ms)),

--- a/Extension/src/lib/pending-response.ts
+++ b/Extension/src/lib/pending-response.ts
@@ -6,11 +6,13 @@ import { ResponseBodyListener } from "./response-body-listener";
 export class PendingResponse {
   public readonly onBeforeRequestEventDetails: Promise<browser.webRequest._OnBeforeRequestDetails>;
   public readonly onCompletedEventDetails: Promise<browser.webRequest._OnCompletedDetails>;
-  public responseBodyListener: ResponseBodyListener;
-  public resolveOnBeforeRequestEventDetails: (
+  // resolveOn* are assigned synchronously inside the Promise executors in the
+  // constructor; responseBodyListener is set by addResponseResponseBodyListener.
+  public responseBodyListener!: ResponseBodyListener;
+  public resolveOnBeforeRequestEventDetails!: (
     details: browser.webRequest._OnBeforeRequestDetails,
   ) => void;
-  public resolveOnCompletedEventDetails: (
+  public resolveOnCompletedEventDetails!: (
     details: browser.webRequest._OnCompletedDetails,
   ) => void;
   constructor() {
@@ -39,7 +41,7 @@ export class PendingResponse {
    *
    * @param ms
    */
-  public async resolvedWithinTimeout(ms) {
+  public async resolvedWithinTimeout(ms: number) {
     const resolved = await Promise.race([
       this.resolved(),
       new Promise((resolve) => setTimeout(resolve, ms)),

--- a/Extension/src/lib/response-body-listener.ts
+++ b/Extension/src/lib/response-body-listener.ts
@@ -3,8 +3,9 @@ import { digestMessage } from "./sha256";
 export class ResponseBodyListener {
   private readonly responseBody: Promise<Uint8Array>;
   private readonly contentHash: Promise<string>;
-  private resolveResponseBody: (responseBody: Uint8Array) => void;
-  private resolveContentHash: (contentHash: string) => void;
+  // Assigned synchronously inside the Promise executors in the constructor.
+  private resolveResponseBody!: (responseBody: Uint8Array) => void;
+  private resolveContentHash!: (contentHash: string) => void;
 
   constructor(details: browser.webRequest._OnBeforeRequestDetails) {
     this.responseBody = new Promise((resolve) => {
@@ -20,9 +21,9 @@ export class ResponseBodyListener {
     ) as any;
 
     let responseBody = new Uint8Array();
-    filter.ondata = (event) => {
-      void digestMessage(event.data).then(this.resolveContentHash);
+    filter.ondata = (event: { data: ArrayBuffer }) => {
       const incoming = new Uint8Array(event.data);
+      void digestMessage(incoming).then(this.resolveContentHash);
       const tmp = new Uint8Array(responseBody.length + incoming.length);
       tmp.set(responseBody);
       tmp.set(incoming, responseBody.length);
@@ -30,7 +31,7 @@ export class ResponseBodyListener {
       filter.write(event.data);
     };
 
-    filter.onstop = (_event) => {
+    filter.onstop = (_event: unknown) => {
       this.resolveResponseBody(responseBody);
       filter.disconnect();
     };

--- a/Extension/src/lib/string-utils.ts
+++ b/Extension/src/lib/string-utils.ts
@@ -2,17 +2,15 @@ export function encode_utf8(s: string) {
   return unescape(encodeURIComponent(s));
 }
 
-export const escapeString = function (str: any) {
+export const escapeString = function (str: unknown): string {
   // Convert to string if necessary
-  if (typeof str !== "string") {
-    str = String(str);
-  }
+  const asString = typeof str === "string" ? str : String(str);
 
-  return encode_utf8(str);
+  return encode_utf8(asString);
 };
 
 export const escapeUrl = function (
-  url: string,
+  url: string | undefined,
   stripDataUrlData: boolean = true,
 ) {
   url = escapeString(url);

--- a/Extension/src/lib/string-utils.ts
+++ b/Extension/src/lib/string-utils.ts
@@ -1,4 +1,4 @@
-export function encode_utf8(s) {
+export function encode_utf8(s: string) {
   return unescape(encodeURIComponent(s));
 }
 
@@ -37,7 +37,7 @@ export const Uint8ToBase64 = function (u8Arr: Uint8Array) {
   let slice: Uint8Array;
   while (index < length) {
     slice = u8Arr.subarray(index, Math.min(index + CHUNK_SIZE, length));
-    result += String.fromCharCode.apply(null, slice);
+    result += String.fromCharCode(...slice);
     index += CHUNK_SIZE;
   }
   return btoa(result);

--- a/Extension/src/lib/uuid.ts
+++ b/Extension/src/lib/uuid.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-bitwise */
 
 // from https://gist.github.com/jed/982883#gistcomment-2403369
-const hex = [];
+const hex: string[] = [];
 
 for (let i = 0; i < 256; i++) {
   hex[i] = (i < 16 ? "0" : "") + i.toString(16);

--- a/Extension/src/loggingdb.ts
+++ b/Extension/src/loggingdb.ts
@@ -1,4 +1,5 @@
 import * as socket from "./socket";
+import { escapeString, Uint8ToBase64 } from "./lib/string-utils";
 
 /**
  * Control message exchanged over the listening socket. In the legacy path the
@@ -253,36 +254,4 @@ export const saveContent = async function (
     typeof content === "string" ? new TextEncoder().encode(content) : content;
   const b64 = Uint8ToBase64(bytes);
   storageController?.send(JSON.stringify(["page_content", [b64, contentHash]]));
-};
-
-function encode_utf8(s: string): string {
-  return unescape(encodeURIComponent(s));
-}
-
-// Base64 encoding, found on:
-// https://stackoverflow.com/questions/12710001/how-to-convert-uint8-array-to-base64-encoded-string/25644409#25644409
-function Uint8ToBase64(u8Arr: Uint8Array): string {
-  const CHUNK_SIZE = 0x8000; // arbitrary number
-  let index = 0;
-  const length = u8Arr.length;
-  let result = "";
-  let slice: Uint8Array;
-  while (index < length) {
-    slice = u8Arr.subarray(index, Math.min(index + CHUNK_SIZE, length));
-    // Uint8Array is array-like; cast avoids a per-chunk Array.from allocation.
-    result += String.fromCharCode.apply(null, slice as unknown as number[]);
-    index += CHUNK_SIZE;
-  }
-  return btoa(result);
-}
-
-export const escapeString = function (string: unknown): string {
-  // Convert to string if necessary
-  const asString = typeof string === "string" ? string : "" + string;
-
-  return encode_utf8(asString);
-};
-
-export const boolToInt = function (bool: boolean): number {
-  return bool ? 1 : 0;
 };

--- a/Extension/src/loggingdb.ts
+++ b/Extension/src/loggingdb.ts
@@ -1,24 +1,37 @@
 import * as socket from "./socket";
 
-let crawlID = null;
-let visitID = null;
-let debugging = false;
-let storageController = null;
-let logAggregator = null;
-let listeningSocket = null;
+/**
+ * Control message exchanged over the listening socket. In the legacy path the
+ * peer may instead send a bare visit id (number or numeric string), which is
+ * why the callback also handles non-object payloads.
+ */
+interface VisitControlMessage {
+  action?: "Initialize" | "Finalize";
+  visit_id?: number;
+  browser_id?: number | null;
+  success?: boolean;
+}
 
-const listeningSocketCallback = async (data) => {
+let crawlID: number | null = null;
+let visitID: number | null = null;
+let debugging = false;
+let storageController: socket.SendingSocket | null = null;
+let logAggregator: socket.SendingSocket | null = null;
+let listeningSocket: socket.ListeningSocket | null = null;
+
+const listeningSocketCallback = async (data: unknown) => {
   // This works even if data is an int
-  const action = data.action;
-  let newVisitID = data.visit_id;
+  const message = data as VisitControlMessage;
+  const action = message.action;
+  let newVisitID = message.visit_id ?? null;
   switch (action) {
     case "Initialize":
       if (visitID) {
         logWarn("Set visit_id while another visit_id was set");
       }
       visitID = newVisitID;
-      data.browser_id = crawlID;
-      storageController.send(JSON.stringify(["meta_information", data]));
+      message.browser_id = crawlID ?? null;
+      storageController?.send(JSON.stringify(["meta_information", message]));
       break;
     case "Finalize":
       if (!visitID) {
@@ -30,21 +43,24 @@ const listeningSocketCallback = async (data) => {
             `Current visit_id ${newVisitID}, received visit_id ${visitID}.`,
         );
       }
-      data.browser_id = crawlID;
-      data.success = true;
-      storageController.send(JSON.stringify(["meta_information", data]));
+      message.browser_id = crawlID ?? null;
+      message.success = true;
+      storageController?.send(JSON.stringify(["meta_information", message]));
       visitID = null;
       break;
     default:
       // Just making sure that it's a valid number before logging
-      newVisitID = parseInt(data, 10);
+      newVisitID = parseInt(String(data), 10);
       logDebug("Setting visit_id the legacy way");
       visitID = newVisitID;
   }
 };
+/** A network endpoint as a `[host, port]` tuple. */
+type SocketAddress = [host: string, port: number];
+
 export const open = async function (
-  storageControllerAddress: any[],
-  logAddress: any[],
+  storageControllerAddress: SocketAddress | null,
+  logAddress: SocketAddress | null,
   curr_crawlID: number,
 ) {
   if (
@@ -76,7 +92,7 @@ export const open = async function (
     );
     console.log("StorageController started?", rv);
   }
-  storageController.send(JSON.stringify(`Browser-${crawlID}`));
+  storageController?.send(JSON.stringify(`Browser-${crawlID}`));
   // Listen for incoming urls as visit ids
   listeningSocket = new socket.ListeningSocket(listeningSocketCallback);
   console.log("Starting socket listening for incoming connections.");
@@ -96,7 +112,7 @@ export const close = function () {
   }
 };
 
-const makeLogJSON = function (lvl, msg) {
+const makeLogJSON = function (lvl: number, msg: string) {
   const log_json = {
     name: "Extension-Logger",
     level: lvl,
@@ -110,7 +126,7 @@ const makeLogJSON = function (lvl, msg) {
   return log_json;
 };
 
-export const logInfo = function (msg) {
+export const logInfo = function (msg: string) {
   // Always log to browser console
   console.log(msg);
 
@@ -120,10 +136,10 @@ export const logInfo = function (msg) {
 
   // Log level INFO == 20 (https://docs.python.org/2/library/logging.html#logging-levels)
   const log_json = makeLogJSON(20, msg);
-  logAggregator.send(JSON.stringify(["EXT", JSON.stringify(log_json)]));
+  logAggregator?.send(JSON.stringify(["EXT", JSON.stringify(log_json)]));
 };
 
-export const logDebug = function (msg) {
+export const logDebug = function (msg: string) {
   // Always log to browser console
   console.log(msg);
 
@@ -133,10 +149,10 @@ export const logDebug = function (msg) {
 
   // Log level DEBUG == 10 (https://docs.python.org/2/library/logging.html#logging-levels)
   const log_json = makeLogJSON(10, msg);
-  logAggregator.send(JSON.stringify(["EXT", JSON.stringify(log_json)]));
+  logAggregator?.send(JSON.stringify(["EXT", JSON.stringify(log_json)]));
 };
 
-export const logWarn = function (msg) {
+export const logWarn = function (msg: string) {
   // Always log to browser console
   console.warn(msg);
 
@@ -146,10 +162,10 @@ export const logWarn = function (msg) {
 
   // Log level WARN == 30 (https://docs.python.org/2/library/logging.html#logging-levels)
   const log_json = makeLogJSON(30, msg);
-  logAggregator.send(JSON.stringify(["EXT", JSON.stringify(log_json)]));
+  logAggregator?.send(JSON.stringify(["EXT", JSON.stringify(log_json)]));
 };
 
-export const logError = function (msg) {
+export const logError = function (msg: string) {
   // Always log to browser console
   console.error(msg);
 
@@ -159,10 +175,10 @@ export const logError = function (msg) {
 
   // Log level INFO == 40 (https://docs.python.org/2/library/logging.html#logging-levels)
   const log_json = makeLogJSON(40, msg);
-  logAggregator.send(JSON.stringify(["EXT", JSON.stringify(log_json)]));
+  logAggregator?.send(JSON.stringify(["EXT", JSON.stringify(log_json)]));
 };
 
-export const logCritical = function (msg) {
+export const logCritical = function (msg: string) {
   // Always log to browser console
   console.error(msg);
 
@@ -172,21 +188,32 @@ export const logCritical = function (msg) {
 
   // Log level CRITICAL == 50 (https://docs.python.org/2/library/logging.html#logging-levels)
   const log_json = makeLogJSON(50, msg);
-  logAggregator.send(JSON.stringify(["EXT", JSON.stringify(log_json)]));
+  logAggregator?.send(JSON.stringify(["EXT", JSON.stringify(log_json)]));
 };
 
+/**
+ * The bookkeeping fields this module reads or stamps onto every record before
+ * persisting it. Instruments build concrete, fully typed records (e.g.
+ * `JavascriptCookieRecord`); we view them through this narrow shape.
+ */
+interface InstrumentRecordFields {
+  visit_id?: number | null;
+  url?: string;
+}
+
 export const dataReceiver = {
-  saveRecord(a, b) {
-    console.log(a, b);
+  saveRecord(instrument: string, record: object) {
+    console.log(instrument, record);
   },
 };
 
-export const saveRecord = function (instrument, record) {
-  record.visit_id = visitID;
+export const saveRecord = function (instrument: string, record: object) {
+  const fields = record as InstrumentRecordFields;
+  fields.visit_id = visitID;
 
   if (!visitID && !debugging) {
     // Navigations to about:blank can be triggered by OpenWPM. We drop those.
-    if (instrument === "navigations" && record.url === "about:blank") {
+    if (instrument === "navigations" && fields.url === "about:blank") {
       logDebug(
         "Extension-" +
           crawlID +
@@ -198,7 +225,7 @@ export const saveRecord = function (instrument, record) {
       `Extension-${crawlID} : visitID is null while attempting to insert into table ${instrument}\n` +
         JSON.stringify(record),
     );
-    record.visit_id = -1;
+    fields.visit_id = -1;
   }
 
   // send to console if debugging
@@ -206,11 +233,14 @@ export const saveRecord = function (instrument, record) {
     console.log("EXTENSION", instrument, record);
     return;
   }
-  storageController.send(JSON.stringify([instrument, record]));
+  storageController?.send(JSON.stringify([instrument, record]));
 };
 
 // Stub for now
-export const saveContent = async function (content, contentHash) {
+export const saveContent = async function (
+  content: string | Uint8Array,
+  contentHash: string,
+) {
   // Send page content to the data aggregator
   // deduplicated by contentHash in a levelDB database
   if (debugging) {
@@ -219,37 +249,40 @@ export const saveContent = async function (content, contentHash) {
   }
   // Since the content might not be a valid utf8 string and it needs to be
   // json encoded later, it is encoded using base64 first.
-  const b64 = Uint8ToBase64(content);
-  storageController.send(JSON.stringify(["page_content", [b64, contentHash]]));
+  const bytes =
+    typeof content === "string" ? new TextEncoder().encode(content) : content;
+  const b64 = Uint8ToBase64(bytes);
+  storageController?.send(JSON.stringify(["page_content", [b64, contentHash]]));
 };
 
-function encode_utf8(s) {
+function encode_utf8(s: string): string {
   return unescape(encodeURIComponent(s));
 }
 
 // Base64 encoding, found on:
 // https://stackoverflow.com/questions/12710001/how-to-convert-uint8-array-to-base64-encoded-string/25644409#25644409
-function Uint8ToBase64(u8Arr) {
+function Uint8ToBase64(u8Arr: Uint8Array): string {
   const CHUNK_SIZE = 0x8000; // arbitrary number
   let index = 0;
   const length = u8Arr.length;
   let result = "";
-  let slice;
+  let slice: Uint8Array;
   while (index < length) {
     slice = u8Arr.subarray(index, Math.min(index + CHUNK_SIZE, length));
-    result += String.fromCharCode.apply(null, slice);
+    // Uint8Array is array-like; cast avoids a per-chunk Array.from allocation.
+    result += String.fromCharCode.apply(null, slice as unknown as number[]);
     index += CHUNK_SIZE;
   }
   return btoa(result);
 }
 
-export const escapeString = function (string) {
+export const escapeString = function (string: unknown): string {
   // Convert to string if necessary
-  if (typeof string !== "string") string = "" + string;
+  const asString = typeof string === "string" ? string : "" + string;
 
-  return encode_utf8(string);
+  return encode_utf8(asString);
 };
 
-export const boolToInt = function (bool) {
+export const boolToInt = function (bool: boolean): number {
   return bool ? 1 : 0;
 };

--- a/Extension/src/schema.ts
+++ b/Extension/src/schema.ts
@@ -107,7 +107,9 @@ export interface HttpRedirect {
   old_request_url?: string;
   old_request_id?: string;
   new_request_url?: string;
-  new_request_id?: string;
+  // redirectRequestId is not exposed by the WebExtension API, so this is
+  // always null; null is persisted as SQL NULL.
+  new_request_id?: string | null;
   extension_session_uuid?: string;
   event_ordinal?: number;
   window_id?: number;

--- a/Extension/src/socket.ts
+++ b/Extension/src/socket.ts
@@ -16,9 +16,9 @@ const DataReceiver = {
 browser.sockets.onDataReceived.addListener(DataReceiver.onDataReceived);
 
 export class ListeningSocket {
-  callback: any;
-  port: number;
-  constructor(callback) {
+  callback: (data: unknown) => void;
+  port!: number; // assigned in startListening()
+  constructor(callback: (data: unknown) => void) {
     this.callback = callback;
   }
 
@@ -31,7 +31,7 @@ export class ListeningSocket {
 }
 
 export class SendingSocket {
-  id: number;
+  id!: number; // assigned in connect()
 
   async connect(host: string, port: number) {
     this.id = await browser.sockets.createSendingSocket();
@@ -44,7 +44,7 @@ export class SendingSocket {
       browser.sockets.sendData(this.id, aData, !!aJSON);
       return true;
     } catch (err) {
-      console.error(err, err.message);
+      console.error(err, err instanceof Error ? err.message : String(err));
       return false;
     }
   }

--- a/Extension/src/types/javascript-instrument.d.ts
+++ b/Extension/src/types/javascript-instrument.d.ts
@@ -6,6 +6,7 @@ export interface openWpmContentScriptConfig {
 }
 declare global {
   interface Window {
-    openWpmContentScriptConfig: openWpmContentScriptConfig;
+    // Optional: the content script deletes it after reading it.
+    openWpmContentScriptConfig?: openWpmContentScriptConfig;
   }
 }

--- a/Extension/tsconfig.json
+++ b/Extension/tsconfig.json
@@ -9,15 +9,10 @@
     "inlineSourceMap": true,
     "esModuleInterop": true /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */,
 
-    // "strict": true /* Enable all strict type-checking options. */,
-
-    /* Strict Type-Checking Options */
-    // "noImplicitAny": true /* Raise error on expressions and declarations with an implied 'any' type. */,
-    // "strictNullChecks": true /* Enable strict null checks. */,
-    // "strictFunctionTypes": true /* Enable strict checking of function types. */,
-    // "strictPropertyInitialization": true /* Enable strict checking of property initialization in classes. */,
-    // "noImplicitThis": true /* Raise error on 'this' expressions with an implied 'any' type. */,
-    // "alwaysStrict": true /* Parse in strict mode and emit "use strict" for each source file. */,
+    // TypeScript 6 makes `strict` default to true. We set it explicitly to
+    // acknowledge that new default and keep the stricter checks enabled as a
+    // quality guardrail rather than opting back out with `strict: false`.
+    "strict": true /* Enable all strict type-checking options. */,
 
     /* Additional Checks */
     "noUnusedLocals": true /* Report errors on unused locals. */,

--- a/scripts/update.py
+++ b/scripts/update.py
@@ -229,29 +229,19 @@ def npm_bump_and_resolve(cwd: Path) -> None:
     run("git", "checkout", "--", "package.json", cwd=cwd)
 
     # Rewrite package.json with the latest published versions of all deps.
-    # typescript is pinned to 5.x: TS 6 enables stricter inference defaults
-    # (TS7006/TS7008/TS2564/TS18046) that surface ~200 latent type issues
-    # in Extension/src. Migration tracked in #1168; until that lands the
-    # bumper stays inside 5.x.
     #
-    # @babel/* is held at 7.x: Babel 8 is a major with its own migration
-    # (config/preset changes). Hold the trio together — bumping preset-env to
-    # 8 while core/cli stay on 7 leaves an uninstallable peer state. Bump them
-    # together once a babel-8 migration is done.
-    #
-    # eslint is held at 9.x: @microsoft/eslint-plugin-sdl (latest 1.1.0) peers
-    # eslint ^9, so bumping to eslint 10 leaves an uninstallable peer state.
-    # eslint 10 needs its own migration (flat-config / API changes); bump once
-    # eslint-plugin-sdl ships an eslint-10-compatible release. eslint-plugin-
-    # unicorn is held alongside it: unicorn 67 peers eslint >=10.4, so it must
-    # stay on its eslint-9-compatible line (64.x) until eslint moves to 10.
+    # @microsoft/eslint-plugin-sdl is held at 1.x: its latest (1.1.0) peers
+    # eslint ^9. We run it under eslint 10 via an npm "overrides" entry that
+    # relaxes its peer range; the plugin's rules are plain AST visitors and
+    # function unchanged. Drop the reject (and the override) once SDL ships an
+    # eslint-10-compatible release.
     conda_run(
         "npx",
         "--yes",
         "npm-check-updates",
         "--upgrade",
         "--reject",
-        "typescript,@babel/core,@babel/cli,@babel/preset-env,eslint,eslint-plugin-unicorn",
+        "@microsoft/eslint-plugin-sdl",
         cwd=cwd,
     )
 


### PR DESCRIPTION
## Summary

Kicks off the "great JS/TS deps major upgrade" by un-holding and bumping the
toolchain majors that were previously pinned to avoid fighting the v0.35.0
release. **Stricter checks introduced by the bumps are kept enabled and the
code is fixed to satisfy them** (no rules disabled, no tsconfig loosened).

Dependency bumps + tool-config migration are complete and green, and the
TypeScript 6 strict-mode code migration is now **complete**: all 214
strict-mode errors are fixed and the full build (`tsc -p` → webpack → web-ext)
is green.

## Per-tool status

| Tool | From | To | Status |
|------|------|-----|--------|
| TypeScript | 5.9.x | **6.0.3** | ✅ done — strict default surfaced 214 latent errors; all fixed, full build green |
| @babel/{core,cli,preset-env} | 7.x | **8.x** | ✅ done — `babel.config.json` needs no changes; preset-env 8 builds the existing config cleanly |
| eslint | 9 | **10.5.0** | ✅ done — flat config loads unchanged; 1 new rule violation fixed |
| eslint-plugin-unicorn | 64 | **67** | ✅ done — moves with eslint (peers `eslint >=10.4`) |
| @eslint/js | 9 | **10** | ✅ done |
| @microsoft/eslint-plugin-sdl | 1.1.0 | 1.1.0 | ✅ works under eslint 10 via override (see below) |

## SDL / eslint-10 blocker verdict: **works-with-override**

`@microsoft/eslint-plugin-sdl`'s latest (1.1.0, Feb 2025) still declares
`peerDependencies: { eslint: "^9" }`, and no newer/prerelease version exists.
The peer constraint is **overly strict**: the plugin's rules are plain AST
visitors with no dependency on eslint-9-only internals.

Verified it actually functions under eslint 10 by inspecting the resolved
config — **9 SDL security rules are active** (`no-cookies`,
`no-document-domain`, `no-document-write`, `no-html-method`, …). It is run
under eslint 10 via an npm `overrides` entry that relaxes its peer range
(rather than force-installing past the peer or dropping the security linter).

`eslint-plugin-import@2.32.0` has the same overly-strict `^9` peer and gets the
same override; it too loads fine. (The maintained fork `eslint-plugin-import-x`
already supports eslint 10 and is the eventual clean replacement if the
override becomes undesirable.)

**No decision is strictly required** to proceed, but the override should be
removed once SDL ships an eslint-10-compatible release. Tracking comment left
in `scripts/update.py`.

## Measured scope

### TypeScript 6 — the real change
TS 6 makes `strict: true` the **default**. This project's `tsconfig.json` had
`strict` commented out, which TS 6 now reads as strict-on. Per the directive we
made `strict: true` **explicit** (keeping the guardrail) rather than setting
`strict: false`. That surfaces **214 latent strict-mode errors** that 5.x was
silently ignoring.

Initial breakdown (214):
- `TS7006` implicit-any parameter ×76
- `TS7005`/`TS7034` variable implicitly any ×51/14
- `TS2564` property no initializer ×15
- `TS2345`/`TS2322` assignability ×11/7
- `TS18048`/`TS18046`/`TS18047` possibly undefined / unknown ×11/6/2
- `TS2683` implicit-any `this` ×6
- others ×16

### eslint 10 — 1 new violation
`no-useless-assignment` (new recommended rule): dead initializer
`let url = ""` in `http-instrument.ts` where every branch reassigns. Fixed by
converting to early returns.

### babel 8 — 0 config changes
`babel.config.json` (`presets: ["@babel/preset-env"]`) builds unchanged.

## What this PR fixes (all 214 errors, full build green)

First pass (~63 errors):
- `cookie-instrument.ts`, `dns-instrument.ts` — typed `dataReceiver`/`crawlID`/listeners
- `string-utils.ts`, `uuid.ts`, `http-post-parser.ts`, `socket.ts` — implicit-any params, dead-typed arrays, `unknown` catch vars, definite-assignment
- `pending-{request,navigation,response}.ts`, `response-body-listener.ts` — definite-assignment `!` on props assigned synchronously inside Promise executors; typed timeout params
- `callstack-instrument.ts`, `content/javascript-instrument-content-scope.ts`, `content.ts` (via `.d.ts`) — typed listeners/messages; made the deleted global optional
- New shared `src/lib/data-receiver.ts` `DataReceiver` interface replaces the implicit-any `dataReceiver` constructor params

Final pass (remaining 151 errors), in dependency order:
- `src/loggingdb.ts` (46) — typed module state (`crawlID`/`visitID`/socket holders), the socket control-message payload, log helpers, and the `saveRecord`/`saveContent` payloads; null-guarded the optional sockets
- `src/background/http-instrument.ts` (26) — typed the webRequest event-listener fields and handlers, narrowed nullable tab/header values, and handled `unknown` catch errors
- `src/background/navigation-instrument.ts` (9) and `src/background/javascript-instrument.ts` (14) — adopted the shared `DataReceiver` interface and typed listeners, senders, and message payloads
- `src/lib/js-instruments.ts` (49) — added `InstrumentMessage`/`JSLogMessageContent`/`CallContext` types, typed the debounce/serialize/instrument helpers, and a typed log counter
- `src/content/javascript-instrument-page-scope.ts` (7) — typed the injected page-script entrypoint via type-only imports

## Validation

- `npx tsc --noEmit`: **0 errors** (down from 214)
- `npm run build` (tsc `build:main` → webpack → web-ext): **green**
- `npm run lint` (eslint 10 + prettier + web-ext): **eslint clean, prettier clean**
- `babel`: builds with existing config
- `jj`-precommit (black/isort/mypy/actionlint/env-pins): **pass**

## Directive compliance

Per the upgrade directive, **no eslint rule was disabled and no tsconfig
strictness was loosened** to go green. `strict: true` was made explicit to
preserve the new TS-6 default as a guardrail. No `any` was introduced except at
the pre-existing dynamic-instrumentation boundary in `js-instruments.ts` (the
property-proxy receivers and arbitrary instrumented objects, matching the
file's established `object: any`/`func: any` convention); no `ts-ignore` /
`ts-expect-error` was used. Definite-assignment `!` is used only where
assignment is provably synchronous (Promise executors).

