### PR TITLE
fix(mp_logger): deterministic logger socket drain on shutdown (Phase-3 R5)

### DIFF
--- a/openwpm/mp_logger.py
+++ b/openwpm/mp_logger.py
@@ -7,7 +7,6 @@ import re
 import struct
 import sys
 import threading
-import time
 from pathlib import Path
 from queue import Empty as EmptyQueue
 from typing import Optional
@@ -225,8 +224,12 @@ class MPLogger(object):
             # Check for shutdown
             if not self._status_queue.empty():
                 self._status_queue.get()
-                socket.close()
-                time.sleep(3)  # TODO: the socket needs a better way of closing
+                # Deterministically stop the socket and wait for all client
+                # handler threads to finish draining their in-flight messages
+                # into socket.queue. This replaces a fixed time.sleep(3) that
+                # only *hoped* the queue had filled, which could drop tail log
+                # records (too short) or stall shutdown (too long).
+                socket.shutdown()
                 while not socket.queue.empty():
                     obj = socket.queue.get()
                     self._process_record(obj)

--- a/openwpm/socket_interface.py
+++ b/openwpm/socket_interface.py
@@ -10,9 +10,6 @@ from typing import Any
 
 import dill
 
-# TODO - Implement a cleaner shutdown for server socket
-# see: https://stackoverflow.com/a/1148237
-
 
 class ServerSocket:
     """
@@ -27,6 +24,18 @@ class ServerSocket:
         self.verbose = verbose
         self.name = name
         self.queue = Queue()
+        # Track the accept thread and per-connection handler threads so that
+        # shutdown() can deterministically wait for all in-flight messages to be
+        # drained into `queue` instead of relying on a fixed-duration sleep.
+        self._accept_thread = None
+        self._conn_threads = []
+        self._conn_lock = threading.Lock()
+        # Live client sockets, so shutdown() can force blocked recv() calls to
+        # return and let the handler threads exit promptly.
+        self._clients = set()
+        # Set by shutdown() so the accept loop stops instead of treating the
+        # wakeup connection as a real client.
+        self._shutting_down = False
         if self.verbose:
             print("Server bound to: " + str(self.sock.getsockname()))
 
@@ -36,6 +45,7 @@ class ServerSocket:
         thread.daemon = True  # stops from blocking shutdown
         if self.name is not None:
             thread.name = thread.name + "-" + self.name
+        self._accept_thread = thread
         thread.start()
 
     def _accept(self):
@@ -43,11 +53,6 @@ class ServerSocket:
         while True:
             try:
                 client, address = self.sock.accept()
-                thread = threading.Thread(
-                    target=self._handle_conn, args=(client, address)
-                )
-                thread.daemon = True
-                thread.start()
             except OSError as e:
                 # Only treat genuine teardown of the listening socket as a
                 # normal shutdown. Closing the socket while we are blocked in
@@ -69,6 +74,21 @@ class ServerSocket:
                         )
                     return
                 raise
+            if self._shutting_down:
+                # This is the wakeup connection made by shutdown() to unblock
+                # accept(); it carries no log records. Close it and stop.
+                try:
+                    client.close()
+                except OSError:
+                    pass
+                return
+            with self._conn_lock:
+                self._clients.add(client)
+            thread = threading.Thread(target=self._handle_conn, args=(client, address))
+            thread.daemon = True
+            with self._conn_lock:
+                self._conn_threads.append(thread)
+            thread.start()
 
     def _handle_conn(self, client, address):
         """
@@ -103,9 +123,16 @@ class ServerSocket:
                     )
                     continue
                 self._put_into_queue(msg)
-        except RuntimeError:
+        except (RuntimeError, OSError):
             if self.verbose:
                 print("Client socket: " + str(address) + " closed")
+        finally:
+            with self._conn_lock:
+                self._clients.discard(client)
+            try:
+                client.close()
+            except OSError:
+                pass
 
     def _put_into_queue(self, msg):
         """Put the parsed message into a queue from where it can be read by consumers"""
@@ -122,6 +149,54 @@ class ServerSocket:
 
     def close(self):
         self.sock.close()
