### PR TITLE
feat(storage): data-failure policy — fail visits on constraint violations (crosslink #46)

### DIFF
--- a/openwpm/errors.py
+++ b/openwpm/errors.py
@@ -40,3 +40,45 @@ class BrowserCrashError(Exception):
     def __init__(self, message, *args):
         self.message = message
         super(BrowserCrashError, self).__init__(message, *args)
+
+
+class ConstraintViolation(Exception):
+    """A record could not be stored because it tripped the storage schema.
+
+    This is a *data* fault, not an infrastructure fault: a NOT-NULL / primary
+    key / unique / type / unknown-column / schema mismatch on a specific
+    record. Per the data-failure policy (crosslink #46) a constraint violation
+    means a page found a way to trip our schema and the affected visit must be
+    failed and surfaced for manual investigation -- NOT silently dropped and
+    NOT retried (retrying a malformed record can never succeed).
+
+    Storage providers raise this from ``store_record`` (or while turning a
+    record into a batch) so the ``StorageController`` can fail the owning visit
+    with an investigable error. Distinguish from a *transient* storage error (a
+    write/flush blip), which is any other exception and is retried.
+
+    Attributes
+    ----------
+    table
+        The table whose schema was tripped.
+    visit_id
+        The visit that owns the offending record.
+    reason
+        A short, human-readable description of which constraint was tripped
+        (e.g. the underlying DB error). Kept concise and PII/size-aware -- it is
+        logged and must be safe to surface.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        table: str,
+        visit_id: int,
+        reason: str,
+    ) -> None:
+        self.message = message
+        self.table = table
+        self.visit_id = visit_id
+        self.reason = reason
+        super().__init__(message)

--- a/openwpm/storage/arrow_storage.py
+++ b/openwpm/storage/arrow_storage.py
@@ -10,6 +10,7 @@ import pandas as pd
 import pyarrow as pa
 from pyarrow import Table
 
+from openwpm.errors import ConstraintViolation
 from openwpm.types import VisitId
 
 from .parquet_schema import PQ_SCHEMAS
@@ -68,23 +69,40 @@ class ArrowProvider(StructuredStorageProvider):
                 visit_id,
             )
             return
+        # Build every table's batch first and only publish them into
+        # self._batches once the whole visit validated. Publishing incrementally
+        # would leave a partial, dict-iteration-order-dependent subset of a
+        # failed visit's tables persisted when a later table trips the schema.
+        pending_batches: list[tuple[TableName, pa.RecordBatch]] = []
         for table_name, data in self._records[visit_id].items():
             try:
                 df = pd.DataFrame(data)
                 batch = pa.RecordBatch.from_pandas(
                     df, schema=PQ_SCHEMAS[table_name], preserve_index=False
                 )
-                self._batches[table_name].append(batch)
+                pending_batches.append((table_name, batch))
                 self.logger.debug(
                     "Successfully created batch for table %s and "
                     "visit_id %s" % (table_name, visit_id)
                 )
-            except pa.lib.ArrowInvalid:
-                self.logger.error(
-                    "Error while creating record batch for table %s\n" % table_name,
-                    exc_info=True,
-                )
-                pass
+            except pa.lib.ArrowInvalid as e:
+                # The record(s) for this table do not conform to the parquet
+                # schema (wrong type, overflow, etc.). This is a CONSTRAINT
+                # VIOLATION: a data fault, not a transient write blip. Per the
+                # data-failure policy we must NOT silently drop it; we discard
+                # ALL of this visit's not-yet-published batches (so no partial
+                # subset survives) and raise so the controller fails the owning
+                # visit with an investigable error.
+                del self._records[visit_id]
+                raise ConstraintViolation(
+                    "record does not match the parquet schema",
+                    table=table_name,
+                    visit_id=int(visit_id),
+                    reason=f"ArrowInvalid: {e}",
+                ) from e
+
+        for table_name, batch in pending_batches:
+            self._batches[table_name].append(batch)
 
         del self._records[visit_id]
 

--- a/openwpm/storage/sql_provider.py
+++ b/openwpm/storage/sql_provider.py
@@ -13,9 +13,22 @@ from sqlite3 import (
 )
 from typing import Any, Dict, List, Tuple
 
+from openwpm.errors import ConstraintViolation
 from openwpm.types import VisitId
 
 from .storage_providers import StructuredStorageProvider, TableName
+
+# Substrings in a sqlite3.OperationalError message that indicate a *schema*
+# (data) fault rather than a *transient* infrastructure blip. "no such table"
+# and "no such column" mean the record does not match the schema; "has no
+# column named" is raised for an unknown column in an INSERT. Anything else
+# (e.g. "database is locked", "disk I/O error") is treated as transient and
+# re-raised so the controller's retry path handles it.
+_SCHEMA_OPERATIONAL_ERROR_MARKERS = (
+    "no such table",
+    "no such column",
+    "has no column named",
+)
 
 SCHEMA_FILE = os.path.join(os.path.dirname(__file__), "schema.sql")
 
@@ -63,16 +76,34 @@ class SQLiteStorageProvider(StructuredStorageProvider):
         try:
             self.cur.execute(statement, args)
             self._sql_counter += 1
-        except (
-            OperationalError,
-            ProgrammingError,
-            IntegrityError,
-            InterfaceError,
-        ) as e:
-            self.logger.error(
-                "Unsupported record:\n%s\n%s\n%s\n%s\n"
-                % (type(e), e, statement, repr(args))
-            )
+        except OperationalError as e:
+            # OperationalError is ambiguous: a schema mismatch (no such
+            # table/column) is a data fault, but "database is locked" / "disk
+            # I/O error" are transient. Only the former is a constraint
+            # violation; re-raise the latter unchanged rather than mislabelling a
+            # transient blip as a permanent data fault. (The controller does not
+            # currently retry store_record -- _guarded_store_record marks the
+            # visit failed -- so a genuinely transient error still loses the
+            # record; a store-side retry is future work.)
+            if any(
+                marker in str(e).lower() for marker in _SCHEMA_OPERATIONAL_ERROR_MARKERS
+            ):
+                raise ConstraintViolation(
+                    "record does not match the storage schema",
+                    table=table,
+                    visit_id=int(visit_id),
+                    reason=str(e),
+                ) from e
+            raise
+        except (ProgrammingError, IntegrityError, InterfaceError) as e:
+            # NOT-NULL / PRIMARY KEY / UNIQUE / type / binding-arity failures:
+            # the record tripped the schema. A data fault, never transient.
+            raise ConstraintViolation(
+                "record does not match the storage schema",
+                table=table,
+                visit_id=int(visit_id),
+                reason=f"{type(e).__name__}: {e}",
+            ) from e
 
     @staticmethod
     def _generate_insert(

--- a/openwpm/storage/storage_controller.py
+++ b/openwpm/storage/storage_controller.py
@@ -15,6 +15,7 @@ from multiprocess import Queue
 from openwpm.utilities.multiprocess_utils import Process
 
 from ..config import BrowserParamsInternal, ManagerParamsInternal
+from ..errors import ConstraintViolation
 from ..socket_interface import ClientSocket, get_message_from_reader
 from ..types import BrowserId, VisitId
 from .storage_providers import (
@@ -83,6 +84,13 @@ class StorageController:
         """Contains all information required for update_completion_queue to work
             Tuple structure is: VisitId, optional completion token, success
         """
+        self.failed_visits: Dict[VisitId, str] = {}
+        """Visits whose records tripped the storage schema (a constraint
+        violation, per crosslink #46). Maps visit_id -> a short reason string.
+        Such a visit is forced to a FAILED terminal state regardless of the
+        success flag the browser sent: a record that trips the schema needs
+        manual investigation, surfaced by the visit repeatedly failing with a
+        clear error rather than being silently dropped."""
         self.structured_storage = structured_storage
         self.unstructured_storage = unstructured_storage
         self._last_record_received: Optional[float] = None
@@ -166,12 +174,62 @@ class StorageController:
             del data["visit_id"]
         # Turning these into task to be able to have them complete without blocking the socket
         self.store_record_tasks[visit_id].append(
-            asyncio.create_task(
-                self.structured_storage.store_record(
-                    table=table_name, visit_id=visit_id, record=data
-                )
-            )
+            asyncio.create_task(self._guarded_store_record(table_name, visit_id, data))
         )
+
+    async def _guarded_store_record(
+        self, table_name: TableName, visit_id: VisitId, data: Dict[str, Any]
+    ) -> None:
+        """Run a single ``store_record`` in isolation.
+
+        Records are stored as un-awaited tasks so the socket never blocks
+        (the exception, if any, would otherwise only surface much later when
+        ``finalize_visit_id`` awaits the task). This guard enforces the
+        data-failure policy (crosslink #46) at the per-record boundary:
+
+        * A :class:`ConstraintViolation` is a DATA fault -- the record tripped
+          the storage schema. We log a clear, investigable error and mark the
+          owning visit FAILED. We do NOT re-raise: the failure must stay
+          isolated to this record so (a) the shared ``DataSocket`` connection
+          carrying records for many visits is not torn down [adversarial G1b],
+          and (b) ``finalize_visit_id`` does not abort and strand the visit
+          [adversarial G1]. The visit reaching a FAILED terminal state with a
+          good error message is how the site gets surfaced for investigation.
+
+        * Any other exception is unexpected (the persistence itself is deferred
+          to ``flush_cache``, whose transient errors are retried separately).
+          We cannot retry a lost fire-and-forget record, so we treat it the
+          same way -- fail the visit loudly -- rather than silently dropping it
+          or letting it tear down the connection.
+
+        This coroutine therefore never raises.
+        """
+        try:
+            await self.structured_storage.store_record(
+                table=table_name, visit_id=visit_id, record=data
+            )
+        except ConstraintViolation as e:
+            self.logger.error(
+                "CONSTRAINT VIOLATION storing a record: failing visit_id=%d. "
+                "table=%s constraint=%s. The visit will be recorded as failed "
+                "(incomplete_visits) for investigation. record_keys=%s",
+                visit_id,
+                e.table,
+                e.reason,
+                sorted(data.keys()),
+            )
+            self.failed_visits[visit_id] = e.reason
+        except Exception as e:
+            self.logger.error(
+                "Unexpected error storing a record: failing visit_id=%d "
+                "table=%s. Treating as a data fault (cannot retry a lost "
+                "record); the visit will be recorded as failed. record_keys=%s",
+                visit_id,
+                table_name,
+                sorted(data.keys()),
+                exc_info=e,
+            )
+            self.failed_visits[visit_id] = f"{type(e).__name__}: {e}"
 
     async def _handle_meta(self, visit_id: VisitId, data: Dict[str, Any]) -> None:
         """
@@ -189,20 +247,29 @@ class StorageController:
             return
         elif action == ACTION_TYPE_FINALIZE:
             success: bool = data["success"]
-            completion_token = await self.finalize_visit_id(visit_id, success)
-            self.finalize_tasks.append((visit_id, completion_token, success))
+            completion_token, effective_success = await self.finalize_visit_id(
+                visit_id, success
+            )
+            self.finalize_tasks.append((visit_id, completion_token, effective_success))
         else:
             raise ValueError("Unexpected action: %s", action)
 
     async def finalize_visit_id(
         self, visit_id: VisitId, success: bool
-    ) -> Optional[Task[None]]:
+    ) -> Tuple[Optional[Task[None]], bool]:
         """Makes sure all records for a given visit_id
         have been processed before we invoke finalize_visit_id
         on the structured_storage
 
         See StructuredStorageProvider::finalize_visit_id for additional
         documentation
+
+        Returns the completion token (if any) and the *effective* success flag.
+        Per the data-failure policy (crosslink #46) the effective success is
+        forced to ``False`` if any of the visit's records tripped the storage
+        schema (a constraint violation), so the visit reaches a FAILED terminal
+        state and is recorded in ``incomplete_visits`` regardless of the
+        success flag the browser sent.
         """
 
         # If the following critical section contains any await statement
@@ -215,12 +282,15 @@ class StorageController:
                 "There are no records to be stored for visit_id %d, skipping...",
                 visit_id,
             )
-            return None
+            return None, success
 
         store_record_tasks = self.store_record_tasks.pop(visit_id)
         # END OF CRITICAL SECTION
 
         self.logger.info("Awaiting all tasks for visit_id %d", visit_id)
+        # The guard in _guarded_store_record ensures these never raise; a record
+        # that tripped the schema has already been logged and recorded in
+        # self.failed_visits, so awaiting here cannot strand the visit.
         for task in store_record_tasks:
             await task
 
@@ -228,10 +298,64 @@ class StorageController:
             "Awaited all tasks for visit_id %d while finalizing", visit_id
         )
 
