### PR TITLE
fix(docs): move Read the Docs onto supported build settings

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,8 +1,10 @@
 version: 2
 build:
-  os: ubuntu-20.04
+  os: ubuntu-24.04
   tools:
-    python: mambaforge-4.10
+    # mambaforge is deprecated by Read the Docs; miniforge3 is the successor.
+    # The python version itself comes from environment.yaml.
+    python: miniforge3-latest
 sphinx:
   builder: html
   configuration: docs/conf.py


### PR DESCRIPTION
## Problem

The Read the Docs build was failing config validation:

```
Config validation error in build.os. Expected one of (ubuntu-22.04,
ubuntu-24.04, ubuntu-26.04, ubuntu-lts-latest), got type str (ubuntu-20.04).
```

`ubuntu-20.04` has been retired upstream. `mambaforge-4.10` is deprecated too,
so it was the next thing due to break. The Python version still comes from
`environment.yaml`.

## Why it went unseen

Not because a red check was ignored — because there was no check. PRs #1225,
#1212 and #1207 carry no commit statuses at all, and no master commit has ever
had one. Read the Docs was reporting nothing to GitHub.

That is already fixed outside this PR: the Read the Docs GitHub App is now
installed on the org, and it posts the build result as a
`docs/readthedocs.org:openwpm` commit status on the pull request head. It shows
up in `gh pr checks`, which exits non-zero on it, so a broken docs build is now
visible with the rest of the checks.

## Verification

The Read the Docs build for this PR succeeds:
https://openwpm--1226.org.readthedocs.build/en/1226/

## Notes

Earlier revisions of this PR added CI machinery around this — a Sphinx build in
Actions, then a poll against the Read the Docs API, then a job mirroring the
commit status. All were dropped. The app already surfaces the result, and the
status cannot be made a required check anyway: merge queue and pull request
required checks are the same list, and Read the Docs does not build merge queue
refs, so requiring it would stall every queue entry until the 20 minute timeout.

The remaining gap is that nothing *blocks* a merge on a red docs build. That is
a deliberate trade rather than an oversight — reviewing the checks covers it.
