### PR TITLE
docs(example): add SetResolution custom-command example (salvaged from #1037)

### DIFF
--- a/custom_command.py
+++ b/custom_command.py
@@ -42,3 +42,49 @@ class LinkCountingCommand(BaseCommand):
         current_url = webdriver.current_url
         link_count = len(webdriver.find_elements(By.TAG_NAME, "a"))
         self.logger.info("There are %d links on %s", link_count, current_url)
+
+
+def get_screen_resolution(webdriver: Firefox) -> list[int]:
+    """Returns the screen resolution [width, height] as seen by the page."""
+    return webdriver.execute_script("return [screen.width, screen.height];")
+
+
+class SetResolution(BaseCommand):
+    """Sets the browser window to a realistic resolution.
+
+    Many crawls run headless or in a virtual framebuffer where the default
+    window size is unusual and easy to fingerprint. Setting a common, realistic
+    resolution makes the browser blend in better with ordinary visitors.
+    """
+
+    # A common desktop resolution; override per-crawl as needed.
+    def __init__(self, width: int = 1920, height: int = 1080) -> None:
+        self.logger = logging.getLogger("openwpm")
+        self.width = width
+        self.height = height
+
+    def __repr__(self) -> str:
+        return f"SetResolution({self.width}, {self.height})"
+
+    def execute(
+        self,
+        webdriver: Firefox,
+        browser_params: BrowserParams,
+        manager_params: ManagerParams,
+        extension_socket: ClientSocket,
+    ) -> None:
+        self.logger.info(
+            "Setting window resolution to %d x %d", self.width, self.height
+        )
+        webdriver.set_window_size(self.width, self.height)
+
+        screen_width, screen_height = get_screen_resolution(webdriver)
+        if self.width > screen_width or self.height > screen_height:
+            self.logger.warning(
+                "Requested window resolution (%d x %d) exceeds the available "
+                "screen resolution (%d x %d); the window may be clamped",
+                self.width,
+                self.height,
+                screen_width,
+                screen_height,
+            )


### PR DESCRIPTION
## What

Adds a `SetResolution` custom-command example to `custom_command.py`, alongside the existing `LinkCountingCommand`. It sets the browser window to a realistic resolution (default 1920x1080) via Selenium's `set_window_size`, with a small `get_screen_resolution` helper and a warning when the requested size exceeds the available screen.

## Why

This salvages the one genuinely useful, generally-applicable bit from the now-closed #1037 branch. The original lived in a `hide_commands/commands.py` module and carried dead imports (`from tkinter import ttk`) plus a stale `BaseCommand.execute` signature (`driver` parameter, deprecated `logger.warn`).

## Changes from the salvaged original

- Modernized to the current `execute(self, webdriver, browser_params, manager_params, extension_socket)` signature (`webdriver`, not `driver`).
- Dropped the unused `from tkinter import ttk` import and the unrelated `SetPosition` command — kept the example minimal and illustrative.
- `logging.warn` → `logging.warning`; lazy `%`-style logging to match the file's existing style.
- Added a sensible default resolution and a descriptive `__repr__` (used for logging, per `BaseCommand` conventions).

No runtime/library behavior changes — this is an example/docs file only.
