### PR TITLE
docs(readme): point the CI badge at the workflow file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 
-# OpenWPM [![Documentation Status](https://readthedocs.org/projects/openwpm/badge/?version=latest)](https://openwpm.readthedocs.io/en/latest/?badge=latest) [![Build Status](https://github.com/openwpm/OpenWPM/workflows/Tests%20and%20linting/badge.svg?branch=master)](https://github.com/openwpm/OpenWPM/actions?query=branch%3Amaster) [![OpenWPM Matrix Channel](https://img.shields.io/matrix/OpenWPM:mozilla.org?label=Join%20us%20on%20matrix&server_fqdn=mozilla.modular.im)](https://matrix.to/#/#OpenWPM:mozilla.org?via=mozilla.org) <!-- omit in toc -->
+# OpenWPM [![Documentation Status](https://readthedocs.org/projects/openwpm/badge/?version=latest)](https://openwpm.readthedocs.io/en/latest/?badge=latest) [![Build Status](https://github.com/openwpm/OpenWPM/actions/workflows/run-tests.yaml/badge.svg?branch=master)](https://github.com/openwpm/OpenWPM/actions/workflows/run-tests.yaml?query=branch%3Amaster) [![OpenWPM Matrix Channel](https://img.shields.io/matrix/OpenWPM:mozilla.org?label=Join%20us%20on%20matrix&server_fqdn=mozilla.modular.im)](https://matrix.to/#/#OpenWPM:mozilla.org?via=mozilla.org) <!-- omit in toc -->
 
 OpenWPM is a web privacy measurement framework which makes it easy to
 collect data for privacy studies on a scale of thousands to millions


### PR DESCRIPTION
The "Tests and linting" badge in the README renders as **no status** even
though the workflow is green on master.

## Cause

The README uses GitHub's old name-based badge path, which no longer resolves
for this repository:

| URL | renders |
| --- | --- |
| `/workflows/Tests%20and%20linting/badge.svg?branch=master` (current) | `no status` |
| `/actions/workflows/run-tests.yaml/badge.svg?branch=master` | `passing` |

Both fetched just now; the first returns `<title>Tests and linting - no
status</title>`, the second `<title>Tests and linting - passing</title>`.

The supported form addresses the workflow by file name rather than by display
name, so it also stops silently breaking if the workflow's `name:` is ever
changed.

## Change

Point the badge at `run-tests.yaml`, and point its link at the same workflow
rather than the repository-wide action list, so clicking it lands on the runs
the badge actually reports.