+
+    def shutdown(self, timeout=None):
+        """Deterministically stop the server and drain in-flight messages.
+
+        Closes the listening socket so no new connections are accepted, then
+        shuts down every live client socket so that any handler thread blocked
+        in ``recv()`` returns and exits. Finally joins all handler threads.
+
+        Once this returns, every message a client fully sent has been parsed
+        into ``self.queue``; callers can drain the queue with no risk of losing
+        a tail record and without waiting a fixed duration.
+        """
+        # Tell the accept loop to stop, then unblock it. Closing the listening
+        # socket alone does not reliably wake a thread blocked in accept(), so
+        # make a throwaway connection to it: accept() returns, sees the flag,
+        # and exits. This must happen while the socket is still listening.
+        self._shutting_down = True
+        if self._accept_thread is not None:
+            try:
+                wakeup = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+                wakeup.connect(self.sock.getsockname())
+                wakeup.close()
+            except OSError:
+                # Listener already gone; nothing left to wake.
+                pass
+            self._accept_thread.join(timeout)
+
+        # Now no new connections can be accepted; close the listening socket.
+        self.close()
+
+        # Force any handler thread blocked in recv() to wake up and exit by
+        # shutting down the read side of each live client socket.
+        with self._conn_lock:
+            clients = list(self._clients)
+        for client in clients:
+            try:
+                client.shutdown(socket.SHUT_RDWR)
+            except OSError:
+                # Already closed / disconnected by the peer.
+                pass
+
+        # Wait for all handler threads to finish. Each handler appends every
+        # fully-received message to self.queue before it exits, so after these
+        # joins the queue holds every such message.
+        with self._conn_lock:
+            threads = list(self._conn_threads)
+        for thread in threads:
+            thread.join(timeout)
 
 
 class ClientSocket:

--- a/test/test_socket_interface.py
+++ b/test/test_socket_interface.py
@@ -1,26 +1,33 @@
-"""Round-trip tests for the instrumentation socket framing.
+"""Tests for the instrumentation socket (``openwpm.socket_interface``).
 
 These are ``pyonly`` tests: they exercise ``openwpm.socket_interface`` directly
-without a browser or extension. The guarantee under test is that non-ASCII
-records survive the length-prefixed framing intact.
+without a browser or extension. Two concerns are covered:
 
-Wire contract (important, and easy to get wrong): on the JS -> Python data
-path every payload reaches ``sockets.sendData`` as a *byte-string*, not a
-Unicode string. Callers pre-encode their text through ``escapeString`` /
-``encode_utf8`` (``Extension/src/lib/string-utils.ts``), so the chars handed to
-the socket are already the UTF-8 bytes (each char in 0-255). The privileged
-``api.js`` therefore narrows each char to one byte and frames on that count;
-the Python reader decodes the frame as UTF-8. Re-encoding that byte-string with
-``TextEncoder`` on the send side would double-encode it and corrupt every
-non-ASCII record -- the regression these tests pin down.
+* Round-trip framing -- non-ASCII records must survive the length-prefixed
+  framing intact.
 
