### PR TITLE
[investigation/do-not-merge] surface legacy instrument error.stack

### DIFF
--- a/test/test_js_instrument_error_stack.py
+++ b/test/test_js_instrument_error_stack.py
@@ -1,0 +1,118 @@
+"""INVESTIGATION / DO-NOT-MERGE: surface the page-observable error.stack of a
+thrown instrumented call so the literal trace shows up in the CI log.
+
+This reproduces PR #1207's (``harden/legacy-error-stacks``) setup faithfully:
+it instruments ``window.atob``, has page code call it with invalid base64 so it
+throws an ``InvalidCharacterError``, catches the error in page code, stashes
+``e.stack`` into ``document.title`` (prefixed ``STACK:``), and a custom command
+reads the title back to a file across the process boundary.
+
+The ONE difference from #1207: instead of asserting
+``"moz-extension://" not in stack`` -- which is a NO-OP because the legacy
+instrument runs in the page world and never produces a moz-extension frame --
+this test DUMPS the exact captured stack via ``pytest.fail(...)``. ``pytest.fail``
+is used deliberately: it guarantees the full stack prints in the CI log
+regardless of content (a passing assertion would hide it). This lets us read the
+literal ``error.stack`` value and check #1207's "no moz-extension:// frame" claim
+against ground truth.
+
+Expectation (per an earlier empirical repro under ``datadir/stack-leak/``): no
+moz-extension:// frame is present, BUT a page-attributed legacy-instrument
+wrapper frame (``getInstrumentJS`` / ``instrumentFunction``) at the document URL
+IS present -- which is the real page-observable leak that #1207's no-op
+assertion misses.
+
+This test is EXPECTED TO FAIL in CI by design (it ends in ``pytest.fail``). That
+is not a regression; the failure message carries the captured trace.
+"""
+
+from pathlib import Path
+
+import pytest
+from selenium.webdriver import Firefox
+
+from openwpm.command_sequence import CommandSequence
+from openwpm.commands.browser_commands import GetCommand
+from openwpm.commands.types import BaseCommand
+from openwpm.config import BrowserParams, ManagerParams
+from openwpm.socket_interface import ClientSocket
+
+TEST_PAGE = "/js_instrument/instrument_error_stack.html"
+
+# The custom command writes the page-captured stack here, relative to the
+# manager's data directory, so the test can read it back across the process
+# boundary (commands run in a subprocess and can't return values directly).
+CAPTURE_FILENAME = "captured_error_stack.txt"
+
+
+class CaptureStackCommand(BaseCommand):
+    """Reads the error stack the test page stored in ``document.title``.
+
+    The page runs an instrumented API that throws, catches the error, and writes
+    its ``.stack`` into the document title (prefixed with ``STACK:``). We read it
+    back via Selenium and persist it to a file in the data directory.
+    """
+
+    def __repr__(self) -> str:
+        return "CaptureStackCommand"
+
+    def execute(
+        self,
+        webdriver: Firefox,
+        browser_params: BrowserParams,
+        manager_params: ManagerParams,
+        extension_socket: ClientSocket,
+    ) -> None:
+        title = webdriver.title
+        out_path = manager_params.data_directory / CAPTURE_FILENAME
+        out_path.write_text(title, encoding="utf-8")
+
+
+def test_instrumented_error_stack_demonstration(
+    default_params, task_manager_creator, server
+):
+    """DO-NOT-MERGE demonstration: surface the page-observable error.stack.
+
+    Reproduces #1207's flow, then prints the literal captured stack via
+    ``pytest.fail`` so Stefan can read it in CI and check the "no
+    moz-extension:// frame" claim against ground truth.
+    """
+    manager_params, browser_params = default_params
+    for bp in browser_params:
+        bp.js_instrument = True
+        # Instrument an API that we can make throw deterministically from page
+        # code. atob() raises an InvalidCharacterError (a DOMException) when
+        # given input outside the base64 alphabet.
+        bp.js_instrument_settings = [{"window": ["atob"]}]
+
+    tm, db = task_manager_creator((manager_params, browser_params))
+    cs = CommandSequence(server.base + TEST_PAGE)
+    cs.append_command(GetCommand(server.base + TEST_PAGE, 0))
+    cs.append_command(CaptureStackCommand())
+    tm.execute_command_sequence(cs)
+    tm.close()
+
+    capture_path: Path = manager_params.data_directory / CAPTURE_FILENAME
+    assert capture_path.exists(), "custom command did not record the page title"
+    captured = capture_path.read_text(encoding="utf-8")
+
+    # Sanity: the instrumented call must actually have thrown and been caught in
+    # page code (otherwise the demonstration below would be vacuous).
+    assert captured.startswith("STACK:"), (
+        "expected the instrumented atob() call to throw and the page to capture "
+        f"its stack; got title: {captured!r}"
+    )
+    stack = captured[len("STACK:") :]
+
+    # DEMONSTRATION: dump the exact captured stack into the CI log. pytest.fail
+    # guarantees the full message prints regardless of content (unlike a passing
+    # assertion, which would hide it). This test is EXPECTED TO FAIL by design.
+    has_mozext = "moz-extension://" in stack
+    has_wrapper = ("instrumentFunction" in stack) or ("getInstrumentJS" in stack)
+    pytest.fail(
+        "DEMONSTRATION (do-not-merge): page-observable error.stack of a thrown "
+        "instrumented atob() call.\n"
+        f"  moz-extension:// frame present? {has_mozext}\n"
+        f"  legacy instrument wrapper frame present? {has_wrapper}\n"
+        "--- full captured stack ---\n" + stack
+    )

