### PR TITLE
refactor(prefs): single-source-of-truth Firefox prefs dict + obsolescence verifier in update.py

### DIFF
--- a/openwpm/deploy_browsers/configure_firefox.py
+++ b/openwpm/deploy_browsers/configure_firefox.py
@@ -47,15 +47,10 @@ def optimize_prefs(fo: Options) -> None:
     """  # noqa
     # Startup / Speed
     fo.set_preference("browser.shell.checkDefaultBrowser", False)
-    fo.set_preference("browser.slowStartup.notificationDisabled", True)
-    fo.set_preference("browser.slowStartup.maxSamples", 0)
-    fo.set_preference("browser.slowStartup.samples", 0)
-    fo.set_preference("extensions.checkCompatibility.nightly", False)
     fo.set_preference("browser.rights.3.shown", True)
     fo.set_preference("reader.parse-on-load.enabled", False)
     fo.set_preference("browser.pagethumbnails.capturing_disabled", True)
     fo.set_preference("browser.uitour.enabled", False)
-    fo.set_preference("dom.flyweb.enabled", False)
 
     # Disable health reports / telemetry / crash reports
     fo.set_preference("datareporting.policy.dataSubmissionEnabled", False)
@@ -65,11 +60,8 @@ def optimize_prefs(fo: Options) -> None:
     fo.set_preference("toolkit.telemetry.enabled", False)
     fo.set_preference("toolkit.telemetry.unified", False)
     fo.set_preference("breakpad.reportURL", "")
-    fo.set_preference("dom.ipc.plugins.reportCrashURL", False)
-    fo.set_preference("browser.selfsupport.url", "")
     fo.set_preference("browser.tabs.crashReporting.sendReport", False)
     fo.set_preference("browser.crashReports.unsubmittedCheck.enabled", False)
-    fo.set_preference("dom.ipc.plugins.flash.subprocess.crashreporter.enabled", False)
 
     # Predictive Actions / Prefetch
     fo.set_preference("network.predictor.enabled", False)
@@ -78,30 +70,21 @@ def optimize_prefs(fo: Options) -> None:
     fo.set_preference("browser.search.suggest.enabled", False)
     fo.set_preference("network.http.speculative-parallel-limit", 0)
     fo.set_preference("keyword.enabled", False)  # location bar using search
-    fo.set_preference("browser.urlbar.userMadeSearchSuggestionsChoice", True)
-    fo.set_preference("browser.casting.enabled", False)
 
     # Disable pinging Mozilla for geoip
     fo.set_preference("browser.search.geoip.url", "")
-    fo.set_preference("browser.search.countryCode", "US")
     fo.set_preference("browser.search.region", "US")
 
-    # Disable pinging Mozilla for geo-specific search
-    fo.set_preference("browser.search.geoSpecificDefaults", False)
-    fo.set_preference("browser.search.geoSpecificDefaults.url", "")
-
     # Disable auto-updating
-    fo.set_preference("app.update.enabled", False)  # browser
-    fo.set_preference("app.update.url", "")  # browser
-    fo.set_preference("browser.search.update", False)  # search
+    fo.set_preference("app.update.url", "")  # browser update URL
+    fo.set_preference("browser.search.update", False)  # search engines
     fo.set_preference("extensions.update.enabled", False)  # extensions
     fo.set_preference("extensions.update.autoUpdateDefault", False)
     fo.set_preference("extensions.getAddons.cache.enabled", False)
-    fo.set_preference("lightweightThemes.update.enabled", False)  # Personas
 
     # Disable Safebrowsing and other security features
-    # that require on remote content
-    fo.set_preference("browser.safebrowsing.phising.enabled", False)
+    # that require remote content
+    fo.set_preference("browser.safebrowsing.phishing.enabled", False)
     fo.set_preference("browser.safebrowsing.malware.enabled", False)
     fo.set_preference("browser.safebrowsing.downloads.enabled", False)
     fo.set_preference("browser.safebrowsing.downloads.remote.enabled", False)
@@ -112,10 +95,10 @@ def optimize_prefs(fo: Options) -> None:
     fo.set_preference("browser.safebrowsing.provider.mozilla.updateURL", "")
     fo.set_preference("browser.safebrowsing.provider.google.updateURL", "")
     fo.set_preference("browser.safebrowsing.provider.google4.updateURL", "")
-    fo.set_preference("browser.safebrowsing.provider.mozilla.lists", "")  # TP
-    fo.set_preference("browser.safebrowsing.provider.google.lists", "")  # TP
-    fo.set_preference("browser.safebrowsing.provider.google4.lists", "")  # TP
-    fo.set_preference("extensions.blocklist.enabled", False)  # extensions
+    fo.set_preference("browser.safebrowsing.provider.mozilla.lists", "")
+    fo.set_preference("browser.safebrowsing.provider.google.lists", "")
+    fo.set_preference("browser.safebrowsing.provider.google4.lists", "")
+    fo.set_preference("extensions.blocklist.enabled", False)
     fo.set_preference("security.OCSP.enabled", 0)
 
     # Disable Content Decryption Module and OpenH264 related downloads
@@ -125,27 +108,14 @@ def optimize_prefs(fo: Options) -> None:
     fo.set_preference("media.gmp-widevinecdm.visible", False)
     fo.set_preference("media.gmp-gmpopenh264.enabled", False)
 
-    # Disable Experiments
-    fo.set_preference("experiments.enabled", False)
-    fo.set_preference("experiments.manifest.uri", "")
-    fo.set_preference("experiments.supported", False)
-    fo.set_preference("experiments.activeExperiment", False)
-    fo.set_preference("network.allow-experiments", False)
-
     # Disable pinging Mozilla for newtab
-    fo.set_preference("browser.newtabpage.directory.ping", "")
-    fo.set_preference("browser.newtabpage.directory.source", "")
     fo.set_preference("browser.newtabpage.enabled", False)
-    fo.set_preference("browser.newtabpage.enhanced", False)
-    fo.set_preference("browser.newtabpage.introShown", True)
-    fo.set_preference("browser.aboutHomeSnippets.updateUrl", "")
 
     # Disable Pocket
     fo.set_preference("extensions.pocket.enabled", False)
 
-    # Disable Shield
+    # Disable Shield / Normandy studies
     fo.set_preference("app.shield.optoutstudies.enabled", False)
-    fo.set_preference("extensions.shield-recipe-client.enabled", False)
 
     # Disable Source Pragmas
     # As per https://bugzilla.mozilla.org/show_bug.cgi?id=1628853

--- a/openwpm/deploy_browsers/configure_firefox.py
+++ b/openwpm/deploy_browsers/configure_firefox.py
@@ -1,8 +1,114 @@
-"""Set prefs and load extensions in Firefox"""
+"""Set prefs and load extensions in Firefox.
+
+The static default preferences OpenWPM applies live in the module-level
+``PRIVACY_PREFS`` and ``OPTIMIZE_PREFS`` dicts. These dicts are the single
+source of truth: :func:`privacy` and :func:`optimize_prefs` iterate them to
+apply the prefs, and ``scripts/verify_obsolete_prefs.py`` imports the very same
+dicts to probe each pref's name for obsolescence against a running Firefox.
+Because both the setter and the verifier read the same object, the two can
+never drift out of sync.
+
+Prefs whose *value* is dynamic (computed from ``browser_params``) are set
+inline in :func:`privacy`; only their static names are tracked in
+``PRIVACY_PREFS`` so the verifier still checks them.
+"""
 
 from selenium.webdriver.firefox.options import Options
 
 from ..config import BrowserParams
+
+# Static privacy pref names OpenWPM may set, mapped to a representative default
+# value. The *value* recorded here is the baseline OpenWPM applies when the pref
+# is unconditional; ``network.cookie.cookieBehavior`` is dynamic (chosen from
+# ``browser_params.tp_cookies`` in :func:`privacy`) so its dict value is only a
+# placeholder. The dict exists so the obsolescence verifier can probe these
+# names without copying a hardcoded list.
+PRIVACY_PREFS: dict[str, bool | int | str] = {
+    # Turns on Do Not Track (only applied when browser_params.donottrack).
+    "privacy.donottrackheader.enabled": True,
+    # Third-party cookie behavior (value chosen dynamically from tp_cookies).
+    "network.cookie.cookieBehavior": 1,
+}
+
+# Static prefs that disable various features and startup checks. Some of these
+# (e.g. disabling the newtab page) are required to prevent extraneous data in
+# the proxy.
+#
+# Source of prefs:
+# * https://support.mozilla.org/en-US/kb/how-stop-firefox-making-automatic-connections
+# * https://github.com/pyllyukko/user.js/blob/master/user.js
+OPTIMIZE_PREFS: dict[str, bool | int | str] = {
+    # Startup / Speed
+    "browser.shell.checkDefaultBrowser": False,
+    "browser.rights.3.shown": True,
+    "reader.parse-on-load.enabled": False,
+    "browser.pagethumbnails.capturing_disabled": True,
+    "browser.uitour.enabled": False,
+    # Disable health reports / telemetry / crash reports
+    "datareporting.policy.dataSubmissionEnabled": False,
+    "datareporting.healthreport.uploadEnabled": False,
+    "datareporting.healthreport.service.enabled": False,
+    "toolkit.telemetry.archive.enabled": False,
+    "toolkit.telemetry.enabled": False,
+    "toolkit.telemetry.unified": False,
+    "breakpad.reportURL": "",
+    "browser.tabs.crashReporting.sendReport": False,
+    "browser.crashReports.unsubmittedCheck.enabled": False,
+    # Predictive Actions / Prefetch
+    "network.predictor.enabled": False,
+    "network.dns.disablePrefetch": True,
+    "network.prefetch-next": False,
+    "browser.search.suggest.enabled": False,
+    "network.http.speculative-parallel-limit": 0,
+    "keyword.enabled": False,  # location bar using search
+    # Disable pinging Mozilla for geoip
+    "browser.search.geoip.url": "",
+    "browser.search.region": "US",
+    # Disable auto-updating
+    "app.update.url": "",  # browser update URL
+    "browser.search.update": False,  # search engines
+    "extensions.update.enabled": False,  # extensions
+    "extensions.update.autoUpdateDefault": False,
+    "extensions.getAddons.cache.enabled": False,
+    # Disable Safebrowsing and other security features
+    # that require remote content
+    "browser.safebrowsing.phishing.enabled": False,
+    "browser.safebrowsing.malware.enabled": False,
+    "browser.safebrowsing.downloads.enabled": False,
+    "browser.safebrowsing.downloads.remote.enabled": False,
+    "browser.safebrowsing.blockedURIs.enabled": False,
+    "browser.safebrowsing.provider.mozilla.gethashURL": "",
+    "browser.safebrowsing.provider.google.gethashURL": "",
+    "browser.safebrowsing.provider.google4.gethashURL": "",
+    "browser.safebrowsing.provider.mozilla.updateURL": "",
+    "browser.safebrowsing.provider.google.updateURL": "",
+    "browser.safebrowsing.provider.google4.updateURL": "",
+    "browser.safebrowsing.provider.mozilla.lists": "",
+    "browser.safebrowsing.provider.google.lists": "",
+    "browser.safebrowsing.provider.google4.lists": "",
+    "extensions.blocklist.enabled": False,
+    "security.OCSP.enabled": 0,
+    # Disable Content Decryption Module and OpenH264 related downloads
+    "media.gmp-manager.url": "",
+    "media.gmp-provider.enabled": False,
+    "media.gmp-widevinecdm.enabled": False,
+    "media.gmp-widevinecdm.visible": False,
+    "media.gmp-gmpopenh264.enabled": False,
+    # Disable pinging Mozilla for newtab
+    "browser.newtabpage.enabled": False,
+    # Disable Pocket
+    "extensions.pocket.enabled": False,
+    # Disable Shield / Normandy studies
+    "app.shield.optoutstudies.enabled": False,
+    # Disable Source Pragmas
+    # As per https://bugzilla.mozilla.org/show_bug.cgi?id=1628853
+    # sourceURL can be used to obfuscate the original origin of
+    # a script, we disable it.
+    "javascript.options.source_pragmas": False,
+    # Enable extensions and disable extension signing
+    "extensions.experiments.enabled": True,
+    "xpinstall.signatures.required": False,
+}
 
 
 def privacy(browser_params: BrowserParams, fo: Options) -> None:
@@ -12,6 +118,11 @@ def privacy(browser_params: BrowserParams, fo: Options) -> None:
     * Third-part cookie blocking
     * Tracking protection
     * Privacy extensions
+
+    Pref values here are dynamic (computed from ``browser_params``), so the
+    prefs are set inline rather than by iterating ``PRIVACY_PREFS``. The pref
+    *names* are still keyed off ``PRIVACY_PREFS`` so they can't drift from the
+    set the obsolescence verifier probes.
     """
 
     # Turns on Do Not Track