-The Python ``ClientSocket`` is a separate, genuinely UTF-8-clean path (it
-encodes real ``str`` objects), exercised by the first two tests below.
+  Wire contract (important, and easy to get wrong): on the JS -> Python data
+  path every payload reaches ``sockets.sendData`` as a *byte-string*, not a
+  Unicode string. Callers pre-encode their text through ``escapeString`` /
+  ``encode_utf8`` (``Extension/src/lib/string-utils.ts``), so the chars handed
+  to the socket are already the UTF-8 bytes (each char in 0-255). The privileged
+  ``api.js`` therefore narrows each char to one byte and frames on that count;
+  the Python reader decodes the frame as UTF-8. Re-encoding that byte-string
+  with ``TextEncoder`` on the send side would double-encode it and corrupt every
+  non-ASCII record -- the regression these tests pin down.
+
+  The Python ``ClientSocket`` is a separate, genuinely UTF-8-clean path (it
+  encodes real ``str`` objects), exercised by the first two tests below.
+
+* Deterministic shutdown drain -- after ``ServerSocket.shutdown()`` returns,
+  every message a client fully sent must already be in the queue, with no
+  fixed-duration sleep involved (Phase-3 R5 of the socket-reliability thread).
 """
 
 import json
 import socket
 import struct
+from queue import Empty
 from typing import Any
 
 import pytest
@@ -199,3 +206,71 @@ def test_send_rejects_oversized_payload() -> None:
             client.close()
     finally:
         server.close()
+
+
+def _make_connected_pair():
+    server = ServerSocket(name="test")
+    server.start_accepting()
+    host, port = server.sock.getsockname()
+    client = ClientSocket(serialization="json")
+    client.connect(host, port)
+    return server, client
+
+
+def test_shutdown_drains_all_sent_records():
+    """All messages a client fully sent are queued after shutdown() returns."""
+    server, client = _make_connected_pair()
+
+    n = 500
+    for i in range(n):
+        client.send({"i": i})
+    # Client has finished sending and closes its end, mirroring a child process
+    # that has logged everything and exited before MPLogger.close().
+    client.close()
+
+    # Deterministic drain: bounded join so a wedged handler can't hang the test.
+    server.shutdown(timeout=30)
+
+    received = []
+    while not server.queue.empty():
+        received.append(server.queue.get())
+
+    assert len(received) == n
+    assert sorted(r["i"] for r in received) == list(range(n))
+
+
+def test_shutdown_with_open_client_connection():
+    """shutdown() still completes promptly when the client never closes.
+
+    The handler thread is blocked in recv(); shutdown() must force it to exit by
+    shutting down the client socket, then join it. This mirrors the parent
+    process's own still-attached socket handler at MPLogger.close() time.
+    """
+    server, client = _make_connected_pair()
+
+    for i in range(10):
+        client.send({"i": i})
+
+    # Note: client connection left open on purpose.
+    server.shutdown(timeout=30)
+
+    received = []
+    while not server.queue.empty():
+        received.append(server.queue.get())
+    assert sorted(r["i"] for r in received) == list(range(10))
+
+    # The accept thread and all handler threads must have exited.
+    assert not server._accept_thread.is_alive()
+    for thread in server._conn_threads:
+        assert not thread.is_alive()
+
+    client.close()
+
+
+def test_shutdown_no_clients():
+    """shutdown() is a no-op-safe drain when nothing ever connected."""
+    server = ServerSocket(name="test")
+    server.start_accepting()
+    server.shutdown(timeout=30)
+    with pytest.raises(Empty):
+        server.queue.get_nowait()


### PR DESCRIPTION
## What

Replaces the `time.sleep(3)` wait-and-hope in `MPLogger._start_listener` with a deterministic close-and-await-drain of the logging `ServerSocket`, so no log records are lost on shutdown and there is no fixed-duration stall.

This is **Phase-3 R5** of the socket-reliability thread (the timeout audit's one clean, design-fork-free REPLACE item). It is self-contained and independent of the bidi extension back-channel.

## The problem

On shutdown, `MPLogger` closed the listening socket and then slept 3 seconds, *hoping* any in-flight client messages had landed in `socket.queue` before draining it:

```python
socket.close()
time.sleep(3)  # TODO: the socket needs a better way of closing
while not socket.queue.empty():
    ...
```

`socket.close()` only closes the *listening* socket; the per-connection handler threads stay blocked in `recv()` on their own client sockets. Too short ⇒ tail log records dropped; too long ⇒ shutdown stalls.

## The drain handshake

Added `ServerSocket.shutdown(timeout=None)` to `socket_interface.py`, which makes the drain deterministic:

1. Set a `_shutting_down` flag and make a throwaway self-connection to wake the `accept()` loop (closing the listening socket alone does not reliably unblock a thread parked in `accept()`), then `join` the accept thread. No new connections are accepted past this point.
2. Close the listening socket.
3. `shutdown(SHUT_RDWR)` every live client socket, forcing each handler thread blocked in `recv()` to return and exit.
4. `join` all handler threads.

`ServerSocket` now tracks its accept thread, its per-connection handler threads, and the live client sockets to make this possible. Each handler puts every fully-received message onto `self.queue` before exiting, so once `shutdown()` returns the queue holds every such message — the caller drains it with no risk of losing a tail record and no fixed wait.

`MPLogger._start_listener` now calls `socket.shutdown()` then drains; the `sleep(3)` and the now-unused `time` import are gone.

## Tests

- New `test/test_socket_interface.py`:
  - `test_shutdown_drains_all_sent_records` — 500 messages sent then client closed; all 500 present after `shutdown()`.
  - `test_shutdown_with_open_client_connection` — client left open; `shutdown()` still drains and all threads exit (this caught a real hang where the accept thread did not wake on a bare `close()`).
  - `test_shutdown_no_clients` — drain is safe when nothing connected.
- Existing `test/test_mp_logger.py` (4 tests) still pass; shutdown completes promptly.

`pytest test/test_socket_interface.py test/test_mp_logger.py` → 7 passed. `pre-commit` (isort/black/mypy) green.

Browser-dependent tests are env-blocked locally (FF150 vs 152) and left to CI.

## Scope

Does **not** touch R1–R4 from the timeout audit (those are needs-human / depend on the bidi back-channel).