--- a/test/test_js_instrument_stack_pop.py
+++ b/test/test_js_instrument_stack_pop.py
@@ -1,0 +1,116 @@
+"""INVESTIGATION / DO-NOT-MERGE: can "popping the top frame off stack traces"
+hide the legacy instrument's page-observable wrapper frame?
+
+Companion to ``test_js_instrument_error_stack.py`` (#1212), which surfaced the
+real leak: when an instrumented native throws, the page-observable ``error.stack``
+shows the legacy wrapper (``getInstrumentJS/instrumentFunction/<``) as the TOP
+frame. The user's hypothesis: have the page-world instrument "pop the top frame"
+off any stack a page reads, hiding the wrapper.
+
+This test empirically answers that with a self-contained page
+(``instrument_stack_pop.html``) that models the wrapper frame, installs an
+``Error.prototype.stack`` getter patch in two variants -- ``crude`` (drop the top
+frame unconditionally) and ``targeted`` (drop only instrument-attributed frames)
+-- and measures, for each, whether the wrapper is hidden and at what cost.
+
+The empirical verdict (Firefox 152, also reproduced direct-selenium with the REAL
+inlined ``getInstrumentJS`` under ``datadir/stack-pop/``):
+
+* ``Error.prototype.stack`` is a native accessor; instances have no own ``stack``
+  data property, so a patch must redefine that accessor.
+* The #1207/#1212 throw cases (``atob``, ``getImageData``) raise a **DOMException**,
+  whose ``.stack`` comes from ``DOMException.prototype`` -- a SEPARATE accessor. An
+  ``Error.prototype.stack`` patch is therefore **inert** for exactly those cases.
+* Where the patch applies (a real ``Error``), **crude over-pops** every legitimate
+  page Error's top frame; targeted avoids that but...
+* ...both leave the stack getter **non-native** (page-detectable, same toString
+  wall as #57), and both are **defeated cross-realm**: a pristine ``Error.prototype``
+  stack getter from a fresh ``<iframe>`` realm re-derives the unfiltered stack,
+  wrapper and all.
+
+Conclusion: popping the top frame is NOT a viable cheap win -- it is another
+instance of the page-world cross-realm ceiling (#56/#57 family). This test asserts
+that ceiling, then dumps the full measured evidence via ``pytest.fail`` so the
+literal stacks appear in the CI log. EXPECTED TO FAIL by design (do-not-merge).
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+from selenium.webdriver import Firefox
+
+from openwpm.command_sequence import CommandSequence
+from openwpm.commands.browser_commands import GetCommand
+from openwpm.commands.types import BaseCommand
+from openwpm.config import BrowserParams, ManagerParams
+from openwpm.socket_interface import ClientSocket
+
+TEST_PAGE = "/js_instrument/instrument_stack_pop.html"
+CAPTURE_FILENAME = "captured_stack_pop.txt"
+
+
+class CapturePopCommand(BaseCommand):
+    """Reads the JSON measurement the test page stored in ``document.title``."""
+
+    def __repr__(self) -> str:
+        return "CapturePopCommand"
+
+    def execute(
+        self,
+        webdriver: Firefox,
+        browser_params: BrowserParams,
+        manager_params: ManagerParams,
+        extension_socket: ClientSocket,
+    ) -> None:
+        out_path = manager_params.data_directory / CAPTURE_FILENAME
+        out_path.write_text(webdriver.title, encoding="utf-8")
+
+
+def test_pop_top_frame_is_a_ceiling(default_params, task_manager_creator, server):
+    """DO-NOT-MERGE demonstration: popping the top frame cannot hide the wrapper
+    without unacceptable cost (inert for DOMExceptions, over-pop, non-native
+    detectability, cross-realm bypass)."""
+    manager_params, browser_params = default_params
+    tm, db = task_manager_creator((manager_params, browser_params))
+    cs = CommandSequence(server.base + TEST_PAGE)
+    cs.append_command(GetCommand(server.base + TEST_PAGE, 0))
+    cs.append_command(CapturePopCommand())
+    tm.execute_command_sequence(cs)
+    tm.close()
+
+    capture_path: Path = manager_params.data_directory / CAPTURE_FILENAME
+    assert capture_path.exists(), "custom command did not record the page title"
+    title = capture_path.read_text(encoding="utf-8")
+    assert title.startswith("POP:"), f"page did not run; got title: {title!r}"
+    r = json.loads(title[len("POP:") :])
+
+    # Mechanism sanity: the patch target is a native accessor and DOMException has
+    # its own, separate stack accessor.
+    assert r["errProtoIsNativeAccessor"] is True
+    assert r["domExceptionHasSeparateStack"] is True
+    assert r["before"]["dom_type"] == "DOMException"
+
+    crude, targeted = r["crude"], r["targeted"]
+
+    # 1. Inert for the #1207/#1212 DOMException throws -- both variants.
+    assert crude["dom_hidesWrapper"] is False
+    assert targeted["dom_hidesWrapper"] is False
+
+    # 2. Crude over-pops a legitimate page Error's top frame; targeted does not.
+    assert crude["legit_overPops"] is True
+    assert targeted["legit_overPops"] is False
+
+    # 3. The patched getter is page-observably non-native for both.
+    assert crude["patchDetectable_getterNonNative"] is True
+    assert targeted["patchDetectable_getterNonNative"] is True
+
+    # 4. Both are defeated cross-realm: a pristine iframe-realm getter reveals the
+    #    wrapper that the main-realm patch hid.
+    assert crude["crossRealm_revealsWrapper"] is True
+    assert targeted["crossRealm_revealsWrapper"] is True
+
+    pytest.fail(
+        "DEMONSTRATION (do-not-merge): popping the top frame is a ceiling, not a "
+        "cheap win.\n" + json.dumps(r, indent=2)
+    )

--- a/test/test_pages/js_instrument/instrument_error_stack.html
+++ b/test/test_pages/js_instrument/instrument_error_stack.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<html>
+  <head>
+    <title>pending</title>
+    <meta charset="utf-8" />
+  </head>
+  <body>
+    <h3>Test page: instrumented API error-stack sanitization</h3>
+    <p>
+      Calls an instrumented API (<code>window.atob</code>) with input that makes
+      it throw, then catches the error in page code and records its
+      <code>.stack</code>. A leak-free instrument must NOT leave any
+      <code>moz-extension://</code> frame on the page-observable stack.
+    </p>
+    <script type="text/javascript">
+      // `atob` is instrumented (configured python-side in the test). Passing a
+      // string with characters outside the base64 alphabet makes the browser's
+      // own implementation throw an InvalidCharacterError (a DOMException),
+      // and that error propagates back out through the instrument wrapper.
+      var stack = "NO_THROW";
+      try {
+        window.atob("not valid base64 !@#$%");
+      } catch (e) {
+        // Stringify the stack so a custom command can read it off the title.
+        stack = "STACK:" + (e && e.stack ? String(e.stack) : "<empty>");
+      }
+      document.title = stack;
+    </script>
+  </body>
+</html>

--- a/test/test_pages/js_instrument/instrument_stack_pop.html
+++ b/test/test_pages/js_instrument/instrument_stack_pop.html
@@ -1,0 +1,182 @@
+<!doctype html>
+<html>
+  <head>
+    <title>pending</title>
+    <meta charset="utf-8" />
+  </head>
+  <body>
+    <h3>Test page: can "popping the top frame" hide an instrument wrapper?</h3>
+    <p>
+      Models the legacy instrument's page-world wrapper frame
+      (<code>getInstrumentJS/instrumentFunction/&lt;</code>), installs an
+      <code>Error.prototype.stack</code> getter patch that drops frames, and
+      measures whether the wrapper is hidden and at what cost. Results are written
+      to <code>document.title</code> (prefixed <code>POP:</code>) as JSON so a
+      custom command can read them across the process boundary.
+    </p>
+    <iframe id="xrealm" src="about:blank" style="display: none"></iframe>
+    <script type="text/javascript">
+      (function () {
+        var out = { schema: "stack-pop-demo/v1" };
+
+        // --- Model the legacy instrument's wrapper, reproducing its frame name.
+        // The real wrapper shows up on stacks as "getInstrumentJS/instrumentFunction/<".
+        // We reproduce that exact attribution by nesting identically-named functions
+        // around a closure that apply()s the original native. This is a faithful
+        // model of the hiding problem: the four properties measured below are
+        // properties of Firefox's Error/DOMException stack machinery and are
+        // independent of the wrapper's body (the sibling test
+        // test_js_instrument_error_stack.py captures the REAL instrument's stack).
+        function getInstrumentJS() {
+          function instrumentFunction(orig) {
+            return function () {
+              return orig.apply(this, arguments);
+            };
+          }
+          return instrumentFunction;
+        }
+        var wrap = getInstrumentJS();
+        var C2D = CanvasRenderingContext2D.prototype;
+        C2D.getImageData = wrap(C2D.getImageData); // DOMException thrower
+        JSON.parse = wrap(JSON.parse); // real-Error (SyntaxError) thrower
+
+        function pageThrowsDOM() {
+          // getImageData(0,0,0,0) -> IndexSizeError, a DOMException (the
+          // #1207/#1212 family: atob() also throws a DOMException).
+          var ctx = document.createElement("canvas").getContext("2d");
+          ctx.getImageData(0, 0, 0, 0);
+        }
+        function pageThrowsReal() {
+          JSON.parse("{bad"); // SyntaxError -- a real Error subclass.
+        }
+        function legitPlainErrorTop() {
+          return new Error("legit"); // NO wrapper on its stack.
+        }
+        function grab(fn) {
+          try {
+            fn();
+          } catch (e) {
+            return e;
+          }
+          return null;
+        }
+        function shapes(stack) {
+          if (typeof stack !== "string") return ["<non-string:" + typeof stack + ">"];
+          return stack
+            .split("\n")
+            .map(function (ln) {
+              if (!ln) return "";
+              var at = ln.indexOf("@");
+              var fn = at >= 0 ? ln.slice(0, at) : ln;
+              var loc = ln.match(/(:\d+:\d+)\s*$/);
+              return (fn || "<anon>") + " " + (loc ? loc[1] : "<noloc>");
+            })
+            .filter(function (x) {
+              return x !== "";
+            });
+        }
+        function isWrapper(line) {
+          return /(^|[@\/])(getInstrumentJS|instrumentFunction)\b/.test(line);
+        }
+
+        // --- A: how Firefox exposes the stack (dictates the patch).
+        var ed = Object.getOwnPropertyDescriptor(Error.prototype, "stack");
+        out.errProtoIsNativeAccessor =
+          !!(ed && ed.get) &&
+          /\[native code\]/.test(Function.prototype.toString.call(ed.get));
+        var dd = Object.getOwnPropertyDescriptor(DOMException.prototype, "stack");
+        out.domExceptionHasSeparateStack = !!(dd && dd.get && dd.get !== (ed && ed.get));
+
+        // --- BEFORE patch: confirm the throw types and that the wrapper leaks.
+        var domB = grab(pageThrowsDOM),
+          realB = grab(pageThrowsReal);
+        out.before = {
+          dom_type: domB && domB.constructor && domB.constructor.name,
+          dom_stack: shapes(domB && domB.stack),
+          real_type: realB && realB.constructor && realB.constructor.name,
+          real_stack: shapes(realB && realB.stack),
+        };
+
+        // Save the pristine native descriptor so we can run both variants cleanly.
+        var NATIVE_DESC = Object.getOwnPropertyDescriptor(Error.prototype, "stack");
+        function installPatch(mode) {
+          var origGet = NATIVE_DESC.get,
+            origSet = NATIVE_DESC.set;
+          function filter(frames) {
+            return mode === "crude"
+              ? frames.slice(1) // drop the top frame unconditionally
+              : frames.filter(function (l) {
+                  return !isWrapper(l); // drop ONLY instrument-attributed frames
+                });
+          }
+          Object.defineProperty(Error.prototype, "stack", {
+            configurable: true,
+            get: function () {
+              var raw = origGet.call(this);
+              if (typeof raw !== "string") return raw;
+              return filter(raw.split("\n")).join("\n");
+            },
+            set: origSet,
+          });
+        }
+        function restoreNative() {
+          Object.defineProperty(Error.prototype, "stack", NATIVE_DESC);
+        }
+
+        function measure(mode) {
+          installPatch(mode);
+          var dom = grab(pageThrowsDOM),
+            real = grab(pageThrowsReal),
+            legit = legitPlainErrorTop();
+          var domStack = shapes(dom && dom.stack);
+          var realStack = shapes(real && real.stack);
+          var legitStack = shapes(legit && legit.stack);
+
+          // patch detectability
+          var pd = Object.getOwnPropertyDescriptor(Error.prototype, "stack");
+          var getterIsNative =
+            !!(pd && pd.get) &&
+            /\[native code\]/.test(Function.prototype.toString.call(pd.get));
+
+          // cross-realm bypass on the real Error
+          var xRevealsWrapper = null,
+            xStack = null;
+          try {
+            var xpd = Object.getOwnPropertyDescriptor(
+              document.getElementById("xrealm").contentWindow.Error.prototype,
+              "stack"
+            );
+            if (xpd && xpd.get && real) {
+              var xs = xpd.get.call(real);
+              xStack = shapes(xs);
+              xRevealsWrapper =
+                typeof xs === "string" && shapes(xs).some(isWrapper);
+            }
+          } catch (e) {
+            xStack = ["XERR:" + e];
+          }
+
+          restoreNative();
+          return {
+            dom_hidesWrapper: !domStack.some(isWrapper),
+            real_hidesWrapper: !realStack.some(isWrapper),
+            legit_overPops: !legitStack.some(function (l) {
+              return /legitPlainErrorTop/.test(l);
+            }),
+            legit_topFrame: legitStack[0] || null,
+            patchDetectable_getterNonNative: !getterIsNative,
+            crossRealm_revealsWrapper: xRevealsWrapper,
+            real_stack_mainPatched: realStack,
+            real_stack_crossRealm: xStack,
+            dom_stack: domStack,
+          };
+        }
+
+        out.crude = measure("crude");
+        out.targeted = measure("targeted");
+
+        document.title = "POP:" + JSON.stringify(out);
+      })();
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Investigation / do-not-merge

This PR is **stacked on #1211** (`test/assert-rewrite-helpers`). It now carries
**two investigation commits** (both end in `pytest.fail` to print their evidence
in the CI log; **both EXPECTED TO FAIL by design** — do **not** merge):

1. `surface ... error.stack` — reproduces #1207's flow and dumps the literal
   page-observable `error.stack` of a thrown instrumented call.
2. `demonstrate that popping the top stack frame cannot hide the wrapper` —
   answers the follow-up question below.

---

### Commit 1 — what the leak actually is

Faithfully reproduces #1207's (`harden/legacy-error-stacks`) flow: instruments
`window.atob`, page code calls `atob("not valid base64 !@#$%")` so it throws an
`InvalidCharacterError`, the page catches it and stashes `e.stack` into
`document.title`; a `CaptureStackCommand` reads the title back across the process
boundary.

#1207 asserts `"moz-extension://" not in stack` — a **no-op**: the legacy
instrument runs in the **page world**, so there is never a `moz-extension://`
frame to leak (the assertion passes vacuously). This commit instead **surfaces**
the captured stack via `pytest.fail`. The real, page-observable leak #1207's
assertion misses is a page-attributed **wrapper frame**
(`getInstrumentJS/instrumentFunction/<`) sitting as the **top** frame:

```
getInstrumentJS/instrumentFunction/<@<page-url>:<line>:<col>   <- wrapper (frame 0)
<page-call-site>@<page-url>:<line>:<col>                       <- page's atob() call site
```

---

### Commit 2 — can the instrument "pop the top frame" to hide that wrapper?

The follow-up hypothesis: have the page-world instrument patch `error.stack` to
drop the top frame, hiding the wrapper. **Verdict (empirically): no — this is
another page-world cross-realm ceiling (the #56/#57 family), not a cheap win.**
Do not ship an instrument patch. Measured on Firefox 152 (also reproduced
direct-selenium with the REAL inlined `getInstrumentJS`):

**How Firefox exposes `error.stack` (dictates the patch).** `Error.prototype.stack`
is a **native accessor** (`get stack`, `[native code]`); instances have **no own
`stack` data property**. So a patch must redefine that accessor. But
`DOMException.prototype.stack` is a **SEPARATE native accessor** — and the
#1207/#1212 throw cases (`atob`, `getImageData`) raise a **`DOMException`**
(`InvalidCharacterError` / `IndexSizeError`), whose stack does **not** come from
`Error.prototype`. So an `Error.prototype.stack` patch is **inert** for exactly
the cases #1207 cared about (`dom_hidesWrapper: false`, both variants); you would
have to also patch every `DOMException`/`Error` subtype's `stack` accessor.

Two patch variants, where the patch *does* apply (a real `Error`,
`JSON.parse("{bad")` → `SyntaxError`, routed through the wrapper):

| measure | crude (drop top frame) | targeted (drop only instrument frames) |
|---|---|---|
| hides wrapper (real Error)? | yes | yes |
| **over-pops a legit page Error?** | **YES** — eats the genuine top frame | no |
| **patch page-observable?** | **YES** — getter non-native (`get`, not `get stack`; JS-body `toString`) | **YES** — same |
| **cross-realm bypassable?** | **YES** | **YES** |

**Over-pop (crude), verbatim.** A legit page Error with **no** wrapper on its
stack — crude silently strips its real top frame `legitPlainErrorTop`:

```
main-realm (crude patch):  ["measure :130:21", "<anon> ...", "<anon> ..."]   # legitPlainErrorTop EATEN
targeted patch:            ["legitPlainErrorTop :53:18", ...]                # preserved
```

Crude corrupts the top frame of **every** page Error — a correctness disaster and
itself a trivial detector (`function f(){return new Error().stack} f()` no longer
shows `f`). Targeted avoids over-pop but is still non-native-detectable.

**Cross-realm bypass (both variants), verbatim.** The same `Error`, read main-realm
(patched, wrapper hidden) vs. through a pristine, never-patched `Error.prototype`
stack getter pulled from a same-origin `<iframe>` realm:

```
main-realm (patched):   ["pageThrowsReal :50:16", "grab :57:13", "measure ...", ...]
iframe-realm (native):  ["getInstrumentJS/instrumentFunction/< :33:27",        # wrapper REVEALED
                         "pageThrowsReal :50:16", "grab :57:13", "measure ...", ...]
```

The iframe realm's getter stays native and untouched by the main-realm patch and
re-derives the unfiltered stack, wrapper and all — the same architectural wall as
the #57 `toString` bypass. A main-realm-only patch cannot close it.

**Why net-negative:** inert for the actual DOMException throws unless you also
patch every error subtype's `stack`; detectable (non-native accessor — the same
toString-wall tell as #57); crude over-pops legitimate page frames; targeted still
non-native-detectable and still cross-realm-bypassed. The wrapper-frame leak is a
property of running in the page world; a page-world stack-getter patch is defeated
by the same cross-realm ceiling as the toString leak.

The second commit's test asserts this ceiling, then `pytest.fail`-dumps the full
measured JSON so the literal stacks appear in the CI log.

### Purpose

Let reviewers read the literal page-observable `error.stack` (commit 1) and the
empirical evidence that "pop the top frame" is a ceiling, not a fix (commit 2),
against ground truth — before deciding whether any error-stack hardening is worth
shipping for the legacy instrument.
