### PR TITLE
[verify/do-not-merge] arity/name guard fails without the #1210 mitigation

### DIFF
--- a/test/test_js_instrument.py
+++ b/test/test_js_instrument.py
@@ -141,6 +141,61 @@ class TestJSInstrumentByPython(OpenWPMJSTest):  # noqa
         )
 
 
+class TestJSInstrumentFunctionArityAndName(OpenWPMJSTest):
+    """A wrapped function must report the same ``.length`` (arity) and ``.name``
+    as the native function it wraps (crosslink #56).
+
+    Without copying these across, the wrapper closure reports ``length === 0``
+    and ``name === ""``, which differs from every native method and is trivially
+    page-observable for fingerprinting. The test page reads the wrapped
+    ``window.fetch``'s observable ``.length``/``.name`` and encodes them into the
+    arguments of an instrumented ``fetch`` call. Native ``fetch`` has arity 1 and
+    name ``"fetch"``; we assert the logged call argument reflects those native
+    values (i.e. ``arity-1`` and ``name-fetch``), which would read ``arity-0`` /
+    ``name-`` under the un-fixed wrapper.
+    """
+
+    TEST_PAGE = "instrument_function_arity_name.html"
+
+    METHOD_CALLS = {
+        (
+            "window.fetch",
+            "call",
+            '["https://arity-1.example.com/name-fetch"]',
+        ),
+    }
+    GETS_AND_SETS: Set[Tuple[str, str, str]] = set()
+
+    def get_config(
+        self, data_dir: Optional[Path]
+    ) -> Tuple[ManagerParams, List[BrowserParams]]:
+        manager_params, browser_params = super().get_config(data_dir)
+        browser_params[0].prefs = {
+            "network.dns.localDomains": "arity-1.example.com,arity-0.example.com"
+        }
+        browser_params[0].js_instrument_settings = [
+            {
+                "window": [
+                    "fetch",
+                ]
+            },
+        ]
+        return manager_params, browser_params
+
+    def test_instrument_object(self):
+        """The wrapped fetch reports native arity (1) and name ("fetch")."""
+        db = self.visit("/js_instrument/%s" % self.TEST_PAGE)
+        top_url = f"{self.server.base}/js_instrument/{self.TEST_PAGE}"
+        self._check_calls(
+            db=db,
+            symbol_prefix="",
+            doc_url=top_url,
+            top_url=top_url,
+            expected_method_calls=self.METHOD_CALLS,
+            expected_gets_and_sets=self.GETS_AND_SETS,
+        )
+
+
 class TestJSInstrumentMockWindowProperty(OpenWPMJSTest):
     GETS_AND_SETS = {
         ("window.alreadyInstantiatedMockClassInstance", "get", "{}"),

--- a/test/test_pages/js_instrument/instrument_function_arity_name.html
+++ b/test/test_pages/js_instrument/instrument_function_arity_name.html
@@ -1,0 +1,41 @@
+<!doctype html>
+<html>
+  <head>
+    <title>
+      Test page for JS Instrument - wrapped function arity (.length) and .name
+      match the native function (crosslink #56)
+    </title>
+  </head>
+  <body>
+    <h3>
+      Test that an instrumented function wrapper reports the same
+      <code>.length</code> (arity) and <code>.name</code> as the native
+      function it wraps, so the wrapper is not trivially fingerprintable.
+    </h3>
+    <p>
+      The browser instruments <code>window.fetch</code> (configured python
+      side). Native <code>fetch</code> has <code>length === 1</code> and
+      <code>name === "fetch"</code>. We read the wrapper's observable
+      <code>.length</code> and <code>.name</code> and encode them into the
+      arguments of an instrumented <code>fetch</code> call so the values land in
+      the javascript table for the test to assert on.
+    </p>
+    <script type="text/javascript">
+      // Accessing window.fetch returns the instrumented wrapper (the property
+      // was redefined as an accessor by the instrument).
+      const wrapped = window.fetch;
+      const arity = wrapped.length;
+      const name = wrapped.name;
+      // Encode the observed arity/name into the fetch URL so they are logged as
+      // the call's arguments. localDomains maps these hosts so the request
+      // does not hit the network.
+      const probe =
+        "https://arity-" + arity + ".example.com/name-" + name;
+      try {
+        window.fetch(probe);
+      } catch (e) {
+        console.log("fetch probe threw (ignored): ", e);
+      }
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Do-not-merge verification branch

This branch runs PR #1210's `TestJSInstrumentFunctionArityAndName` against **un-fixed master** to prove the test is a genuine guard for the wrapper arity/name mitigation.

### What is on this branch
- **Only** #1210's test additions are applied on top of master:
  - `TestJSInstrumentFunctionArityAndName` in `test/test_js_instrument.py` (the new class, +55 lines, nothing else)
  - the new test page `test/test_pages/js_instrument/instrument_function_arity_name.html`
- `Extension/src/lib/js-instruments.ts` is left as master's **UN-FIXED** wrapper — the `copyMatchingDescriptor` length/name copy from #1210 is intentionally **not** applied. The extension was rebuilt from this un-fixed source.

### Expected result: FAILURE
The test reads the live wrapped `window.fetch`'s `.length`/`.name`, encodes them into a fetch URL, and asserts `arity-1.example.com/name-fetch`. Under the un-fixed wrapper the closure reports `length === 0` / `name === ""`, so the logged call is expected to be `arity-0.example.com/name-` → the tests shard running this test **should fail**.

That failure is the proof: it demonstrates the test genuinely guards the mitigation and is not a tautology. **Do not merge.**