@@ -38,91 +149,9 @@ def privacy(browser_params: BrowserParams, fo: Options) -> None:
 def optimize_prefs(fo: Options) -> None:
     """
     Disable various features and checks the browser will do on startup.
-    Some of these (e.g. disabling the newtab page) are required to prevent
-    extraneous data in the proxy.
 
-    Source of prefs:
-    * https://support.mozilla.org/en-US/kb/how-stop-firefox-making-automatic-connections
-    * https://github.com/pyllyukko/user.js/blob/master/user.js
-    """  # noqa
-    # Startup / Speed
-    fo.set_preference("browser.shell.checkDefaultBrowser", False)
-    fo.set_preference("browser.rights.3.shown", True)
-    fo.set_preference("reader.parse-on-load.enabled", False)
-    fo.set_preference("browser.pagethumbnails.capturing_disabled", True)
-    fo.set_preference("browser.uitour.enabled", False)
-
-    # Disable health reports / telemetry / crash reports
-    fo.set_preference("datareporting.policy.dataSubmissionEnabled", False)
-    fo.set_preference("datareporting.healthreport.uploadEnabled", False)
-    fo.set_preference("datareporting.healthreport.service.enabled", False)
-    fo.set_preference("toolkit.telemetry.archive.enabled", False)
-    fo.set_preference("toolkit.telemetry.enabled", False)
-    fo.set_preference("toolkit.telemetry.unified", False)
-    fo.set_preference("breakpad.reportURL", "")
-    fo.set_preference("browser.tabs.crashReporting.sendReport", False)
-    fo.set_preference("browser.crashReports.unsubmittedCheck.enabled", False)
-
-    # Predictive Actions / Prefetch
-    fo.set_preference("network.predictor.enabled", False)
-    fo.set_preference("network.dns.disablePrefetch", True)
-    fo.set_preference("network.prefetch-next", False)
-    fo.set_preference("browser.search.suggest.enabled", False)
-    fo.set_preference("network.http.speculative-parallel-limit", 0)
-    fo.set_preference("keyword.enabled", False)  # location bar using search
-
-    # Disable pinging Mozilla for geoip
-    fo.set_preference("browser.search.geoip.url", "")
-    fo.set_preference("browser.search.region", "US")
-
-    # Disable auto-updating
-    fo.set_preference("app.update.url", "")  # browser update URL
-    fo.set_preference("browser.search.update", False)  # search engines
-    fo.set_preference("extensions.update.enabled", False)  # extensions
-    fo.set_preference("extensions.update.autoUpdateDefault", False)
-    fo.set_preference("extensions.getAddons.cache.enabled", False)
-
-    # Disable Safebrowsing and other security features
-    # that require remote content
-    fo.set_preference("browser.safebrowsing.phishing.enabled", False)
-    fo.set_preference("browser.safebrowsing.malware.enabled", False)
-    fo.set_preference("browser.safebrowsing.downloads.enabled", False)
-    fo.set_preference("browser.safebrowsing.downloads.remote.enabled", False)
-    fo.set_preference("browser.safebrowsing.blockedURIs.enabled", False)
-    fo.set_preference("browser.safebrowsing.provider.mozilla.gethashURL", "")
-    fo.set_preference("browser.safebrowsing.provider.google.gethashURL", "")
-    fo.set_preference("browser.safebrowsing.provider.google4.gethashURL", "")
-    fo.set_preference("browser.safebrowsing.provider.mozilla.updateURL", "")
-    fo.set_preference("browser.safebrowsing.provider.google.updateURL", "")
-    fo.set_preference("browser.safebrowsing.provider.google4.updateURL", "")
-    fo.set_preference("browser.safebrowsing.provider.mozilla.lists", "")
-    fo.set_preference("browser.safebrowsing.provider.google.lists", "")
-    fo.set_preference("browser.safebrowsing.provider.google4.lists", "")
-    fo.set_preference("extensions.blocklist.enabled", False)
-    fo.set_preference("security.OCSP.enabled", 0)
-
-    # Disable Content Decryption Module and OpenH264 related downloads
-    fo.set_preference("media.gmp-manager.url", "")
-    fo.set_preference("media.gmp-provider.enabled", False)
-    fo.set_preference("media.gmp-widevinecdm.enabled", False)
-    fo.set_preference("media.gmp-widevinecdm.visible", False)
-    fo.set_preference("media.gmp-gmpopenh264.enabled", False)
-
-    # Disable pinging Mozilla for newtab
-    fo.set_preference("browser.newtabpage.enabled", False)
-
-    # Disable Pocket
-    fo.set_preference("extensions.pocket.enabled", False)
-
-    # Disable Shield / Normandy studies
-    fo.set_preference("app.shield.optoutstudies.enabled", False)
-
-    # Disable Source Pragmas
-    # As per https://bugzilla.mozilla.org/show_bug.cgi?id=1628853
-    # sourceURL can be used to obfuscate the original origin of
-    # a script, we disable it.
-    fo.set_preference("javascript.options.source_pragmas", False)
-
-    # Enable extensions and disable extension signing
-    fo.set_preference("extensions.experiments.enabled", True)
-    fo.set_preference("xpinstall.signatures.required", False)
+    Applies every static pref in ``OPTIMIZE_PREFS`` (the single source of truth
+    shared with the obsolescence verifier).
+    """
+    for name, value in OPTIMIZE_PREFS.items():
+        fo.set_preference(name, value)

--- a/scripts/update.py
+++ b/scripts/update.py
@@ -14,6 +14,7 @@ Run from the project root:
 """
 
 import json