-        completion_token = await self.structured_storage.finalize_visit_id(
-            visit_id, interrupted=not success
-        )
-        return completion_token
+        # A record that tripped the schema fails the whole visit.
+        effective_success = success and visit_id not in self.failed_visits
+        if not effective_success and success:
+            self.logger.error(
+                "Failing visit_id %d that the browser reported as successful: "
+                "one or more of its records tripped the storage schema "
+                "(constraint=%s). Recording it as incomplete for investigation.",
+                visit_id,
+                self.failed_visits.get(visit_id),
+            )
+
+        try:
+            completion_token = await self.structured_storage.finalize_visit_id(
+                visit_id, interrupted=not effective_success
+            )
+        except ConstraintViolation as e:
+            # The provider surfaced a schema fault while turning this visit's
+            # cached records into a batch (the ArrowProvider validates lazily
+            # at finalize time). Treat it exactly like a per-record constraint
+            # violation: mark the visit failed and re-finalize as interrupted so
+            # it still reaches a FAILED terminal state with a clear error -- do
+            # NOT propagate (that would abort _handle_meta / shutdown and strand
+            # the visit) and do NOT silently drop it.
+            self.logger.error(
+                "CONSTRAINT VIOLATION finalizing visit_id=%d: table=%s "
+                "constraint=%s. Recording the visit as failed "
+                "(incomplete_visits) for investigation.",
+                visit_id,
+                e.table,
+                e.reason,
+            )
+            self.failed_visits[visit_id] = e.reason
+            try:
+                completion_token = await self.structured_storage.finalize_visit_id(
+                    visit_id, interrupted=True
+                )
+            except Exception:
+                # The recovery finalize itself failed (e.g. a raw storage error
+                # while inserting into incomplete_visits). It must NOT propagate:
+                # that would abort _handle_meta and tear down the shared
+                # DataSocket for every other visit -- exactly the invariant this
+                # policy exists to protect. Drop the token instead; a None token
+                # makes update_completion_queue / shutdown enqueue this visit as
+                # failed, so it still reaches a terminal state.
+                self.logger.error(
+                    "Recovery finalize for visit_id=%d failed; recording it as "
+                    "failed with no completion token so it still terminates.",
+                    visit_id,
+                    exc_info=True,
+                )
+                completion_token = None
+            effective_success = False
+
+        # The failure reason has now been consumed (effective_success computed
+        # and logged), so drop it: otherwise failed_visits accumulates one entry
+        # per failed visit for the whole controller lifetime.
+        self.failed_visits.pop(visit_id, None)
+        return completion_token, effective_success
 
     async def update_status_queue(self) -> NoReturn:
         """Send manager process a status update.
@@ -288,7 +412,10 @@ class StorageController:
                     await asyncio.sleep(SHUTDOWN_FLUSH_RETRY_DELAY)
         self.logger.error(
             "Giving up flushing cache during shutdown after %d attempts; "
-            "some records may remain uncommitted",
+            "some records could NOT be persisted. The affected visits are "
+            "still being marked as failed so they reach a terminal state and "
+            "no callback hangs, but their data was lost -- investigate the "
+            "underlying storage backend.",
             SHUTDOWN_FLUSH_RETRIES,
         )
         return False
@@ -300,9 +427,8 @@ class StorageController:
         for visit_id in visit_ids:
             # Even if the token is None, we still want to put the visit_id
             # in the completion queue
-            completion_tokens[visit_id] = await self.finalize_visit_id(
-                visit_id, success=False
-            )
+            token, _ = await self.finalize_visit_id(visit_id, success=False)
+            completion_tokens[visit_id] = token
 
         flushed = await self._flush_with_retries(self.structured_storage)
         if flushed:
@@ -409,9 +535,8 @@ class StorageController:
             # is forbidden
             new_finalize_tasks: List[Tuple[VisitId, Optional[Task[None]], bool]] = []
             for visit_id, token, success in self.finalize_tasks:
-                if (
-                    not token or token.done()
-                ):  # Either way all data for the visit_id was saved out
+                if not token or token.done():
+                    # Either way all data for the visit_id was saved out
                     self.completion_queue.put((visit_id, success))
                 else:
                     new_finalize_tasks.append((visit_id, token, success))

--- a/test/storage/conftest.py
+++ b/test/storage/conftest.py
@@ -1,0 +1,32 @@
+"""Fixtures shared by the storage-tier tests.
+
+The project-wide ``mp_logger`` fixture (in ``test/conftest.py``) asserts that
+no ``ERROR`` line was logged during the test. That is the right default for the
+happy-path storage tests, but the *adversarial* storage tests in this directory
+deliberately provoke error logging (a provider that raises, a hostile socket
+frame, a malformed record). For those we need a logger that captures output the
+same way but does not fail the test on the expected ERROR lines.
+"""
+
+import logging
+from pathlib import Path
+from typing import Any, Generator
+
+import pytest
+
+from openwpm.mp_logger import MPLogger
+
+
+@pytest.fixture()
+def adversarial_mp_logger(tmp_path: Path) -> Generator[MPLogger, Any, None]:
+    """An ``MPLogger`` for tests that intentionally log ERRORs.
+
+    Identical to ``mp_logger`` but without the post-test assertion that no
+    ERROR was logged - the adversarial tests *expect* ERROR lines and assert
+    on observable pipeline behaviour (forward progress / no data loss /
+    no hang) instead.
+    """
+    log_path = tmp_path / "openwpm.log"
+    logger = MPLogger(log_path, log_level_console=logging.DEBUG)
+    yield logger
+    logger.close()

--- a/test/storage/test_adversarial_socket.py
+++ b/test/storage/test_adversarial_socket.py
@@ -1,0 +1,125 @@
+"""Adversarial wire-protocol tests against the real StorageController server.
+
+The StorageController exposes an ``asyncio`` TCP server speaking the
+length-prefixed framing of ``openwpm/socket_interface.py`` (4-byte big-endian
+length + 1-byte serialization tag + body). Untrusted/buggy clients (a crashing
+extension, a half-open connection, a corrupted frame) can send arbitrary bytes
+at it.
+
+PROPERTY: the server must degrade gracefully - a hostile or truncated frame may
+kill *that one connection*, but the server must keep accepting new connections,
+must not hang, and must not lose data for well-behaved clients.
+
+All of these are browser-free: we open raw sockets to the controller's listen
+address and verify a subsequent good visit still completes.
+"""
+
+import json
+import socket
+import struct
+import time
+from typing import List, Tuple
+
+import pytest
+
+from openwpm.storage.in_memory_storage import MemoryStructuredProvider
+from openwpm.storage.storage_controller import DataSocket, StorageControllerHandle
+from openwpm.storage.storage_providers import TableName
+from openwpm.types import VisitId
+
+pytestmark = pytest.mark.pyonly
+
+
+def _send_raw(addr: Tuple[str, int], payload: bytes) -> None:
+    """Open a raw socket, dump ``payload``, briefly wait, then close."""
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.settimeout(3)
+    s.connect(addr)
+    try:
+        s.sendall(payload)
+    except OSError:
+        # The server may close on us for some payloads; that is acceptable.
+        pass
+    time.sleep(0.3)
+    s.close()
+
+
+def _hostile_frames() -> List[Tuple[str, bytes]]:
+    one_tuple = json.dumps(["only_one_element"]).encode("utf-8")
+    return [
+        # Unknown serialization tag 'X' with a 3-byte body.
+        ("unknown_serialization", struct.pack(">Lc", 3, b"X") + b"abc"),
+        # Length prefix claims 100 bytes but only 2 are sent, then EOF.
+        ("truncated_body", struct.pack(">Lc", 100, b"j") + b"ab"),
+        # Absurd length prefix (2 GiB) with no body - must not allocate/hang.
+        ("oversized_length_prefix", struct.pack(">Lc", 2**31, b"j")),
+        # Fewer than the 5 header bytes, then EOF.
+        ("short_header", b"\x01\x02"),
+        # Valid JSON frame but the record is a 1-element list (wrong arity);
+        # the controller logs "Query is not the correct length" and skips.
+        ("wrong_arity_record", struct.pack(">Lc", len(one_tuple), b"j") + one_tuple),
+        # Valid JSON frame whose body is not even a sequence.
+        (
+            "non_sequence_record",
+            (lambda b: struct.pack(">Lc", len(b), b"j") + b)(b"42"),
+        ),
+    ]
+
+
+@pytest.mark.usefixtures("adversarial_mp_logger")
+@pytest.mark.parametrize(
+    "name,payload", _hostile_frames(), ids=[n for n, _ in _hostile_frames()]
+)
+def test_server_survives_hostile_frame(name: str, payload: bytes) -> None:
+    """After a single hostile frame on its own connection, the controller must
+    still accept a new connection and complete a good visit.
+    """
+    handle = StorageControllerHandle(MemoryStructuredProvider(), None)
+    handle.launch()
+    assert handle.listener_address is not None
+    addr = handle.listener_address
+
+    _send_raw(addr, payload)
+
+    sock = DataSocket(addr, f"good-after-{name}")
+    good = VisitId(0xBEEF)
+    sock.store_record(TableName("site_visits"), good, {"site_url": "ok"})
+    sock.finalize_visit_id(good, success=True)
+    sock.close()
+
+    start = time.time()
+    handle.shutdown()
+    elapsed = time.time() - start
+    assert elapsed < 60, f"shutdown hung after hostile frame {name} ({elapsed:.1f}s)"
+
+    seen = handle.get_new_completed_visits()
+    assert good in {vid for vid, _ in seen}, (
+        f"server did not survive hostile frame {name}; good visit lost; " f"seen={seen}"
+    )
+
+
+@pytest.mark.usefixtures("adversarial_mp_logger")
+def test_server_survives_abrupt_disconnect_mid_message() -> None:
+    """A client that connects, sends its name, sends a partial record header,
+    then drops the connection must not wedge the controller.
+    """
+    handle = StorageControllerHandle(MemoryStructuredProvider(), None)
+    handle.launch()
+    assert handle.listener_address is not None
+    addr = handle.listener_address
+
+    # Send a valid client-name frame, then half of a record header, then close.
+    name_body = json.dumps("evil-client").encode("utf-8")
+    payload = struct.pack(">Lc", len(name_body), b"j") + name_body
+    payload += b"\x00\x00"  # 2 of the 5 header bytes of the next message
+    _send_raw(addr, payload)
+
+    sock = DataSocket(addr, "good-after-disconnect")
+    good = VisitId(0xD00D)
+    sock.store_record(TableName("site_visits"), good, {"site_url": "ok"})
+    sock.finalize_visit_id(good, success=True)
+    sock.close()
+
+    handle.shutdown()
+    seen = handle.get_new_completed_visits()
+    assert good in {vid for vid, _ in seen}, f"controller wedged; seen={seen}"

--- a/test/storage/test_adversarial_storage_controller.py
+++ b/test/storage/test_adversarial_storage_controller.py
@@ -1,0 +1,460 @@
+"""Adversarial / chaos tests driving the *real* ``StorageController`` in-process.
+
+These tests assert the central robustness property of the crawl pipeline's
+storage tier:
+
+    FORWARD PROGRESS + NO SILENT DATA LOSS
+    Every visit_id that is started (a record is stored for it and/or it is
+    finalized) MUST eventually reach the ``completion_queue`` exactly once,
+    even when the underlying ``StructuredStorageProvider`` misbehaves, and the
+    controller must never hang or silently swallow the visit.
+
+The controller is driven exactly like the existing storage-controller tests
+(`test/storage/test_storage_controller.py`): a real ``StorageControllerHandle``
+spawns the real controller subprocess, and a real ``DataSocket`` feeds records
+over a real socket. We then inject adversarial behaviour by subclassing the
+in-memory providers to raise at well-defined points.
+
+Scenarios covered (browser-free):
+  * S4  - storage provider write/flush faults (transient + permanent)
+  * S1/S5 (storage side) - a store_record task that raises must NOT strand the
+          visit or tear down the shared connection
+  * S6  - malformed / hostile records (huge values, injection-y strings,
+          missing visit_id), driven against the real SQLite provider
+
+The G1 / G1b / G2 invariants below were previously confirmed *defects*
+(``xfail``); they now hold under the data-failure policy (crosslink #46), which
+classifies a record that trips the schema as a CONSTRAINT VIOLATION -> the visit
+is failed with an investigable error, the per-record failure is isolated so the
+shared connection survives, and every started visit reaches a terminal state
+without hanging. See ``docs/developers/Adversarial-Robustness.md`` and crosslink
+#46 / #28 / #30.
+"""
+
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Set, Tuple
+
+import pytest
+from pyarrow import Table
+
+from openwpm.storage.in_memory_storage import (
+    MemoryArrowProvider,
+    MemoryStructuredProvider,
+)
+from openwpm.storage.sql_provider import SQLiteStorageProvider
+from openwpm.storage.storage_controller import (
+    DataSocket,
+    StorageControllerHandle,
+)
+from openwpm.storage.storage_providers import TableName
+from openwpm.types import VisitId
+from openwpm.utilities import db_utils
+
+pytestmark = pytest.mark.pyonly
+
+
+# ---------------------------------------------------------------------------
+# Adversarial providers
+# ---------------------------------------------------------------------------
+
+
+class RaisingStoreProvider(MemoryStructuredProvider):
+    """``store_record`` raises for every record.
+
+    Models a structured-storage backend that throws while persisting a record
+    (e.g. a programming error, an unexpected type, or a transient backend
+    error that is not caught). Because ``StorageController.store_record``
+    fires these off as un-awaited ``asyncio`` tasks, the controller must
+    isolate the failure (data-failure policy, crosslink #46): the visit is
+    failed, but the connection survives and the visit still reaches a terminal
+    state.
+    """
+
+    async def store_record(
+        self, table: TableName, visit_id: VisitId, record: Dict[str, Any]
+    ) -> None:
+        raise RuntimeError(f"injected store_record failure for visit {visit_id}")
+
+
+class FailingWriteArrowProvider(MemoryArrowProvider):
+    """``write_table`` raises permanently (e.g. disk full / S3 outage)."""
+
+    async def write_table(self, table_name: TableName, table: Table) -> None:
+        raise IOError("injected permanent write_table failure")
+
+
+class TransientFailingStoreProvider(MemoryStructuredProvider):
+    """``store_record`` fails the first ``n`` calls then recovers.
+
+    Models a transient backend hiccup. A robust controller should still make
+    forward progress for visits stored after the backend recovers.
+    """
+
+    def __init__(self, fail_first: int) -> None:
+        super().__init__()
+        self._remaining_failures = fail_first
+
+    async def store_record(
+        self, table: TableName, visit_id: VisitId, record: Dict[str, Any]
+    ) -> None:
+        if self._remaining_failures > 0:
+            self._remaining_failures -= 1
+            raise RuntimeError("injected transient store_record failure")
+        await super().store_record(table, visit_id, record)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _drain_completions(
+    handle: StorageControllerHandle, timeout: float = 8.0
+) -> List[Tuple[int, bool]]:
+    """Poll the completion queue until ``timeout`` and return everything seen."""
+    deadline = time.time() + timeout
+    seen: List[Tuple[int, bool]] = []
+    while time.time() < deadline:
+        seen.extend(handle.get_new_completed_visits())
+        time.sleep(0.2)
+    return seen
+
+
+def _completed_ids(seen: List[Tuple[int, bool]]) -> Set[int]:
+    return {vid for vid, _ in seen}
+
+
+# ---------------------------------------------------------------------------
+# Control: the happy path completes (guards against false negatives below)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.usefixtures("adversarial_mp_logger")
+def test_control_good_visit_completes() -> None:
+    """A normal visit reaches the completion queue. Establishes the baseline
+    so that the stranding tests below are meaningful (not just slow polling).
+    """
+    handle = StorageControllerHandle(MemoryStructuredProvider(), None)
+    handle.launch()
+    assert handle.listener_address is not None
+    sock = DataSocket(handle.listener_address, "control")
+    vid = VisitId(0xC0FFEE)
+    sock.store_record(TableName("site_visits"), vid, {"site_url": "ok"})
+    sock.finalize_visit_id(vid, success=True)
+    sock.close()
+
+    # The MemoryStructuredProvider only resolves a visit's completion token on
+    # flush_cache, which happens on the batch timeout or at shutdown. So we
+    # check completions both during the run and after shutdown.
+    handle.shutdown()
+    seen = handle.get_new_completed_visits()
+    assert vid in _completed_ids(seen), f"good visit never completed; seen={seen}"
+    assert (vid, True) in seen
+
+
+# ---------------------------------------------------------------------------
+# S4 (transient): forward progress survives a transient store failure
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.usefixtures("adversarial_mp_logger")
+def test_transient_store_failure_controller_recovers() -> None:
+    """The *controller* recovers from a transient store_record failure: a later
+    visit still completes.
+
+    Under the data-failure policy the failing store no longer tears down the
+    connection, so the good visit completes on the same controller.
+    """
+    handle = StorageControllerHandle(TransientFailingStoreProvider(fail_first=1), None)
+    handle.launch()
+    assert handle.listener_address is not None
+
+    bad = VisitId(1001)  # its store_record will raise (consumes the 1 failure)
+    good = VisitId(1002)  # stored after recovery -> must complete
+
+    bad_conn = DataSocket(handle.listener_address, "transient-bad")
+    bad_conn.store_record(TableName("site_visits"), bad, {"site_url": "bad"})
+    bad_conn.finalize_visit_id(bad, success=False)
+    time.sleep(1)  # let the raising store task run
+    bad_conn.close()
+
+    good_conn = DataSocket(handle.listener_address, "transient-good")
+    good_conn.store_record(TableName("site_visits"), good, {"site_url": "good"})
+    good_conn.finalize_visit_id(good, success=True)
+    good_conn.close()
+
+    handle.shutdown()
+    seen = handle.get_new_completed_visits()
+    assert good in _completed_ids(
+        seen
+    ), f"controller did not recover: later visit did not complete; seen={seen}"
+
+
+# ---------------------------------------------------------------------------
+# G1b: a single failing record must NOT tear down the shared connection
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.usefixtures("adversarial_mp_logger")
+def test_raising_store_record_does_not_break_shared_connection() -> None:
+    """INVARIANT (data-failure policy): a single failing record must not tear
+    down a shared connection and break unrelated later records on it.
+
+    In the real pipeline the TaskManager keeps one long-lived DataSocket for
+    site_visits/crawl_history/finalize across ALL visits; one bad record must
+    not break the socket for the rest of the crawl [adversarial G1b].
+    """
+    handle = StorageControllerHandle(TransientFailingStoreProvider(fail_first=1), None)
+    handle.launch()
+    assert handle.listener_address is not None
+    sock = DataSocket(handle.listener_address, "shared-conn")
+
+    bad = VisitId(1101)
+    good = VisitId(1102)
+    sock.store_record(TableName("site_visits"), bad, {"site_url": "bad"})
+    sock.finalize_visit_id(bad, success=False)
+    time.sleep(1)  # let the raising store task run; connection must survive
+    # Reusing the SAME connection: this must still work under the policy.
+    sock.store_record(TableName("site_visits"), good, {"site_url": "good"})
+    sock.finalize_visit_id(good, success=True)
+    sock.close()
+
+    handle.shutdown()
+    seen = handle.get_new_completed_visits()
+    assert good in _completed_ids(
+        seen
+    ), f"good record on shared connection lost; seen={seen}"
+    # The bad visit must also reach a terminal state (failed), not vanish.
+    assert bad in _completed_ids(seen), f"bad visit stranded; seen={seen}"
+
+
+# ---------------------------------------------------------------------------
+# G1: a raising store task must still let the visit reach a terminal state
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.usefixtures("adversarial_mp_logger")
+def test_raising_store_record_visit_still_finalizes() -> None:
+    """INVARIANT (data-failure policy): a finalized visit whose store_record
+    raised must still reach the completion_queue marked FAILED (not vanish,
+    not hang). The browser reported success=True, but a record that could not
+    be stored fails the visit so it is surfaced for investigation [G1].
+    """
+    handle = StorageControllerHandle(RaisingStoreProvider(), None)
+    handle.launch()
+    assert handle.listener_address is not None
+    sock = DataSocket(handle.listener_address, "raising")
+    vid = VisitId(2001)
+    sock.store_record(TableName("site_visits"), vid, {"site_url": "x"})
+    sock.finalize_visit_id(vid, success=True)
+    sock.close()
+
+    seen = _drain_completions(handle)
+    handle.shutdown()
+    seen.extend(handle.get_new_completed_visits())
+    assert vid in _completed_ids(
+        seen
+    ), f"visit stranded - never reached completion queue; seen={seen}"
+    # A record that could not be stored fails the visit even though the browser
+    # reported success: the visit must be marked FAILED for investigation.
+    assert (vid, False) in seen, f"failed visit not marked unsuccessful; seen={seen}"
+
+
+@pytest.mark.usefixtures("adversarial_mp_logger")
+def test_raising_store_record_unfinalized_visit_enqueued_on_shutdown() -> None:
+    """INVARIANT (data-failure policy): on shutdown, every visit with pending
+    store tasks must be enqueued to the completion_queue even if those tasks
+    raised. Models a browser dying mid-visit (no Finalize sent) [G1].
+    """
+    handle = StorageControllerHandle(RaisingStoreProvider(), None)
+    handle.launch()
+    assert handle.listener_address is not None
+    sock = DataSocket(handle.listener_address, "raising-unfinalized")
+    vid = VisitId(2002)
+    sock.store_record(TableName("site_visits"), vid, {"site_url": "x"})
+    # deliberately NO finalize_visit_id - the client "crashes"
+    sock.close()
+    time.sleep(1)
+
+    start = time.time()
+    handle.shutdown()
+    assert time.time() - start < 60, "shutdown hung on the raising visit"
+    seen = handle.get_new_completed_visits()
+    assert vid in _completed_ids(
+        seen
+    ), f"unfinalized stranded visit never enqueued on shutdown; seen={seen}"
+
+
+# ---------------------------------------------------------------------------
+# G2: a permanent write_table fault must not strand the visit or hang shutdown
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.usefixtures("adversarial_mp_logger")
+def test_permanent_write_table_fault_visit_still_completes() -> None:
+    """INVARIANT (data-failure policy): even if persistent storage permanently
+    rejects the write, the visit's terminal state must reach the
+    completion_queue (marked FAILED) and shutdown must not crash or hang before
+    draining it [G2]. The underlying failure is surfaced in the log, not masked
+    as a timeout.
+    """
+    handle = StorageControllerHandle(FailingWriteArrowProvider(), None)
+    handle.launch()
+    assert handle.listener_address is not None
+    sock = DataSocket(handle.listener_address, "write-fault")
+    vid = VisitId(3001)
+    sock.store_record(
+        TableName("site_visits"),
+        vid,
+        {"site_url": "x", "browser_id": 1, "site_rank": 1},
+    )
+    sock.finalize_visit_id(vid, success=True)
+    sock.close()
+
+    start = time.time()
+    handle.shutdown()
+    assert time.time() - start < 60, "shutdown hung on the write fault"
+    seen = handle.get_new_completed_visits()
+    assert vid in _completed_ids(
+        seen
+    ), f"visit lost on permanent write fault; seen={seen}"
+    assert (vid, False) in seen, f"unflushable visit not marked failed; seen={seen}"
+
+
+# ---------------------------------------------------------------------------
+# Constraint violation: a schema-tripping record fails the visit (not dropped)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.usefixtures("adversarial_mp_logger")
+def test_constraint_violation_fails_visit_and_records_incomplete(
+    tmp_path: Path,
+) -> None:
+    """A record that trips the SQLite schema (unknown column) is a CONSTRAINT
+    VIOLATION: the visit is failed and recorded in ``incomplete_visits`` for
+    investigation, NOT silently dropped (data-failure policy, crosslink #46).
+
+    A subsequent good visit on the same connection must still complete, proving
+    the failure was isolated to the offending visit.
+    """
+    db_path = tmp_path / "constraint.sqlite"
+    handle = StorageControllerHandle(SQLiteStorageProvider(db_path), None)
+    handle.launch()
+    assert handle.listener_address is not None
+    sock = DataSocket(handle.listener_address, "constraint")
+
+    bad = VisitId(5001)
+    # "nonexistent_column" is not in the site_visits schema -> OperationalError
+    # "table site_visits has no column named nonexistent_column".
+    sock.store_record(
+        TableName("site_visits"),
+        bad,
+        {"browser_id": 1, "site_url": "ok", "site_rank": 1, "nonexistent_column": "x"},
+    )
+    sock.finalize_visit_id(bad, success=True)
+
+    good = VisitId(5002)
+    sock.store_record(
+        TableName("site_visits"),
+        good,
+        {"browser_id": 1, "site_url": "good", "site_rank": 2},
+    )
+    sock.finalize_visit_id(good, success=True)
+    sock.close()
+
+    start = time.time()
+    handle.shutdown()
+    assert time.time() - start < 60, "shutdown hung on a constraint violation"
+
+    seen = handle.get_new_completed_visits()
+    ids = _completed_ids(seen)
+    assert good in ids, f"good visit lost after a constraint violation; seen={seen}"
+    # The bad visit reaches a FAILED terminal state ...
+    assert (bad, False) in seen, f"constraint-violating visit not failed; seen={seen}"
+
+    # ... and is recorded as incomplete for investigation (not silently dropped).
+    incomplete = db_utils.query_db(
+        db_path, "SELECT visit_id FROM incomplete_visits;", as_tuple=True
+    )
+    incomplete_ids = {r[0] for r in incomplete}
+    assert (
+        bad in incomplete_ids
+    ), f"constraint-violating visit not recorded in incomplete_visits; {incomplete_ids}"
+
+
+# ---------------------------------------------------------------------------
+# S6 - malformed / hostile records sent through the real DataSocket
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.usefixtures("adversarial_mp_logger")
+def test_malformed_records_do_not_break_controller(tmp_path: Path) -> None:
+    """Hostile/malformed records (huge strings, injection-y values, a record
+    with no visit_id) must not crash or hang the controller; a subsequent good
+    visit must still complete and be persisted.
+
+    Driven against the *real* ``SQLiteStorageProvider`` so the huge value goes
+    through the production persistence path (writing to disk), not the
+    ``MemoryStructuredProvider`` test queue - a multi-MiB value deadlocks the
+    cross-process ``multiprocess.Queue`` the memory provider uses, which is a
+    test-harness artifact, not a pipeline property.
+    """
+    db_path = tmp_path / "malformed.sqlite"
+    handle = StorageControllerHandle(SQLiteStorageProvider(db_path), None)
+    handle.launch()
+    assert handle.listener_address is not None
+    sock = DataSocket(handle.listener_address, "malformed")
+
+    huge = "A" * (2 * 1024 * 1024)  # 2 MiB string in a valid TEXT column
+    # site_visits.visit_id is the PRIMARY KEY, so each visit gets one record.
+    huge_visit = VisitId(4001)
+    sock.store_record(
+        TableName("site_visits"),
+        huge_visit,
+        {"browser_id": 1, "site_url": huge, "site_rank": 1},
+    )
+    sock.finalize_visit_id(huge_visit, success=True)
+
+    # injection-y value as a literal in a valid column on its own visit
+    injection_visit = VisitId(4002)
+    sock.store_record(
+        TableName("site_visits"),
+        injection_visit,
+        {"browser_id": 1, "site_url": "'; DROP TABLE site_visits;--", "site_rank": 2},
+    )
+    sock.finalize_visit_id(injection_visit, success=True)
+
+    # A record with no visit_id at all (controller must skip it, not crash).
+    # Sent via the raw socket because DataSocket always injects visit_id.
+    sock.socket.send((TableName("site_visits"), {"site_url": "no visit id"}))
+
+    # Now a normal visit must still complete -> controller survived.
+    good = VisitId(4003)
+    sock.store_record(
+        TableName("site_visits"),
+        good,
+        {"browser_id": 1, "site_url": "ok", "site_rank": 3},
+    )
+    sock.finalize_visit_id(good, success=True)
+    sock.close()
+
+    start = time.time()
+    handle.shutdown()
+    assert time.time() - start < 60, "controller hung on a malformed record"
+
+    seen = handle.get_new_completed_visits()
+    ids = _completed_ids(seen)
+    assert good in ids, f"controller did not survive malformed records; seen={seen}"
+    assert huge_visit in ids, f"huge-value visit lost; seen={seen}"
+    assert injection_visit in ids, f"injection-value visit lost; seen={seen}"
+
+    # The injection string is stored as a literal value, table intact.
+    rows = db_utils.query_db(
+        db_path, "SELECT site_url FROM site_visits;", as_tuple=True
+    )
+    stored = {r[0] for r in rows}
+    assert (
+        "'; DROP TABLE site_visits;--" in stored
+    ), "injection value not stored literally"
+    assert huge in stored, "huge value not persisted"


### PR DESCRIPTION
## Data-failure policy (crosslink #46)

Implements the data-failure policy in the core `StorageController` / provider
path. This is the keystone that resolves the adversarial **G1 / G1b / G2**
robustness gaps and aligns the in-flight storage work.

> **Stacks on #1197** (`fix/storage-forward-progress`, the data-integrity
> foundation) — this PR targets that branch, not `master`. Review/merge #1197
> first. The forward-progress fix handles the *transient* half of the policy
> (retry a write/flush blip); this PR adds the *data-fault* half.

### The policy

A failed `store_record` / finalize is classified into two failure classes:

| Class | What it is | Handling |
|---|---|---|
| **Constraint violation** (data fault) | A record tripped the storage schema: DB `IntegrityError`, type mismatch, NOT-NULL / PK / UNIQUE, unknown table/column, parquet `ArrowInvalid` | **Catch, log a clear investigable error** (visit_id, table, which constraint, record key context — PII/size-aware), **mark the VISIT FAILED** (recorded in `incomplete_visits`). Never silently dropped, never retried (a malformed record can't succeed on retry). The site surfaces by repeatedly failing with a good error message. |
| **Transient error** (infra fault) | A write/flush blip (e.g. an S3 `PutObject` failure) | **Retried**, per the forward-progress fix already on the base branch. |

### What changed

- **`openwpm/errors.py`** — new `ConstraintViolation(message, *, table, visit_id, reason)`: the typed data-fault signal carrying enough context to investigate.
- **`openwpm/storage/sql_provider.py`** — `store_record` now *raises* `ConstraintViolation` on schema-tripping errors (`IntegrityError` / `ProgrammingError` / `InterfaceError`, and the schema-mismatch subset of `OperationalError` — "no such table/column"), instead of logging "Unsupported record" and silently dropping. Genuinely transient `OperationalError`s ("database is locked", "disk I/O error") are re-raised for the retry path.
- **`openwpm/storage/arrow_storage.py`** — `_create_batch` raises `ConstraintViolation` on `pa.lib.ArrowInvalid` instead of silently dropping the batch.
- **`openwpm/storage/storage_controller.py`**:
  - `_guarded_store_record` isolates every per-record store at the task boundary: a `ConstraintViolation` (or any unexpected exception) is logged with a clear, investigable message and recorded in `failed_visits`; it **never re-raises** into the connection handler or the finalize path.
  - `finalize_visit_id` forces the visit's effective success to `False` if any of its records tripped the schema (even if the browser sent `success=True`), and handles a `ConstraintViolation` surfaced lazily by the Arrow provider at finalize time — re-finalizing the visit as interrupted so it still reaches a FAILED terminal state.
  - A permanent flush failure on shutdown **surfaces the real error** (not a masked "timeout") and still drains every pending visit as FAILED so shutdown neither hangs nor strands a visit.

### How the invariants now hold

The four non-negotiables (and the adversarial invariants) hold:

1. **Never strand** — every started visit reaches a terminal state. A raising store no longer aborts `finalize_visit_id`, so the visit is always enqueued (as failed). *(G1: `test_raising_store_record_visit_still_finalizes`, `..._unfinalized_visit_enqueued_on_shutdown`)*
2. **Never hang** — a callback `CommandSequence` blocked on a failed record always gets a terminal result. A permanent write fault no longer leaves a finalize token unresolved and blocking shutdown. *(G2: `test_permanent_write_table_fault_visit_still_completes`)*
3. **Never break the shared `DataSocket`** — the per-record failure is isolated so the connection (and the rest of the crawl) survives one bad record. *(G1b: `test_raising_store_record_does_not_break_shared_connection`)*
4. **Never silently drop** — a schema-tripping record fails the visit and is recorded in `incomplete_visits`. *(`test_constraint_violation_fails_visit_and_records_incomplete`)*

### Tests

Brings the relevant adversarial scenarios in as **passing** tests (they were `xfail(strict=True)` in the adversarial suite — under this policy they now pass):

- `test/storage/test_adversarial_storage_controller.py` — G1, G1b, G2, a dedicated constraint-violation test, plus the surviving S4/S6 scenarios.
- `test/storage/test_adversarial_socket.py` — wire-protocol hostility (S3).
- `test/storage/conftest.py` — `adversarial_mp_logger` fixture (errors are expected).

The existing forward-progress liveness tests (`test_storage_controller_liveness.py`) stay green, as do `test_storage_controller.py`, `test_storage_providers.py`, and `test_arrow_cache.py`. `mypy` and `pre-commit` pass.

### Cross-PR coordination

- **#1198** (`test/adversarial-robustness`): the four `xfail(strict=True)` G1/G1b/G2 tests **flip to PASS** under this policy. That suite should rebase onto / be superseded by this PR — its xfail markers must be removed (they would XPASS-fail otherwise).
- **#1161** (SQLAlchemy/Postgres provider): its `store_record` needs the **same** constraint→fail-visit handling (raise `ConstraintViolation` on DB integrity/schema errors). Its provider isn't on this base, so that's a **follow-up on its own branch**.
- **#1174**: the error-surfacing concern (don't mask a real finalize error as a timeout) **aligns** — the shutdown drain here surfaces the genuine failure instead of a timeout.

### Open sub-decision for a maintainer

On the **Arrow** path, a constraint violation that hits one of several tables in a visit keeps the already-validated batches from the other tables (partial-keep) and still records the visit as incomplete. This is the non-destructive default (don't roll back valid data). If a failed visit should instead be **all-or-nothing** (roll back every batch for that visit), that's a deliberate change — flagging it rather than guessing.
