### PR TITLE
test: rewrite asserts in shared test helper modules for readable failures

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -6,6 +6,18 @@ from typing import Any, Callable, Generator, List, Literal, Protocol, Tuple, Typ
 
 import pytest
 
+# Enable pytest's assertion rewriting (the rich observed-vs-expected diff) for
+# shared test helper/base modules. pytest only rewrites collected test modules
+# and conftest.py automatically; helper modules that hold runtime asserts (e.g.
+# OpenWPMJSTest._check_calls' `assert observed == expected`) are otherwise run
+# un-rewritten and fail with a bare `AssertionError`. This call must run before
+# those modules are first imported, so it stays above every other import here.
+pytest.register_assert_rewrite(
+    "test.openwpm_jstest",
+    "test.openwpmtest",
+    "openwpm.utilities.db_utils",
+)
+
 from openwpm.config import BrowserParams, ManagerParams
 from openwpm.mp_logger import MPLogger
 from openwpm.storage.sql_provider import SQLiteStorageProvider


### PR DESCRIPTION
## Problem

pytest only applies assertion rewriting — the rich `observed == expected` diff — to two kinds of modules: collected test modules (the `test_*.py` pattern) and `conftest.py` files (which are rewritten automatically). Shared helper/base classes and utility modules are imported by the tests but are **not** rewritten, so any `assert` that executes inside them fails with a bare `AssertionError` and no values.

This bit `test/test_js_instrument.py::TestJSInstrumentNoObjectGlobalLeak`, whose comparison actually lives in `test/openwpm_jstest.py::OpenWPMJSTest._check_calls`:

```python
assert observed_calls == expected_method_calls
```

When it failed, the report showed only `- AssertionError`, hiding the observed-vs-expected call lists that make the failure diagnosable.

## Fix

Register the helper modules that contain runtime asserts via `pytest.register_assert_rewrite(...)` at the very top of `test/conftest.py`, before those modules are first imported:

- `test.openwpm_jstest` — `OpenWPMJSTest._check_calls` observed-vs-expected asserts (the motivating case)
- `test.openwpmtest` — `OpenWPMTest` base class
- `openwpm.utilities.db_utils` — test-only DB query helper

### Modules deliberately *not* registered

- `test.storage.fixtures` — already rewritten automatically because it is listed in `pytest_plugins`.
- `test.utilities` — contains no runtime asserts.
- `test/manual_test.py` — an interactive script, never imported by the test run.

## Verification

A throwaway pyonly test confirmed each registered module's `__loader__` is pytest's `AssertionRewritingHook`:

- **Before** this change: `test.openwpm_jstest` / `test.openwpmtest` / `openwpm.utilities.db_utils` load with a plain `SourceFileLoader` (not rewritten); `test.storage.fixtures` is already rewritten via `pytest_plugins`.
- **After**: all registered modules load with `AssertionRewritingHook`.

The throwaway test was removed before committing.


## References

- pytest API reference — [`pytest.register_assert_rewrite`](https://docs.pytest.org/en/stable/reference/reference.html#pytest-register-assert-rewrite): *"Register one or more module names to be rewritten on import. This function will make sure that this module or all modules inside the package will get their assert statements rewritten."*
- pytest explanation — [Assertion rewriting](https://docs.pytest.org/en/stable/how-to/writing_plugins.html#assertion-rewriting): why pytest only rewrites `assert` in collected test modules and explicitly-registered modules, and why helper/base modules need registering to get the rich introspection.