+import os
 import re
 import subprocess
 import sys
@@ -21,6 +22,9 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent
 SCRIPTS = ROOT / "scripts"
+
+# Where install-firefox.sh drops the unbranded Firefox build (non-macOS).
+_FIREFOX_BINARY = ROOT / "firefox-bin" / "firefox-bin"
 
 _MAX_RESOLVE_ATTEMPTS = 10
 
@@ -344,6 +348,81 @@ def bump_version_if_behind() -> None:
     version_file.write_text(target + "\n")
 
 
+def check_obsolete_firefox_prefs() -> None:
+    """Probe the installed Firefox for prefs OpenWPM sets that it no longer
+    recognizes, and print a non-fatal WARNING block for any that probe obsolete.
+
+    This reads the freshly-installed Firefox (``firefox-bin/firefox-bin``, or
+    ``$FIREFOX_BINARY`` if set) via ``scripts/verify_obsolete_prefs.py``, which
+    imports the very pref dicts ``configure_firefox.py`` applies — so the check
+    covers exactly the prefs we set, with no separate list to maintain.
+
+    Never fatal: a missing binary, a launch failure, or obsolete prefs only emit
+    a warning. The point is to surface drift after a Firefox bump, not to block
+    the update.
+    """
+    print("\n=== Checking installed Firefox for obsolete OpenWPM prefs ===")
+
+    binary = os.environ.get("FIREFOX_BINARY") or str(_FIREFOX_BINARY)
+    if not Path(binary).is_file():
+        print(
+            f"  Firefox binary not found at {binary}; skipping pref check.\n"
+            "  Run ./scripts/install-firefox.sh, then re-run this check with\n"
+            "  `python scripts/verify_obsolete_prefs.py`."
+        )
+        return
+
+    env = {**os.environ, "FIREFOX_BINARY": binary}
+    result = subprocess.run(
+        [sys.executable, str(SCRIPTS / "verify_obsolete_prefs.py"), "--json"],
+        cwd=ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        print(
+            "  WARNING: could not probe Firefox prefs (non-fatal).\n"
+            f"  {result.stderr.strip()}",
+            file=sys.stderr,
+        )
+        return
+
+    try:
+        results: dict[str, int] = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        print(
+            "  WARNING: could not parse pref-probe output (non-fatal).",
+            file=sys.stderr,
+        )
+        return
+
+    # pref_type 0 == PREF_INVALID: Firefox ships no default for this pref.
+    obsolete = [pref for pref, ptype in results.items() if ptype == 0]
+    if not obsolete:
+        print(f"  All {len(results)} prefs OpenWPM sets are still recognized.")
+        return
+
+    print(
+        "\n"
+        "  ============================ WARNING ============================\n"
+        f"  {len(obsolete)} pref(s) OpenWPM sets are no longer recognized by the\n"
+        "  installed Firefox (no default-branch entry). Consider pruning them\n"
+        "  from openwpm/deploy_browsers/configure_firefox.py:\n",
+        file=sys.stderr,
+    )
+    for pref in obsolete:
+        print(f"    - {pref}", file=sys.stderr)
+    print(
+        "\n"
+        "  Note: a default-branch absence is a strong but not absolute signal\n"
+        "  (a few prefs are read with an inline fallback). Confirm against\n"
+        "  searchfox/mozilla-central before removing.\n"
+        "  ================================================================\n",
+        file=sys.stderr,
+    )
+
+
 def main() -> None:
     # Repin the conda environment from unpinned sources
     run("./repin.sh", cwd=SCRIPTS)
@@ -369,6 +448,10 @@ def main() -> None:
     import firefox_version
 
     firefox_version.update_if_needed()
+
+    # Verify the prefs OpenWPM sets are still recognized by the installed
+    # Firefox (non-fatal warning if any have gone obsolete).
+    check_obsolete_firefox_prefs()
 
 
 if __name__ == "__main__":

--- a/scripts/verify_obsolete_prefs.py
+++ b/scripts/verify_obsolete_prefs.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""Probe whether Firefox still recognizes the default prefs OpenWPM sets.
+
+Methodology (inverts the searchfox approach): instead of trying to prove that
+Firefox does *not* read a pref by grepping mozilla-central, we ask the actual
+bundled Firefox binary whether it ships a *default* for the pref. A pref that
+Firefox no longer defines on the default branch is, for OpenWPM's purposes, an
+obsolescence candidate: setting it in the profile has no built-in counterpart
+to override.
+
+For each pref we read ``Services.prefs.getDefaultBranch("").getPrefType(name)``
+on a *fresh* profile, inside the privileged chrome context. The returned type:
+
+    0   PREF_INVALID  -> Firefox ships NO default  -> obsolescence candidate
+    32  PREF_STRING   -> Firefox ships a string default  -> LIVE
+    64  PREF_INT      -> Firefox ships an int default     -> LIVE
+    128 PREF_BOOL     -> Firefox ships a bool default     -> LIVE
+
+We use the *default* branch (not the user branch) deliberately: the user branch
+would be polluted by anything Selenium/our own options set. The default branch
+reflects only what the shipped Firefox build itself defines.
+
+Important caveat — this is a strong signal, NOT an absolute proof. A handful of
+prefs are read at runtime without a compiled-in default (the code calls
+``getBoolPref(name, fallback)`` with an inline fallback), so they legitimately
+have no default-branch entry yet are still honored. Therefore prefs that probe
+INVALID are reported as **review candidates**, not auto-removed: a human should
+confirm against searchfox/mozilla-central before pruning them from
+``configure_firefox.py``.
+
+The pref list is NOT hardcoded here. It is imported directly from
+``openwpm.deploy_browsers.configure_firefox`` (``PRIVACY_PREFS`` and
+``OPTIMIZE_PREFS``), the single source of truth that the Firefox setter also
+reads. This structural interlock guarantees the verifier always checks exactly
+the prefs OpenWPM applies — the two cannot drift.
+
+Usage:
+    FIREFOX_BINARY=/path/to/firefox-bin python scripts/verify_obsolete_prefs.py
+    # JSON output:
+    FIREFOX_BINARY=... python scripts/verify_obsolete_prefs.py --json
+
+Requires: selenium + geckodriver on PATH, and a Firefox launched with
+``-remote-allow-system-access`` (Firefox 138+ gates chrome-context system
+access behind that flag).
+"""
+
+import argparse
+import json
+import os
+import shutil
+import sys
+from pathlib import Path
+
+from selenium import webdriver
+from selenium.webdriver.firefox.options import Options
+from selenium.webdriver.firefox.service import Service
+
+# Make the openwpm package importable when run as a bare script from anywhere.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from openwpm.deploy_browsers.configure_firefox import (  # noqa: E402
+    OPTIMIZE_PREFS,
+    PRIVACY_PREFS,
+)
+
+PREF_TYPE_NAMES = {
+    0: "INVALID (no default -> review candidate)",
+    32: "STRING (default -> LIVE)",
+    64: "INT (default -> LIVE)",
+    128: "BOOL (default -> LIVE)",
+}
+
+# Single source of truth: every static pref OpenWPM sets, deduplicated and
+# ordered (privacy first, then optimize) for stable output.
+PREFS: list[str] = list(dict.fromkeys([*PRIVACY_PREFS, *OPTIMIZE_PREFS]))
+
+
+def make_driver() -> webdriver.Firefox:
+    binary = os.environ.get("FIREFOX_BINARY")
+    if not binary:
+        sys.exit("Set FIREFOX_BINARY to the Firefox binary to probe.")
+    options = Options()
+    options.binary_location = binary
+    # Required for chrome-context system access in Firefox 138+.
+    options.add_argument("-remote-allow-system-access")
+    options.add_argument("-headless")
+    # Prefer an explicit geckodriver on PATH; fall back to selenium-manager.
+    geckodriver = shutil.which("geckodriver")
+    service = Service(executable_path=geckodriver) if geckodriver else Service()
+    return webdriver.Firefox(options=options, service=service)
+
+
+def probe(driver: webdriver.Firefox, pref: str) -> int:
+    """Return the default-branch pref type for ``pref`` (see PREF_TYPE_NAMES)."""
+    with driver.context(driver.CONTEXT_CHROME):
+        return driver.execute_script(
+            "return Services.prefs.getDefaultBranch('')" ".getPrefType(arguments[0]);",
+            pref,
+        )
+
+
+def probe_all() -> dict[str, int]:
+    """Probe every pref in ``PREFS`` and return ``{pref: pref_type}``."""
+    driver = make_driver()
+    results: dict[str, int] = {}
+    try:
+        for pref in PREFS:
+            results[pref] = probe(driver, pref)
+    finally:
+        driver.quit()
+    return results
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--json", action="store_true", help="emit JSON")
+    args = parser.parse_args()
+
+    results = probe_all()
+
+    if args.json:
+        print(json.dumps(results, indent=2))
+        return
+
+    width = max(len(p) for p in PREFS)
+    for pref in PREFS:
+        ptype = results[pref]
+        label = PREF_TYPE_NAMES.get(ptype, f"UNKNOWN({ptype})")
+        print(f"{pref.ljust(width)}  {ptype:>3}  {label}")
+
+    invalid = [p for p, t in results.items() if t == 0]
+    if invalid:
+        print(f"\n{len(invalid)} pref(s) probe INVALID (review candidates):")
+        for pref in invalid:
+            print(f"  {pref}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Makes OpenWPM's default Firefox preferences a single source-of-truth that both
the **setter** (`configure_firefox.py`) and the **obsolescence verifier** read,
so the two are structurally interlocked and cannot drift. Wires the verifier
into `scripts/update.py` so every dependency/Firefox update auto-checks the
prefs we set for obsolescence.

> **Stacks on #1140** (`fix/obsolete-firefox-prefs`). This refactors the
> already-cleaned pref set from that PR; merge #1140 first. The diff shown
> against `master` will look larger until #1140 lands.

## What changed

### 1. Prefs consolidated into dicts (single source of truth)

`openwpm/deploy_browsers/configure_firefox.py` now defines two module-level
dicts:

- `OPTIMIZE_PREFS: dict[str, bool | int | str]` — the 54 static
  speed/telemetry/safebrowsing/update prefs, with the original comment grouping
  preserved. `optimize_prefs()` is now `for name, value in OPTIMIZE_PREFS.items(): fo.set_preference(name, value)`.
- `PRIVACY_PREFS: dict[str, bool | int | str]` — the privacy pref **names**
  (`privacy.donottrackheader.enabled`, `network.cookie.cookieBehavior`). These
  prefs' **values** are dynamic (computed from `browser_params`), so `privacy()`
  still sets them inline/conditionally; only the names live in the dict so the
  verifier can probe them.

**Behavior is identical** — same prefs, same values, same ordering (privacy
then optimize), and `browser_params.prefs` still override last. Verified by
mock-capturing the new `optimize_prefs()` output and diffing it against the
pre-refactor source: 54/54 optimize prefs match on name+value, privacy
`set_preference` calls byte-identical, and `PRIVACY_PREFS` covers exactly the
privacy pref names.

### 2. Verifier moved + interlocked

`datadir/verify_obsolete_prefs.py` → **`scripts/verify_obsolete_prefs.py`**. It
now **imports** `PRIVACY_PREFS` and `OPTIMIZE_PREFS` and probes their
`.keys()` — no hardcoded/copied pref list. It keeps the Firefox
default-branch probe (`getDefaultBranch('').getPrefType`) and the honest
caveat: a default-branch absence is a strong-but-not-absolute signal, so
INVALID prefs are reported as **review candidates**, not auto-removed. Takes
`FIREFOX_BINARY` from the environment.

### 3. Wired into `scripts/update.py`

After the Firefox bump step (`firefox_version.update_if_needed()`),
`check_obsolete_firefox_prefs()` runs `scripts/verify_obsolete_prefs.py`
against the installed Firefox (`firefox-bin/firefox-bin`, or `$FIREFOX_BINARY`)
and prints a clear **WARNING block** listing any pref that now probes obsolete.
Fully **non-fatal**: a missing binary, a launch failure, or obsolete prefs only
warn — the update is never blocked.

## Verification

- `from openwpm.deploy_browsers.configure_firefox import PRIVACY_PREFS, OPTIMIZE_PREFS` → `2 54`
- `import openwpm.deploy_browsers.deploy_firefox` imports cleanly
- `scripts/verify_obsolete_prefs.py` imports and builds a 56-pref list (privacy-first, no dupes)
- Applied pref-set proven unchanged vs. the pre-refactor source (see above)
- `update.py` skip path exercised (non-fatal when no binary present)
- pre-commit (black / isort / mypy) green

A full crawl was not run (browser env-blocked); the static "same prefs" proof
is the key check.
