### PR TITLE
feat: bidirectional sockets stacked on hardened socket base (stacks on #1180)

### DIFF
--- a/Extension/bundled/privileged/sockets/api.js
+++ b/Extension/bundled/privileged/sockets/api.js
@@ -19,6 +19,9 @@ const gManager = {
   sendingSocketMap: new Map(),
   nextSendingSocketId: 0,
   onDataReceivedListeners: new Set(),
+  // Map of connectionId -> { stream, bOutputStream } for accepted connections
+  connectionMap: new Map(),
+  nextConnectionId: 0,
 };
 
 let bufferpack;
@@ -32,6 +35,56 @@ function writeAll(bOutputStream, bytes) {
   bOutputStream.writeByteArray(bytes, bytes.length);
 }
 
+// Narrow an already-encoded byte-string (each char in 0-255, as produced by
+// escapeString()/encode_utf8() in Extension/src/lib/string-utils.ts) into a
+// Uint8Array of raw bytes. Running TextEncoder over this already-UTF-8 string
+// would double-encode it; assigning into a Uint8Array applies ToUint8 (mod
+// 256), so each already-byte-sized char code lands as the intended raw byte.
+function toBytes(data) {
+  const bytes = new Uint8Array(data.length);
+  for (let i = 0; i < data.length; i++) {
+    bytes[i] = data.charCodeAt(i);
+  }
+  return bytes;
+}
+
+// Pack the length-prefixed header for a payload of `byteLength` bytes. The
+// length field is a big-endian u32 (`>L`); bufferpack silently clamps
+// out-of-range values, which would emit a wrong length and permanently desync
+// the stream. Reject oversized payloads instead.
+function packHeader(byteLength, serializationSymbol) {
+  if (byteLength > 0xffffffff) {
+    throw new Error(
+      `Payload of ${byteLength} bytes exceeds the u32 length ` +
+        `field (max ${0xffffffff}); refusing to send to avoid ` +
+        `framing desync.`,
+    );
+  }
+  return bufferpack.pack(">Lc", [byteLength, serializationSymbol]);
+}
+
+/**
+ * Write a length-prefixed message to a connection's output stream.
+ *
+ * The wire format matches the Python `socket_interface` framing: a 4-byte
+ * big-endian length, a 1-byte serialization tag, then the payload.
+ *
+ * `conn` is a `{ stream, bOutputStream }` pair as stored in `sendingSocketMap`
+ * (outbound connections) or `connectionMap` (replies on accepted connections).
+ *
+ * `data` is an already-encoded byte-string (see `toBytes`); framing on the
+ * narrowed byte length keeps the prefix consistent with the bytes on the wire
+ * for non-ASCII payloads too. Both the header and the payload go through
+ * `writeAll` on the blocking binary stream so a frame can never be partially
+ * written (which would desync the length-prefixed stream).
+ */
+function writeFramedMessage(conn, data, json) {
+  const serializationSymbol = json ? "j" : "n";
+  const bytes = toBytes(data);
+  const header = packHeader(bytes.length, serializationSymbol);
+  writeAll(conn.bOutputStream, header);
+  writeAll(conn.bOutputStream, bytes);
+}
 this.sockets = class extends ExtensionAPI {
   getAPI(context) {
     if (!bufferpack) {
@@ -61,6 +114,29 @@ this.sockets = class extends ExtensionAPI {
           socket.asyncListen({
             onSocketAccepted: (sock, transport) => {
               const inputStream = transport.openInputStream(0, 0, 0);
+              // Open the reply stream in blocking mode (the default flag 0
+              // would yield a non-blocking stream whose write() can throw
+              // NS_BASE_STREAM_WOULD_BLOCK). Replies are tiny and the peer is
+              // a localhost socket that is actively reading, so a blocking
+              // write returns immediately; this mirrors the outbound
+              // `connect()` stream below.
+              const outputStream = transport.openOutputStream(
+                Ci.nsITransport.OPEN_BLOCKING,
+                0,
+                0,
+              );
+
+              gManager.nextConnectionId++;
+              const connectionId = gManager.nextConnectionId;
+              const bOutputStream = Cc[
+                "@mozilla.org/binaryoutputstream;1"
+              ].createInstance(Ci.nsIBinaryOutputStream);
+              bOutputStream.setOutputStream(outputStream);
+              gManager.connectionMap.set(connectionId, {
+                stream: outputStream,
+                bOutputStream,
+              });
+
               const socketListener = {
                 onInputStreamReady: () => {
                   try {
@@ -70,6 +146,18 @@ this.sockets = class extends ExtensionAPI {
                       // Abnormal close, let's log the error.
                       console.error(e);
                     }
+                    // Connection closed: close the paired output stream so we
+                    // don't leak it, then drop the bookkeeping entry.
+                    const conn = gManager.connectionMap.get(connectionId);
+                    if (conn) {
+                      try {
+                        conn.stream.close();
+                      } catch {
+                        // Already closed by the peer; nothing to do.
+                      }
+                    }
+                    inputStream.close();
+                    gManager.connectionMap.delete(connectionId);
                     return;
                   }
                   const bis = Cc[
@@ -99,12 +187,12 @@ this.sockets = class extends ExtensionAPI {
                       new Uint8Array(payloadBytes),
                     );
                     gManager.onDataReceivedListeners.forEach((listener) => {
-                      listener(port, string, tag === "j");
+                      listener(port, string, tag === "j", connectionId);
                     });
                   } else if (tag === "n") {
                     const rawBytes = new Uint8Array(payloadBytes);
                     gManager.onDataReceivedListeners.forEach((listener) => {
-                      listener(port, rawBytes, false);
+                      listener(port, rawBytes, false, connectionId);
                     });
                   } else {
                     console.error(`Unsupported serialization type ('${tag}').`);
@@ -122,8 +210,8 @@ this.sockets = class extends ExtensionAPI {
           context,
           name: "sockets.onDataReceived",
           register: (fire) => {
-            const listener = (id, data, is_json) => {
-              fire.async(id, data, is_json);
+            const listener = (id, data, is_json, connectionId) => {
+              fire.async(id, data, is_json, connectionId);
             };
             gManager.onDataReceivedListeners.add(listener);
             return () => {
@@ -131,6 +219,27 @@ this.sockets = class extends ExtensionAPI {
             };
           },
         }).api(),
+
+        sendResponse(connectionId, data, json) {
+          if (!gManager.connectionMap.has(connectionId)) {
+            console.error(
+              "Unknown connection ID for sendResponse; connection may have closed.",
+            );
+            return false;
+          }
+
+          try {
+            writeFramedMessage(
+              gManager.connectionMap.get(connectionId),
+              data,
+              json,
+            );
+            return true;
+          } catch (err) {
+            console.error(err, err.message);
+            return false;
+          }
+        },
 
         async createSendingSocket() {
           gManager.nextSendingSocketId++;
@@ -181,45 +290,17 @@ this.sockets = class extends ExtensionAPI {
             return false;
           }
 
-          const socket = gManager.sendingSocketMap.get(id);
           try {
-            const serializationSymbol = json ? "j" : "n";
-            // `data` is ALREADY a byte-string, NOT a Unicode string. Every
-            // caller funnels payloads through escapeString()/encode_utf8()
-            // (see Extension/src/lib/string-utils.ts), which converts the
-            // source text to UTF-8 and exposes each byte as a Latin-1 char
-            // (code points 0-255); binary POST bodies arrive the same way. The
-            // bytes we must put on the wire are therefore exactly those char
-            // codes narrowed to one byte each -- this is the lossless byte
-            // pass-through the Python reader (socket_interface._parse) decodes
-            // as UTF-8. Running TextEncoder over this already-encoded
-            // byte-string would double-encode it (the UTF-8 of "你好" turns
-            // into the UTF-8 of "ä½\xa0å¥½" mojibake), so we narrow instead of
-            // re-encode (api.js narrows each char to a byte below). Framing on
-            // bytes.length (== data.length here, since every char is one byte)
-            // keeps the length prefix consistent with the payload.
-            // Assigning into a Uint8Array applies ToUint8 (mod 256), so each
-            // already-byte-sized char code lands as the intended raw byte.
-            const bytes = new Uint8Array(data.length);
-            for (let i = 0; i < data.length; i++) {
-              bytes[i] = data.charCodeAt(i);
-            }
-            // The length field is a big-endian u32 (`>L`); bufferpack silently
-            // clamps out-of-range values, which would emit a wrong length and
-            // permanently desync the stream. Reject oversized payloads instead.
-            if (bytes.length > 0xffffffff) {
-              throw new Error(
-                `Payload of ${bytes.length} bytes exceeds the u32 length ` +
-                  `field (max ${0xffffffff}); refusing to send to avoid ` +
-                  `framing desync.`,
-              );
-            }
-            const buff = bufferpack.pack(">Lc", [
-              bytes.length,
-              serializationSymbol,
-            ]);
-            writeAll(socket.bOutputStream, buff);
-            writeAll(socket.bOutputStream, bytes);
+            // Outbound framing shares the hardened code path with replies:
+            // `data` is an already-encoded byte-string (each char in 0-255 via
+            // escapeString()/encode_utf8() in Extension/src/lib/string-utils.ts;
+            // binary POST bodies arrive the same way). writeFramedMessage()
+            // narrows those char codes back to raw bytes -- re-encoding with
+            // TextEncoder would double-encode and corrupt non-ASCII payloads --
+            // frames on the narrowed byte length, rejects payloads over the u32
+            // length field, and writes header+payload through writeAll() on the
+            // blocking stream so a frame can never be partially written.
+            writeFramedMessage(gManager.sendingSocketMap.get(id), data, json);
             return true;
           } catch (err) {
             console.error(err, err.message);

--- a/Extension/bundled/privileged/sockets/schema.json
+++ b/Extension/bundled/privileged/sockets/schema.json
@@ -73,6 +73,25 @@
             "name": "id"
           }
         ]
+      },
+      {
+        "name": "sendResponse",
+        "type": "function",
+        "async": false,
+        "parameters": [
+          {
+            "type": "number",
+            "name": "connectionId"
+          },
+          {
+            "type": "string",
+            "name": "data"
+          },
+          {
+            "type": "boolean",
+            "name": "json"
+          }
+        ]
       }
     ],
     "events": [
@@ -91,6 +110,10 @@
           {
             "type": "boolean",
             "name": "json"
+          },
+          {
+            "type": "number",
+            "name": "connectionId"
           }
         ]
       }

--- a/Extension/src/loggingdb.ts
+++ b/Extension/src/loggingdb.ts
@@ -11,6 +11,7 @@ interface VisitControlMessage {
   visit_id?: number;
   browser_id?: number | null;
   success?: boolean;
+  finalize_grace_seconds?: number;
 }
 
 let crawlID: number | null = null;
@@ -20,7 +21,7 @@ let storageController: socket.SendingSocket | null = null;
 let logAggregator: socket.SendingSocket | null = null;
 let listeningSocket: socket.ListeningSocket | null = null;
 
-const listeningSocketCallback = async (data: unknown) => {
+const listeningSocketCallback = async (data: unknown, respond: socket.RespondFn) => {
   // This works even if data is an int
   const message = data as VisitControlMessage;
   const action = message.action;
@@ -34,7 +35,7 @@ const listeningSocketCallback = async (data: unknown) => {
       message.browser_id = crawlID ?? null;
       storageController?.send(JSON.stringify(["meta_information", message]));
       break;
-    case "Finalize":
+    case "Finalize": {
       if (!visitID) {
         logWarn("Received Finalize while no visit_id was set");
       }
@@ -46,9 +47,33 @@ const listeningSocketCallback = async (data: unknown) => {
       }
       message.browser_id = crawlID ?? null;
       message.success = true;
+      // BrowserManager has already torn down the visit's tab, but events
+      // captured just before that can still be in flight (content script ->
+      // background messaging, late webRequest callbacks). Keep visitID set
+      // during a short grace period so those stragglers are still attributed
+      // to this visit -- this is what the old Python-side pre-Finalize sleep
+      // achieved, except the wait now happens in the event loop that actually
+      // drains the stragglers rather than in an idle Python sleep.
+      //
+      // No fallback is needed for a missing finalize_grace_seconds: the
+      // extension xpi is built from, and shipped inside, the same repo commit
+      // as the Python that drives it (see install.sh / scripts/build-extension),
+      // so the two never disagree on the control-socket message shape.
+      const graceMs = message.finalize_grace_seconds! * 1000;
+      delete message.finalize_grace_seconds;
+      await new Promise((resolve) => setTimeout(resolve, graceMs));
+      // Grace elapsed: meta_information is the visit's last record, so the
+      // storage controller sees it only after every straggler. Clear the
+      // visit, then acknowledge -- the ack means "visit fully finalized".
       storageController?.send(JSON.stringify(["meta_information", message]));
       visitID = null;
+      respond({
+        action: "FinalizeAck",
+        visit_id: newVisitID,
+        success: true,
+      });
       break;
+    }
     default:
       // Just making sure that it's a valid number before logging
       newVisitID = parseInt(String(data), 10);

--- a/Extension/src/socket.ts
+++ b/Extension/src/socket.ts
@@ -1,11 +1,14 @@
 /* eslint-disable max-classes-per-file */
 
+export type RespondFn = (msg: any) => void;
+
 const DataReceiver = {
   callbacks: new Map(),
   onDataReceived: (
     aSocketId: number,
     aData: string | Uint8Array,
     aJSON: boolean,
+    aConnectionId: number,
   ): void => {
     if (!DataReceiver.callbacks.has(aSocketId)) {
       return;
@@ -13,16 +16,19 @@ const DataReceiver = {
     // aJSON is only ever true for the "j" tag, whose payload is a UTF-8
     // string; "n" arrives as a raw Uint8Array and is handed through untouched.
     const data = aJSON ? JSON.parse(aData as string) : aData;
-    DataReceiver.callbacks.get(aSocketId)(data);
+    const respond: RespondFn = (msg: any) => {
+      browser.sockets.sendResponse(aConnectionId, JSON.stringify(msg), true);
+    };
+    DataReceiver.callbacks.get(aSocketId)(data, respond);
   },
 };
 
 browser.sockets.onDataReceived.addListener(DataReceiver.onDataReceived);
 
 export class ListeningSocket {
-  callback: (data: unknown) => void;
+  callback: (data: unknown, respond: RespondFn) => void;
   port!: number; // assigned in startListening()
-  constructor(callback: (data: unknown) => void) {
+  constructor(callback: (data: unknown, respond: RespondFn) => void) {
     this.callback = callback;
   }
 

--- a/Extension/src/types/browser.d.ts
+++ b/Extension/src/types/browser.d.ts
@@ -4,6 +4,7 @@ declare namespace browser.profileDirIO {
 }
 
 declare namespace browser.sockets {
+  export type ConnectionId = number;
   export const onDataReceived: {
     // `data` is a UTF-8 string for the "j"/"u" tags (isJson is true only for
     // "j") and a raw Uint8Array for the "n" (no-serialization) tag, mirroring
@@ -13,6 +14,7 @@ declare namespace browser.sockets {
         socketId: number,
         data: string | Uint8Array,
         isJson: boolean,
+        connectionId: ConnectionId,
       ) => void,
     ): void;
   };
@@ -30,6 +32,11 @@ declare namespace browser.sockets {
   // (e.g. the connection dropped) or the socket id is unknown.
   export function sendData(
     id: SendingSocketId,
+    data: string,
+    json: boolean,
+  ): boolean;
+  export function sendResponse(
+    connectionId: ConnectionId,
     data: string,
     json: boolean,
   ): boolean;

--- a/openwpm/command_sequence.py
+++ b/openwpm/command_sequence.py
@@ -1,7 +1,9 @@
+import math
 from pathlib import Path
 from typing import Callable, List, Optional, Tuple
 
 from .commands.browser_commands import (
+    FINALIZE_ACK_MARGIN,
     BrowseCommand,
     DumpPageSourceCommand,
     FinalizeCommand,
@@ -197,5 +199,13 @@ class CommandSequence:
         """
         commands = list(self._commands_with_timeout)
         commands.insert(0, (InitializeCommand(), 10))
-        commands.append((FinalizeCommand(sleep=5), 10))
+        # FinalizeCommand.execute() blocks up to ``sleep + FINALIZE_ACK_MARGIN``
+        # seconds waiting for the extension's FinalizeAck. The command timeout
+        # MUST exceed that bound (plus headroom for the command-queue handoff),
+        # otherwise the watchdog would kill a healthy browser that is still
+        # draining in-flight events before its ack arrives. Derive both from the
+        # same constants so they cannot silently drift apart.
+        finalize_sleep = 5
+        finalize_timeout = math.ceil(finalize_sleep + FINALIZE_ACK_MARGIN) + 5
+        commands.append((FinalizeCommand(sleep=finalize_sleep), finalize_timeout))
         return commands

--- a/openwpm/commands/browser_commands.py
+++ b/openwpm/commands/browser_commands.py
@@ -3,6 +3,8 @@ import json
 import logging
 import os
 import random
+import socket
+import struct
 import sys
 import time
 import traceback
@@ -37,6 +39,16 @@ from .utils.webdriver_utils import (
 NUM_MOUSE_MOVES = 10  # Times to randomly move the mouse
 RANDOM_SLEEP_LOW = 1  # low (in sec) for random sleep between page loads
 RANDOM_SLEEP_HIGH = 7  # high (in sec) for random sleep between page loads
+# Slack added on top of the extension-side finalize grace period when waiting
+# for a FinalizeAck: covers the control-socket round trip and the extension
+# handing the visit's meta_information to the storage controller.
+#
+# INVARIANT: FinalizeCommand.execute() blocks for up to
+# ``grace + FINALIZE_ACK_MARGIN`` seconds. The FinalizeCommand's per-command
+# timeout (set in CommandSequence.get_commands_with_timeout) MUST stay strictly
+# greater than this, or the watchdog will kill a healthy browser mid-drain.
+# That timeout is derived from this constant so the two cannot drift apart.
+FINALIZE_ACK_MARGIN = 10.0
 logger = logging.getLogger("openwpm")
 
 
@@ -500,11 +512,61 @@ class FinalizeCommand(BaseCommand):
     ):
         """Informs the extension that a visit is done"""
         tab_restart_browser(webdriver)
-        # This doesn't immediately stop data saving from the current
-        # visit so we sleep briefly before unsetting the visit_id.
-        time.sleep(self.sleep)
-        msg = {"action": "Finalize", "visit_id": self.visit_id}
+        # The extension keeps attributing events to this visit for a short
+        # grace period after Finalize (events can still be in flight once the
+        # tab is torn down). We hand it that grace duration and then block on
+        # its FinalizeAck, so the visit is only considered done once the
+        # extension has flushed meta_information to the storage controller.
+        grace = 0.5 if manager_params.testing else self.sleep
+        msg = {
+            "action": "Finalize",
+            "visit_id": self.visit_id,
+            "finalize_grace_seconds": grace,
+        }
         extension_socket.send(msg)
+
+        deadline = time.monotonic() + grace + FINALIZE_ACK_MARGIN
+        browser_id = browser_params.browser_id
+        try:
+            while True:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    raise socket.timeout()
+                ack = extension_socket.receive(timeout=remaining)
+                # The control socket is strictly request/response, but a
+                # FinalizeAck from a previous visit that timed out could still
+                # be buffered. Only a matching ack ends the wait.
+                if (
+                    isinstance(ack, dict)
+                    and ack.get("action") == "FinalizeAck"
+                    and ack.get("visit_id") == self.visit_id
+                ):
+                    logger.debug(
+                        "BROWSER %s: received FinalizeAck for visit_id %s",
+                        browser_id,
+                        self.visit_id,
+                    )
+                    break
+                logger.warning(
+                    "BROWSER %s: discarding unexpected control-socket message "
+                    "while waiting for FinalizeAck of visit_id %s: %r",
+                    browser_id,
+                    self.visit_id,
+                    ack,
+                )
+        except socket.timeout:
+            logger.warning(
+                "BROWSER %s: timed out waiting for FinalizeAck of visit_id %s; "
+                "proceeding anyway",
+                browser_id,
+                self.visit_id,
+            )
+        except (RuntimeError, ValueError, struct.error):
+            logger.exception(
+                "BROWSER %s: error reading FinalizeAck of visit_id %s",
+                browser_id,
+                self.visit_id,
+            )
 
 
 class InitializeCommand(BaseCommand):

--- a/openwpm/socket_interface.py
+++ b/openwpm/socket_interface.py
@@ -264,6 +264,18 @@ async def get_message_from_reader(reader: asyncio.StreamReader) -> Any:
     return _parse(serialization, msg)
 
 
+async def send_to_writer(writer: asyncio.StreamWriter, msg: Any) -> None:
+    """Send a JSON-serialized message to an asyncio StreamWriter.
+
+    Uses the same wire format as ClientSocket.send() so that
+    ClientSocket can receive responses using the same protocol.
+    """
+    encoded = json.dumps(msg).encode("utf-8")
+    header = struct.pack(">Lc", len(encoded), b"j")
+    writer.write(header + encoded)
+    await writer.drain()
+
+
 def _parse(serialization: bytes, msg: bytes) -> Any:
     # SECURITY NOTE (single-tenant known issue; tracked in
     # https://github.com/openwpm/OpenWPM/issues/1179):

--- a/openwpm/socket_interface.py
+++ b/openwpm/socket_interface.py
@@ -4,6 +4,7 @@ import json
 import socket
 import struct
 import threading
+import time
 import traceback
 from queue import Queue
 from typing import Any
@@ -138,6 +139,12 @@ class ClientSocket:
             raise ValueError("Unsupported serialization type: %s" % serialization)
         self.serialization = serialization
         self.verbose = verbose
+        # Bytes read from the socket but not yet consumed by receive(). Holding
+        # them on the instance keeps the framing synchronized: a timeout part
+        # way through a frame leaves the already-read bytes here for the next
+        # call, and a read that overshoots into the following frame keeps the
+        # surplus rather than discarding it.
+        self._recv_buffer = b""
 
     def connect(self, host, port):
         if self.verbose:
@@ -187,6 +194,50 @@ class ClientSocket:
             if sent == 0:
                 raise RuntimeError("socket connection broken")
             totalsent = totalsent + sent
+
+    def _fill(self, nbytes: int, deadline: float) -> None:
+        """Read until ``self._recv_buffer`` holds at least ``nbytes``.
+
+        Reads stop at ``deadline`` (a ``time.monotonic()`` value). Bytes that
+        have already been read are kept in ``self._recv_buffer`` even when the
+        deadline is hit, so the caller can resume framing on the next call.
+
+        :raises socket.timeout: if the deadline passes before enough bytes
+            have arrived.
+        :raises RuntimeError: if the peer closes the connection.
+        """
+        while len(self._recv_buffer) < nbytes:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise socket.timeout("timed out while reading response")
+            self.sock.settimeout(remaining)
+            chunk = self.sock.recv(4096)
+            if not chunk:
+                raise RuntimeError("socket connection broken")
+            self._recv_buffer += chunk
+
+    def receive(self, timeout: float = 5.0) -> Any:
+        """Read a single response message from the socket.
+
+        Uses the same wire format as :meth:`send`: 4-byte big-endian length +
+        1-byte serialization type + payload. ``timeout`` bounds the whole
+        read; any socket timeout configured before the call is restored
+        afterwards.
+
+        :raises socket.timeout: if no complete message arrives within
+            ``timeout`` seconds.
+        """
+        prev_timeout = self.sock.gettimeout()
+        deadline = time.monotonic() + timeout
+        try:
+            self._fill(5, deadline)
+            msglen, serialization = struct.unpack(">Lc", self._recv_buffer[:5])
+            self._fill(5 + msglen, deadline)
+            frame = self._recv_buffer[: 5 + msglen]
+            self._recv_buffer = self._recv_buffer[5 + msglen :]
+            return _parse(serialization, frame[5:])
+        finally:
+            self.sock.settimeout(prev_timeout)
 
     def close(self):
         self.sock.close()

--- a/openwpm/storage/storage_controller.py
+++ b/openwpm/storage/storage_controller.py
@@ -15,7 +15,7 @@ from multiprocess import Queue
 from openwpm.utilities.multiprocess_utils import Process
 
 from ..config import BrowserParamsInternal, ManagerParamsInternal
-from ..socket_interface import ClientSocket, get_message_from_reader
+from ..socket_interface import ClientSocket, get_message_from_reader, send_to_writer
 from ..types import BrowserId, VisitId
 from .storage_providers import (
     StructuredStorageProvider,
@@ -101,7 +101,7 @@ class StorageController:
         await writer.wait_closed()
 
     async def handler(
-        self, reader: asyncio.StreamReader, _: asyncio.StreamWriter
+        self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter
     ) -> None:
         """Created for every new connection to the Server"""
         client_name = await get_message_from_reader(reader)
@@ -109,7 +109,7 @@ class StorageController:
         while True:
             try:
                 record: Tuple[str, Any] = await get_message_from_reader(reader)
-            except IncompleteReadError:
+            except (IncompleteReadError, OSError):
                 self.logger.info(
                     f"Terminating handler for {client_name}, because the underlying socket closed"
                 )
@@ -149,7 +149,7 @@ class StorageController:
             visit_id = VisitId(data["visit_id"])
 
             if record_type == RECORD_TYPE_META:
-                await self._handle_meta(visit_id, data)
+                await self._handle_meta(visit_id, data, writer)
                 continue
 
             table_name = TableName(record_type)
@@ -170,7 +170,12 @@ class StorageController:
             )
         )
 
-    async def _handle_meta(self, visit_id: VisitId, data: Dict[str, Any]) -> None:
+    async def _handle_meta(
+        self,
+        visit_id: VisitId,
+        data: Dict[str, Any],
+        writer: asyncio.StreamWriter,
+    ) -> None:
         """
         Messages for the table RECORD_TYPE_SPECIAL are meta information
         communicated to the storage controller
@@ -188,6 +193,19 @@ class StorageController:
             success: bool = data["success"]
             completion_token = await self.finalize_visit_id(visit_id, success)
             self.finalize_tasks.append((visit_id, completion_token, success))
+            # Send ack back only if the client requested it.
+            # Writing to a closed connection poisons the asyncio transport,
+            # preventing any further reads on the same connection.
+            if data.get("want_ack"):
+                try:
+                    await send_to_writer(
+                        writer,
+                        {"action": "finalize_ack", "visit_id": visit_id},
+                    )
+                except Exception:
+                    self.logger.debug(
+                        "Failed to send finalize ack for visit_id %d", visit_id
+                    )
         else:
             raise ValueError("Unexpected action: %s", action)
 

--- a/openwpm/storage/storage_controller.py
+++ b/openwpm/storage/storage_controller.py
@@ -427,6 +427,56 @@ class DataSocket:
             )
         )
 
+    def finalize_visit_id_with_ack(
+        self, visit_id: VisitId, success: bool, timeout: float = 10.0
+    ) -> bool:
+        """Send finalize and wait for acknowledgment from StorageController.
+
+        Returns True if ack was received, False on timeout.
+        Falls back gracefully - the finalize is still sent even if
+        the ack is not received.
+
+        This is the data-socket back-channel substrate: it lets a caller block
+        until the StorageController has accepted a visit's finalize, replacing a
+        fixed sleep with a real completion signal. The server side
+        (``_handle_meta``, which answers ``want_ack`` with ``finalize_ack``) is
+        wired; the TaskManager-side caller is intentionally left for a
+        follow-up, because on the current architecture the ``Finalize`` message
+        is emitted by ``FinalizeCommand`` -> extension, not by TaskManager
+        directly. See the bidi-on-hardening PR for the reconciliation note.
+        """
+        self.socket.send(
+            (
+                RECORD_TYPE_META,
+                {
+                    "action": ACTION_TYPE_FINALIZE,
+                    "visit_id": visit_id,
+                    "success": success,
+                    "want_ack": True,
+                },
+            )
+        )
+        # ClientSocket.receive() bounds the wait itself and raises on timeout
+        # or a dropped connection; treat both as "no ack" and fall back rather
+        # than letting the finalize path fail.
+        try:
+            ack = self.socket.receive(timeout=timeout)
+        except (socket.timeout, RuntimeError) as exc:
+            self.logger.debug(
+                "Did not receive finalize ack for visit_id %d (%s)",
+                visit_id,
+                exc,
+            )
+            return False
+        if isinstance(ack, dict) and ack.get("action") == "finalize_ack":
+            return True
+        self.logger.debug(
+            "Did not receive finalize ack for visit_id %d (got: %r)",
+            visit_id,
+            ack,
+        )
+        return False
+
     def close(self) -> None:
         self.socket.close()
 

--- a/test/test_socket_interface.py
+++ b/test/test_socket_interface.py
@@ -21,6 +21,7 @@ encodes real ``str`` objects), exercised by the first two tests below.
 import json
 import socket
 import struct
+import threading
 from typing import Any
 
 import pytest
@@ -199,3 +200,95 @@ def test_send_rejects_oversized_payload() -> None:
             client.close()
     finally:
         server.close()
+
+
+# ---------------------------------------------------------------------------
+# Read-side framing tests for ClientSocket.receive() (the response channel
+# used by the finalize-ack round trips). Exercised against a plain TCP peer.
+# ---------------------------------------------------------------------------
+
+def frame(obj: object, serialization: bytes = b"j") -> bytes:
+    """Encode ``obj`` the way the extension's socket API frames a reply."""
+    payload = json.dumps(obj).encode("utf-8")
+    return struct.pack(">Lc", len(payload), serialization) + payload
+
+
+@pytest.fixture
+def connected_pair():
+    """Yield ``(peer_conn, client)`` for a connected localhost TCP pair."""
+    listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    listener.bind(("localhost", 0))
+    listener.listen(1)
+    host, port = listener.getsockname()
+
+    client = ClientSocket(serialization="json")
+    client.connect(host, port)
+    peer_conn, _ = listener.accept()
+    listener.close()
+    try:
+        yield peer_conn, client
+    finally:
+        peer_conn.close()
+        client.close()
+
+
+def test_receive_single_frame(connected_pair):
+    peer, client = connected_pair
+    peer.sendall(frame({"action": "FinalizeAck", "visit_id": 7}))
+    assert client.receive(timeout=2.0) == {"action": "FinalizeAck", "visit_id": 7}
+
+
+def test_receive_two_frames_in_one_chunk(connected_pair):
+    """A read that overshoots into the next frame keeps the surplus buffered."""
+    peer, client = connected_pair
+    peer.sendall(frame({"visit_id": 1}) + frame({"visit_id": 2}))
+    assert client.receive(timeout=2.0) == {"visit_id": 1}
+    assert client.receive(timeout=2.0) == {"visit_id": 2}
+
+
+def test_partial_frame_timeout_does_not_desync(connected_pair):
+    """A timeout part-way through a frame must not corrupt the next read."""
+    peer, client = connected_pair
+    full = frame({"action": "FinalizeAck", "visit_id": 9})
+
+    peer.sendall(full[:3])  # only part of the 5-byte header
+    with pytest.raises(socket.timeout):
+        client.receive(timeout=0.2)
+
+    peer.sendall(full[3:])  # the remainder arrives later
+    assert client.receive(timeout=2.0) == {"action": "FinalizeAck", "visit_id": 9}
+
+
+def test_receive_restores_prior_socket_timeout(connected_pair):
+    peer, client = connected_pair
+    client.sock.settimeout(3.5)
+    peer.sendall(frame({"ok": True}))
+    client.receive(timeout=1.0)
+    assert client.sock.gettimeout() == 3.5
+
+
+def test_receive_raises_when_peer_closes(connected_pair):
+    peer, client = connected_pair
+    peer.close()
+    with pytest.raises(RuntimeError):
+        client.receive(timeout=2.0)
+
+
+def test_receive_handles_frame_split_across_recv_calls(connected_pair):
+    """A frame delivered in trickled writes is reassembled into one message."""
+    peer, client = connected_pair
+    full = frame({"action": "FinalizeAck", "visit_id": 42})
+
+    def trickle():
+        for byte in full:
+            peer.sendall(bytes([byte]))
+
+    sender = threading.Thread(target=trickle)
+    sender.start()
+    try:
+        assert client.receive(timeout=5.0) == {
+            "action": "FinalizeAck",
+            "visit_id": 42,
+        }
+    finally:
+        sender.join()

--- a/test/test_socket_interface.py
+++ b/test/test_socket_interface.py
@@ -207,6 +207,7 @@ def test_send_rejects_oversized_payload() -> None:
 # used by the finalize-ack round trips). Exercised against a plain TCP peer.
 # ---------------------------------------------------------------------------
 
+
 def frame(obj: object, serialization: bytes = b"j") -> bytes:
     """Encode ``obj`` the way the extension's socket API frames a reply."""
     payload = json.dumps(obj).encode("utf-8")


### PR DESCRIPTION
## Bidirectional sockets, stacked on the hardened socket base

This branch stacks the bidirectional-socket / finalize-ack work **on top of the hardened socket base (#1180)**, producing one coherent branch. It is part of the socket-reliability thread.

**Stacks on #1180 (`fix/socket-hardening`).** Review/merge #1180 first; the diff here is meant to be read against that base, not master.

### What's in the stack (bottom to top)

1. `fix/socket-hardening` — the hardened base (#1180): read-side correctness, UTF-8 framing, `echo_mode` validation, wire-protocol test. *(not owned by this PR)*
2. **extension-to-BrowserManager finalize ack** (from #1174) — rebased onto #1180 and reconciled. Adds the framing-safe `ClientSocket.receive()` (buffered, survives partial-frame timeouts) plus the control-socket `FinalizeAck` round trip (`FinalizeCommand` blocks on the extension's ack instead of a fixed sleep). This is the canonical `receive()` for the whole stack.
3. **StorageController response writing** (from #1129) — `send_to_writer()` and a server-side `finalize_ack` reply: when a data-socket client sets `want_ack`, the StorageController answers once the visit's finalize has been accepted.
4. **`DataSocket.finalize_visit_id_with_ack`** (from #1129) — the client side of that data-socket back-channel: send finalize, block on the ack, fall back gracefully on timeout / dropped connection.

### Finalize-ack reconciliation (#1129 vs #1174)

These are **two finalize-ack channels at different layers**, not duplicates:

- **#1174** acks at the **extension -> BrowserManager** boundary over the *control* socket.
- **#1129** acks at the **StorageController -> data-socket client** boundary over the *data* socket.

The only real overlap was that both added `ClientSocket.receive()`. **#1174's is strictly better** (a persistent `_recv_buffer` keeps framing synced across timeouts and overshoot reads; #1129's `_recv_exactly` discarded bytes on timeout and desynced). I kept #1174's `receive()`, dropped #1129's, and adapted #1129's `finalize_visit_id_with_ack` to #1174's contract (which *raises* `socket.timeout` rather than returning `None`).

On the extension wire (`api.js`), reply framing (`writeFramedMessage`/`sendResponse`) now shares #1180's hardened send path: UTF-8 byte-narrowing, u32 overflow guard, and all-or-throw `writeAll` on the blocking stream. `sendData` delegates to the same helper.

### needs-human: the #1129 TaskManager wiring was dropped

#1129's third commit wired `finalize_visit_id_with_ack` into a `TaskManager.finalize_visit_id` method that came from the **abandoned `refactor/event-driven-completion` branch** (#1129's base, no longer on origin). On current master, **TaskManager does not send finalize at all** — `FinalizeCommand` -> extension does. That commit's premise does not exist here, so it was dropped rather than guessed at.

Consequence: the data-socket back-channel (commits 3-4) is landed as **wired-but-uncalled infrastructure**. The server answers `want_ack`, and the client method exists, but nothing requests an ack yet. This is the substrate a follow-up (Phase 3) will use to replace fixed sleeps with real completion signals. The method docstring records why the caller is deferred. **A human should decide the call site** (extension-driven vs. a new TaskManager-driven finalize).

### Verification

- `jj-precommit` green (isort, black, mypy).
- Extension: `npm ci` + `npm run build` succeed; eslint + prettier clean; web-ext lint clean.
- `test/test_socket_interface.py` (UTF-8 framing + `receive()` framing) and storage-controller/provider tests pass.
- The one real-extension echo test is env-blocked here (no `firefox-bin`), not a code failure.

Draft pending review of the reconciliation and the needs-human call-site decision.
