### PR TITLE
feat(webdriver): spoof navigator.webdriver to false in every realm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## Unreleased
+
+### Behaviour changes
+
+- `navigator.webdriver` now reads as `false` by default. Selenium sets it to
+  `true`, which is the cheapest signal a site has that a visit is automated, so
+  crawls have been announcing themselves to every page they visit. The new
+  `BrowserParams.spoof_webdriver` controls it and defaults to `True`, meaning
+  **existing crawls will present differently to sites than they did before** —
+  set it to `False` to keep the old behaviour, or to measure how much of a
+  site's treatment of a crawl is attributable to that one signal. The spoof
+  records nothing and is independent of the instruments. It requires
+  `dom.ipc.processPrelaunch.enabled`; disabling that pref while the spoof is on
+  is now a `ConfigError` rather than a crawl with some content processes
+  unhooked.
+- `validate_browser_params` no longer replaces its own explanatory errors with
+  a generic "Something went wrong" message, so rejections such as `echo_mode`
+  or `callstack_instrument` now say what is actually wrong.
+
 ## v0.37.0 - 2026-09-06
 
 Bump to Firefox 155

--- a/Extension/bundled/manifest.json
+++ b/Extension/bundled/manifest.json
@@ -52,6 +52,14 @@
         "script": "./privileged/stackDump/api.js",
         "paths": [["stackDump"]]
       }
+    },
+    "webdriverSpoof": {
+      "schema": "./privileged/webdriverSpoof/schema.json",
+      "parent": {
+        "scopes": ["addon_parent"],
+        "script": "./privileged/webdriverSpoof/api.js",
+        "paths": [["webdriverSpoof"]]
+      }
     }
   }
 }

--- a/Extension/bundled/privileged/webdriverSpoof/OpenWPMWebdriverSpoofChild.sys.mjs
+++ b/Extension/bundled/privileged/webdriverSpoof/OpenWPMWebdriverSpoofChild.sys.mjs
@@ -1,0 +1,84 @@
+/**
+ * Makes `navigator.webdriver` read as `false` in every content realm.
+ *
+ * Runs in the content process with chrome privileges, driven by the
+ * `content-document-global-created` observer notification, which fires
+ * synchronously as each window global is created -- before any script in that
+ * realm, and before the parent task that created a frame continues.
+ *
+ * Nothing in the content realm is hooked to achieve this. The page's own
+ * `Navigator.prototype.webdriver` accessor is replaced with one compiled in the
+ * page's compartment via `Cu.exportFunction`, so it reports `[native code]`
+ * under the native accessor name and the rest of the descriptor is reused
+ * unchanged. `HTMLIFrameElement.prototype` and friends are left alone, so this
+ * adds no page-observable surface of its own.
+ */
+
+export class OpenWPMWebdriverSpoofChild extends JSWindowActorChild {
+  observe(subject, topic) {
+    if (topic !== "content-document-global-created") {
+      return;
+    }
+    try {
+      spoofNavigatorWebdriver(subject);
+    } catch (error) {
+      console.error("OpenWPM: failed to spoof navigator.webdriver", error);
+    }
+  }
+}
+
+function spoofNavigatorWebdriver(win) {
+  if (!win) {
+    return;
+  }
+  // Leave privileged and extension documents alone; only content is measured.
+  const principal = win.document?.nodePrincipal;
+  if (!principal || principal.isSystemPrincipal || principal.addonPolicy) {
+    return;
+  }
+
+  const pageWindow = win.wrappedJSObject;
+  const navigatorPrototype = pageWindow?.Navigator?.prototype;
+  if (!navigatorPrototype) {
+    return;
+  }
+  const descriptor = Object.getOwnPropertyDescriptor(
+    navigatorPrototype,
+    "webdriver",
+  );
+  if (!descriptor?.get) {
+    return;
+  }
+  // `defineAs` names the page-side function, so the page sees the native
+  // accessor name "get webdriver". The throwaway null-prototype holder keeps
+  // the function off any object the page can reach.
+  const nativeGetter = descriptor.get;
+  const spoofedGetter = Cu.exportFunction(
+    function () {
+      // Delegate receiver validation to the native getter rather than
+      // reimplementing it: called on anything that is not a Navigator this
+      // throws exactly what the page would otherwise have seen, down to the
+      // message. Its return value is what we are replacing, so discard it.
+      nativeGetter.call(this);
+      return false;
+    },
+    pageWindow.Object.create(null),
+    { defineAs: "get webdriver" },
+  );
+  // `exportFunction` installs `name` before `length`; a native accessor reports
+  // them the other way round, and `Object.getOwnPropertyNames` exposes the
+  // difference. Both are configurable, so redefine them in the native order.
+  const nameDescriptor = Object.getOwnPropertyDescriptor(spoofedGetter, "name");
+  const lengthDescriptor = Object.getOwnPropertyDescriptor(
+    spoofedGetter,
+    "length",
+  );
+  delete spoofedGetter.name;
+  delete spoofedGetter.length;
+  Object.defineProperty(spoofedGetter, "length", lengthDescriptor);
+  Object.defineProperty(spoofedGetter, "name", nameDescriptor);
+  Object.defineProperty(navigatorPrototype, "webdriver", {
+    ...descriptor,
+    get: spoofedGetter,
+  });
+}

--- a/Extension/bundled/privileged/webdriverSpoof/OpenWPMWebdriverSpoofParent.sys.mjs
+++ b/Extension/bundled/privileged/webdriverSpoof/OpenWPMWebdriverSpoofParent.sys.mjs
@@ -1,0 +1,7 @@
+/**
+ * Parent side of the webdriver-spoof actor.
+ *
+ * All the work happens in the child, in the content process. This side exists
+ * because a JSWindowActor is registered as a pair; it carries no logic.
+ */
+export class OpenWPMWebdriverSpoofParent extends JSWindowActorParent {}

--- a/Extension/bundled/privileged/webdriverSpoof/api.js
+++ b/Extension/bundled/privileged/webdriverSpoof/api.js
@@ -1,0 +1,139 @@
+"use strict";
+
+const ACTOR_NAME = "OpenWPMWebdriverSpoof";
+const RESOURCE_BASE = "resource://openwpm/privileged/webdriverSpoof/";
+const BOOTSTRAP_PATH = "privileged/webdriverSpoof/bootstrap.js";
+const ROOT_PREF = "extensions.openwpm.rootURI";
+let BOOTSTRAP_URL = null;
+
+/**
+ * The `resource:` handler, used to map this extension's files to
+ * `resource://openwpm/` so the actor module can be loaded by URI.
+ *
+ * Queried as `nsIResProtocolHandler`, matching Gecko's own callers
+ * (`Extension.sys.mjs`, `BackgroundTasksManager.sys.mjs`). Note that
+ * `defineLazyServiceGetter` wants an interface object, not its name as a
+ * string -- passing a string fails with NS_ERROR_XPC_BAD_CONVERT_JS from inside
+ * XPCOMUtils, which names neither the interface nor the real problem.
+ */
+function resourceProtocol() {
+  return Services.io
+    .getProtocolHandler("resource")
+    .QueryInterface(Ci.nsIResProtocolHandler);
+}
+
+/**
+ * Registers the window actor that makes `navigator.webdriver` read as `false`.
+ *
+ * The patch has to run from an actor rather than a content script because
+ * content scripts are not injected into a frame's *uncommitted* initial
+ * about:blank -- the document that exists between `appendChild` and the real
+ * document committing. `ExtensionContent.sys.mjs` skips it deliberately
+ * (see `isUncommittedInitialDocument`, and https://bugzilla.mozilla.org/1415539).
+ * A parent that appends an iframe and reads `contentWindow.navigator.webdriver`
+ * in the same task reads exactly that document, so a content script can never
+ * cover the case.
+ *
+ * `content-document-global-created` fires synchronously in the content process
+ * for every window global, uncommitted ones included, which is below the layer
+ * that does the skipping.
+ */
+this.webdriverSpoof = class extends ExtensionAPI {
+  getAPI(context) {
+    return {
+      webdriverSpoof: {
+        async enable() {
+          // Every step here is required for the spoof to work at all. A crawl
+          // that silently lost it would produce plausible-looking data with the
+          // automation flag still visible to sites, so fail loudly instead of
+          // reporting status nobody reads.
+          if (BOOTSTRAP_URL) {
+            throw new ExtensionUtils.ExtensionError(
+              "webdriverSpoof.enable() called twice",
+            );
+          }
+
+          // resource: is the only scheme the system ESM loader accepts for an
+          // actor module; moz-extension: and the XPI's own jar: URL are both
+          // silently declined, with no error and no actor.
+          const CHILD_URI =
+            RESOURCE_BASE + "OpenWPMWebdriverSpoofChild.sys.mjs";
+          const PARENT_URI =
+            RESOURCE_BASE + "OpenWPMWebdriverSpoofParent.sys.mjs";
+
+          // The handler does propagate this mapping to content processes
+          // (SubstitutingProtocolHandler::SendSubstitution), but it does so
+          // over IPC, asynchronously with respect to the actor registration
+          // below -- register the actor straight after this and a child can be
+          // asked for the module before the mapping arrives, which surfaces as
+          // a bare "Failed to load resource://openwpm/...". The bootstrap below
+          // makes it ordered by having each content process register the
+          // mapping itself before it hosts a document.
+          resourceProtocol().setSubstitution(
+            "openwpm",
+            context.extension.rootURI,
+          );
+          Services.prefs.setStringPref(
+            ROOT_PREF,
+            context.extension.rootURI.spec,
+          );
+
+          BOOTSTRAP_URL = context.extension.rootURI.resolve(BOOTSTRAP_PATH);
+          // Processes created from here on run this during process init,
+          // ahead of any document.
+          Services.ppmm.loadProcessScript(BOOTSTRAP_URL, true);
+
+          // Processes that already exist do not pick it up, so the
+          // preallocated pool has to be replaced rather than patched: toggling
+          // the pref tears it down, and it refills with processes that postdate
+          // the registration above. Without this a page landing in a stale
+          // pooled process is unhooked.
+          const PRELAUNCH_PREF = "dom.ipc.processPrelaunch.enabled";
+          if (!Services.prefs.getBoolPref(PRELAUNCH_PREF, false)) {
+            // Preallocation is off, so the stale pool cannot be replaced and
+            // pre-existing content processes stay unhooked. Better to refuse
+            // than to crawl with partial coverage.
+            throw new ExtensionUtils.ExtensionError(
+              `webdriverSpoof requires ${PRELAUNCH_PREF} to be enabled`,
+            );
+          }
+          Services.prefs.setBoolPref(PRELAUNCH_PREF, false);
+          Services.prefs.setBoolPref(PRELAUNCH_PREF, true);
+
+          ChromeUtils.unregisterWindowActor(ACTOR_NAME);
+          ChromeUtils.registerWindowActor(ACTOR_NAME, {
+            parent: { esModuleURI: PARENT_URI },
+            child: {
+              esModuleURI: CHILD_URI,
+              // Fires synchronously as each window global is created,
+              // including the uncommitted initial about:blank that content
+              // scripts skip.
+              observers: ["content-document-global-created"],
+            },
+            allFrames: true,
+            // Web content runs in untrusted content processes; without this
+            // the actor is never instantiated there.
+            safeForUntrustedWebProcess: true,
+          });
+        },
+      },
+    };
+  }
+
+  onShutdown() {
+    ChromeUtils.unregisterWindowActor(ACTOR_NAME);
+    if (BOOTSTRAP_URL) {
+      Services.ppmm.removeDelayedProcessScript(BOOTSTRAP_URL);
+      BOOTSTRAP_URL = null;
+    }
+    // Leave nothing behind in the profile: the substitution points at an
+    // install-specific path, and the pref would otherwise be archived with the
+    // profile and outlive the extension.
+    try {
+      resourceProtocol().setSubstitution("openwpm", null);
+    } catch (error) {
+      console.error("OpenWPM: failed to clear resource://openwpm/", error);
+    }
+    Services.prefs.clearUserPref(ROOT_PREF);
+  }
+};

--- a/Extension/bundled/privileged/webdriverSpoof/bootstrap.js
+++ b/Extension/bundled/privileged/webdriverSpoof/bootstrap.js
@@ -1,0 +1,30 @@
+/**
+ * Registers `resource://openwpm/` in whichever process loads this.
+ *
+ * The actor's `esModuleURI` is a `resource://openwpm/` URL, and a resource:
+ * substitution is per-process: setting it in the parent leaves content
+ * processes unable to resolve the actor module ("Failed to load ..."). Loaded
+ * via `loadProcessScript(..., true)` so processes started later run it during
+ * process init, ahead of any document.
+ *
+ * The extension's root URI is passed by pref because prefs propagate to content
+ * processes on their own, which avoids a message round-trip during startup.
+ */
+
+"use strict";
+
+(function () {
+  const ROOT_PREF = "extensions.openwpm.rootURI";
+
+  try {
+    const root = Services.prefs.getStringPref(ROOT_PREF, "");
+    if (root) {
+      Services.io
+        .getProtocolHandler("resource")
+        .QueryInterface(Ci.nsIResProtocolHandler)
+        .setSubstitution("openwpm", Services.io.newURI(root));
+    }
+  } catch (error) {
+    console.error("OpenWPM: failed to register resource://openwpm/", error);
+  }
+})();

--- a/Extension/bundled/privileged/webdriverSpoof/schema.json
+++ b/Extension/bundled/privileged/webdriverSpoof/schema.json
@@ -1,0 +1,13 @@
+[
+  {
+    "namespace": "webdriverSpoof",
+    "functions": [
+      {
+        "name": "enable",
+        "type": "function",
+        "async": true,
+        "parameters": []
+      }
+    ]
+  }
+]

--- a/Extension/eslint.config.mjs
+++ b/Extension/eslint.config.mjs
@@ -124,9 +124,10 @@ export default tseslint.config(
     },
   },
 
-  // Privileged extension scripts
+  // Privileged extension scripts. `.sys.mjs` are system ES modules (JSWindowActor
+  // sides); they share the same chrome-scope globals as the `.js` API scripts.
   {
-    files: ["bundled/privileged/**/*.js"],
+    files: ["bundled/privileged/**/*.js", "bundled/privileged/**/*.sys.mjs"],
     languageOptions: {
       globals: {
         AppConstants: "readonly",
@@ -145,6 +146,8 @@ export default tseslint.config(
         MatchGlob: "readonly",
         MatchPattern: "readonly",
         MatchPatternSet: "readonly",
+        JSWindowActorChild: "readonly",
+        JSWindowActorParent: "readonly",
         Services: "readonly",
         StructuredCloneHolder: "readonly",
         OS: "readonly",

--- a/Extension/src/feature.ts
+++ b/Extension/src/feature.ts
@@ -41,6 +41,7 @@ async function main() {
       ],
       http_instrument: true,
       callstack_instrument: true,
+      spoof_webdriver: true,
       save_content: false,
       testing: true,
       browser_id: 0,
@@ -84,6 +85,24 @@ async function main() {
     loggingDB.logDebug("Cookie instrumentation enabled");
     const cookieInstrument = new CookieInstrument(loggingDB);
     cookieInstrument.run(config.browser_id);
+  }
+
+  // Enabled before the JavaScript instrument so that, when both are on, the
+  // instrument wraps the spoofed getter and still records every read of
+  // `navigator.webdriver` -- with the value the page actually saw. Enabling it
+  // afterwards would replace the instrument's wrapper and lose the capture.
+  if (config.spoof_webdriver) {
+    loggingDB.logDebug("navigator.webdriver spoofing enabled");
+    try {
+      await browser.webdriverSpoof.enable();
+    } catch (err) {
+      loggingDB.logError(
+        "webdriverSpoof.enable failed: " +
+          String(err) +
+          " :: " +
+          String((err as Error)?.stack),
+      );
+    }
   }
 
   if (config.js_instrument) {

--- a/Extension/src/types/browser.d.ts
+++ b/Extension/src/types/browser.d.ts
@@ -3,6 +3,13 @@ declare namespace browser.profileDirIO {
   export function writeFile(filename: string, content: string): void;
 }
 
+declare namespace browser.webdriverSpoof {
+  // Registers the window actor that makes `navigator.webdriver` read as
+  // `false` in every content realm. See
+  // Extension/bundled/privileged/webdriverSpoof/.
+  export function enable(): Promise<void>;
+}
+
 declare namespace browser.sockets {
   export const onDataReceived: {
     // `data` is a UTF-8 string for the "j"/"u" tags (isJson is true only for

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -105,6 +105,33 @@ left out of this section.
     - `from_visited`: Only accept third-party cookies from sites that have been visited as a first party.
 - `donottrack`
   - Set to `True` to enable Do Not Track in the browser.
+- `spoof_webdriver`
+  - Defaults to `True`. Makes `navigator.webdriver` read as `false` in every
+    page and frame, hiding the loudest signal that the visit is automated.
+  - Selenium sets `navigator.webdriver = true`. A privileged window actor
+    replaces the page's `Navigator.prototype.webdriver` getter with one compiled
+    in the page's compartment, so the page sees `[native code]` under the native
+    accessor name. The rest of the accessor is matched too: the descriptor
+    flags, the absent setter, the getter's own property order, and its behaviour
+    when called on something that is not a `Navigator` (it throws, as the native
+    one does). No own property is added to the `navigator` instance.
+  - The actor patches each realm as its global is created, so this covers every
+    realm the page can reach -- including a frame's *uncommitted initial
+    `about:blank`*, the placeholder document that exists between `appendChild`
+    and the real document committing, which content scripts are never injected
+    into ([bug 1415539](https://bugzilla.mozilla.org/show_bug.cgi?id=1415539)).
+    A page that appends a `srcdoc` iframe and reads
+    `frame.contentWindow.navigator.webdriver` in the same task reads exactly
+    that document.
+  - This is independent of `js_instrument`: it records nothing and applies
+    whether or not any instrument is enabled. If `js_instrument` is configured
+    to capture `window.navigator.webdriver`, it records the spoofed value.
+  - Requires `dom.ipc.processPrelaunch.enabled`. Setting that pref to `False`
+    in `prefs` while the spoof is on raises a `ConfigError`, rather than
+    crawling with the processes that predate the extension left unhooked.
+  - Set to `False` to leave `navigator.webdriver` at its real value, e.g. to
+    measure how much of a crawl's treatment by sites is attributable to this
+    one signal.
 - `tracking_protection`
   - **NOT SUPPORTED.** See [#101](https://github.com/citp/OpenWPM/issues/101).
   - Set to `True` to enable Firefox's built-in

--- a/openwpm/config.py
+++ b/openwpm/config.py
@@ -95,6 +95,13 @@ class BrowserParams(DataClassJsonMixin):
     prefs: dict = field(default_factory=dict)
     tp_cookies: str = "always"
     bot_mitigation: bool = False
+    spoof_webdriver: bool = True
+    """Make ``navigator.webdriver`` read as ``false`` in the page.
+
+    Hides the flag Selenium sets, which is the cheapest signal a site has that
+    a visit is automated. Records nothing and is independent of the
+    instruments. See ``docs/Configuration.md``.
+    """
     profile_archive_dir: Optional[Path] = field(
         default=None, metadata=DCJConfig(encoder=path_to_str, decoder=str_to_path)
     )
@@ -245,6 +252,20 @@ def validate_browser_params(browser_params: BrowserParams) -> None:
                 )
             )
 
+        # The spoof covers every content process by replacing the
+        # preallocated pool, which it cannot do if preallocation is off.
+        # Refuse rather than crawl with some processes unhooked.
+        if browser_params.spoof_webdriver and (
+            browser_params.prefs.get("dom.ipc.processPrelaunch.enabled") is False
+        ):
+            raise ConfigError(
+                "spoof_webdriver requires dom.ipc.processPrelaunch.enabled; "
+                "with preallocation disabled, content processes that predate "
+                "the extension stay unhooked and pages landing in them would "
+                "still see navigator.webdriver === true. Either leave the pref "
+                "alone or set spoof_webdriver=False."
+            )
+
         if browser_params.browser.lower() not in SUPPORTED_BROWSER_LIST:
             raise ConfigError(
                 CONFIG_ERROR_STRING.format(
@@ -307,7 +328,11 @@ def validate_browser_params(browser_params: BrowserParams) -> None:
                         "in browser_params.save_content (%s)" % diff,
                     )
 
-    except:
+    except ConfigError:
+        # Deliberate, already-explained rejections carry an actionable message;
+        # re-raise them instead of flattening them into the generic one below.
+        raise
+    except Exception:
         raise ConfigError(
             "Something went wrong while validating BrowserParams. "
             "Please check values provided for BrowserParams are of expected types"

--- a/test/test_dataclass_validations.py
+++ b/test/test_dataclass_validations.py
@@ -111,3 +111,22 @@ def test_num_browser_crawl_config():
 
     browser_params.append(BrowserParams())
     validate_crawl_configs(manager_params, browser_params)
+
+
+def test_spoof_webdriver_requires_process_prelaunch() -> None:
+    """The spoof replaces the preallocated pool, so it needs preallocation on.
+
+    Without it the content processes that predate the extension stay unhooked
+    and pages landing in them still see `navigator.webdriver === true`, which
+    is worse than not spoofing at all because it is silent.
+    """
+    browser_params = BrowserParams(spoof_webdriver=True)
+    browser_params.prefs = {"dom.ipc.processPrelaunch.enabled": False}
+    with pytest.raises(ConfigError, match="processPrelaunch"):
+        validate_browser_params(browser_params)
+
+    # Leaving the pref alone, or turning the spoof off, is fine.
+    validate_browser_params(BrowserParams(spoof_webdriver=True))
+    off = BrowserParams(spoof_webdriver=False)
+    off.prefs = {"dom.ipc.processPrelaunch.enabled": False}
+    validate_browser_params(off)

--- a/test/test_js_instrument.py
+++ b/test/test_js_instrument.py
@@ -90,7 +90,9 @@ class TestJSInstrumentByPython(OpenWPMJSTest):  # noqa
     TEST_PAGE = "instrument_pyside.html"
 
     GETS_AND_SETS = {
-        ("window.navigator.webdriver", "get", "true"),
+        # "false", not "true": `spoof_webdriver` is on by default, and the
+        # instrument records the value the page actually saw.
+        ("window.navigator.webdriver", "get", "false"),
         ("window.document.cookie", "set", "a=COOKIE"),
         ("window.document.cookie", "get", "a=COOKIE"),
     }
@@ -482,3 +484,41 @@ class TestJSInstrumentFailurePropagates(OpenWPMJSTest):
         # The visit must be recorded as incomplete (finalized success=False).
         incomplete = db_utils.query_db(db, "SELECT visit_id FROM incomplete_visits")
         assert incomplete, "expected the failed visit to be marked incomplete"
+
+
+class TestSrcdocFrameInstrumentation(OpenWPMJSTest):  # noqa
+    """Instrumentation reaches `srcdoc` frames, not just frames with a URL.
+
+    A srcdoc frame's document is written inline in the attribute, lives at
+    `about:srcdoc`, and inherits the parent's origin. Ad frames and embed
+    widgets use them heavily, so a gap here would be a silent measurement hole
+    rather than an obvious one. `matchAboutBlank` on the registered content
+    script is what covers them.
+    """
+
+    TEST_PAGE = "srcdoc_probe.html"
+
+    def get_config(
+        self, data_dir: Optional[Path]
+    ) -> Tuple[ManagerParams, List[BrowserParams]]:
+        manager_params, browser_params = super().get_config(data_dir)
+        browser_params[0].js_instrument_settings = [{"window.navigator": ["userAgent"]}]
+        return manager_params, browser_params
+
+    def test_srcdoc_frame_is_instrumented(self):
+        db = self.visit("/js_instrument/%s" % self.TEST_PAGE)
+        base = f"{self.server.base}/js_instrument"
+        observed = {
+            (row["document_url"], row["symbol"])
+            for row in db_utils.get_javascript_entries(db, all_columns=True)
+        }
+        assert observed == {
+            # Top-level document.
+            (f"{base}/{self.TEST_PAGE}", "window.navigator.userAgent"),
+            # Control: an ordinary same-origin child document.
+            (f"{base}/srcdoc_child.html", "window.navigator.userAgent"),
+            # The case under test. The call is made by a <script> inside the
+            # srcdoc attribute, so this also shows the content script lands
+            # before the frame's own code runs.
+            ("about:srcdoc", "window.navigator.userAgent"),
+        }

--- a/test/test_pages/js_instrument/srcdoc_child.html
+++ b/test/test_pages/js_instrument/srcdoc_child.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html>
+  <head>
+    <title>Same-origin child frame control.</title>
+  </head>
+  <body>
+    <script type="text/javascript">
+      void window.navigator.userAgent;
+    </script>
+  </body>
+</html>

--- a/test/test_pages/js_instrument/srcdoc_probe.html
+++ b/test/test_pages/js_instrument/srcdoc_probe.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html>
+  <head>
+    <title>Does instrumentation reach srcdoc frames?</title>
+  </head>
+  <body>
+    <h3>Does instrumentation reach srcdoc frames?</h3>
+    <script type="text/javascript">
+      // Top-level realm: the baseline that must always be captured.
+      void window.navigator.userAgent;
+    </script>
+    <!-- Control: an ordinary same-origin child document. -->
+    <iframe id="plain" src="srcdoc_child.html"></iframe>
+    <!-- The case under test: an inline document at about:srcdoc. -->
+    <iframe
+      id="sd"
+      srcdoc="<!doctype html><html><body><script>void window.navigator.userAgent;</script></body></html>"
+    ></iframe>
+  </body>
+</html>

--- a/test/test_pages/webdriver_spoof.html
+++ b/test/test_pages/webdriver_spoof.html
@@ -1,0 +1,57 @@
+<!doctype html>
+<html>
+  <head>
+    <title>Test page for navigator.webdriver spoofing.</title>
+    <script type="text/javascript">
+      // Runs in the page world during parsing, i.e. as early as a bot check on
+      // a real site would. The result is written into the DOM at load, because
+      // Selenium's execute_script sees the page through Xray vision and would
+      // read the unspoofed value and none of the page's expandos.
+      window.__openwpmWebdriverProbe = (function () {
+        var descriptor = Object.getOwnPropertyDescriptor(
+          Navigator.prototype,
+          "webdriver"
+        );
+        return {
+          value: navigator.webdriver,
+          ownOnInstance: Object.prototype.hasOwnProperty.call(
+            navigator,
+            "webdriver"
+          ),
+          prototypeKeys: Object.getOwnPropertyNames(Navigator.prototype),
+          getterName: descriptor.get.name,
+          getterSource: descriptor.get.toString(),
+          hasSetter: descriptor.set !== undefined,
+          // A replaced accessor tends to differ from native here: native
+          // throws when called on a non-Navigator, and reports its own
+          // property order.
+          getterOnWrongReceiver: (function () {
+            try {
+              descriptor.get.call({});
+              return "returned";
+            } catch (e) {
+              return "threw:" + e.name;
+            }
+          })(),
+          getterOwnKeys: Object.getOwnPropertyNames(descriptor.get).join(","),
+          enumerable: descriptor.enumerable,
+          configurable: descriptor.configurable,
+        };
+      })();
+    </script>
+  </head>
+  <body>
+    <h3>Test page for navigator.webdriver spoofing.</h3>
+    <iframe id="static-frame" src="simple_a.html"></iframe>
+    <pre id="probe"></pre>
+    <script type="text/javascript">
+      window.addEventListener("load", function () {
+        var probe = window.__openwpmWebdriverProbe;
+        probe.staticFrameValue = document.getElementById("static-frame")
+          .contentWindow.navigator.webdriver;
+        document.getElementById("probe").textContent = JSON.stringify(probe);
+        document.documentElement.setAttribute("data-probe-complete", "1");
+      });
+    </script>
+  </body>
+</html>

--- a/test/test_pages/webdriver_spoof_escapes.html
+++ b/test/test_pages/webdriver_spoof_escapes.html
@@ -1,0 +1,121 @@
+<!doctype html>
+<html>
+  <head>
+    <title>Test page for navigator.webdriver spoofing across realms.</title>
+  </head>
+  <body>
+    <h3>Test page for navigator.webdriver spoofing across realms.</h3>
+    <pre id="probe"></pre>
+    <script type="text/javascript">
+      // Each probe reaches a realm other than this one and records the raw
+      // `navigator.webdriver` it managed to read. Every probe that can runs
+      // during parsing, i.e. as early as a bot check would.
+      (function () {
+        var results = {};
+
+        function write(done) {
+          document.getElementById("probe").textContent = JSON.stringify(results);
+          if (done) {
+            // The reader waits for this rather than for a fixed duration.
+            document.documentElement.setAttribute("data-probe-complete", "1");
+          }
+        }
+
+        function probe(name, fn) {
+          try {
+            results[name] = fn();
+          } catch (e) {
+            results[name] = "threw: " + e.name + ": " + e.message;
+          }
+        }
+
+        // A frame appended and read back in the same task, with no chance for
+        // anything asynchronous to run in between.
+        probe("syncAppendedIframe", function () {
+          var f = document.createElement("iframe");
+          document.body.appendChild(f);
+          var v = f.contentWindow.navigator.webdriver;
+          f.remove();
+          return v;
+        });
+
+        probe("syncAppendedIframeAboutBlank", function () {
+          var f = document.createElement("iframe");
+          f.src = "about:blank";
+          document.body.appendChild(f);
+          var v = f.contentWindow.navigator.webdriver;
+          f.remove();
+          return v;
+        });
+
+        // Indexed access reaches the frame's realm by a different route than
+        // the element's contentWindow accessor.
+        probe("indexedFrameAccess", function () {
+          var f = document.createElement("iframe");
+          document.body.appendChild(f);
+          var v = window[window.length - 1].navigator.webdriver;
+          f.remove();
+          return v;
+        });
+
+        // A pop-up is a top-level document rather than a frame.
+        probe("popupEmpty", function () {
+          var w = window.open("");
+          if (!w) {
+            return "blocked";
+          }
+          var v = w.navigator.webdriver;
+          w.close();
+          return v;
+        });
+
+        probe("popupAboutBlank", function () {
+          var w = window.open("about:blank");
+          if (!w) {
+            return "blocked";
+          }
+          var v = w.navigator.webdriver;
+          w.close();
+          return v;
+        });
+
+        // Calling a fresh realm's own getter, rather than reading through this
+        // realm's prototype chain.
+        probe("frameNavigatorPrototypeGetter", function () {
+          var f = document.createElement("iframe");
+          document.body.appendChild(f);
+          var desc = Object.getOwnPropertyDescriptor(
+            f.contentWindow.Navigator.prototype,
+            "webdriver"
+          );
+          var v = desc.get.call(f.contentWindow.navigator);
+          f.remove();
+          return v;
+        });
+
+        // A srcdoc document is parsed on a later task than the appendChild
+        // that creates it, so read the same frame at three points to separate
+        // "never patched" from "not patched yet".
+        var sd = document.createElement("iframe");
+        sd.srcdoc = "<!doctype html><title>srcdoc</title>";
+        sd.onload = function () {
+          probe("srcdocOnLoad", function () {
+            return sd.contentWindow.navigator.webdriver;
+          });
+          setTimeout(function () {
+            probe("srcdocAfterTimeout", function () {
+              return sd.contentWindow.navigator.webdriver;
+            });
+            write(true);
+          }, 500);
+        };
+        document.body.appendChild(sd);
+        probe("srcdocSyncAfterAppend", function () {
+          return sd.contentWindow.navigator.webdriver;
+        });
+
+        write();
+      })();
+    </script>
+  </body>
+</html>

--- a/test/test_webdriver_spoof.py
+++ b/test/test_webdriver_spoof.py
@@ -1,0 +1,196 @@
+"""Tests for `BrowserParams.spoof_webdriver`.
+
+The point of the spoof is that the *page* cannot tell it happened, so every
+assertion here compares a spoofed run against a `spoof_webdriver=False`
+baseline: the value flips, and nothing else about the property does.
+"""
+
+import json
+from pathlib import Path
+
+from selenium.webdriver import Firefox
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.ui import WebDriverWait
+
+from openwpm.command_sequence import CommandSequence
+from openwpm.commands.types import BaseCommand
+from openwpm.config import BrowserParamsInternal, ManagerParamsInternal
+from openwpm.socket_interface import ClientSocket
+
+from .conftest import FullConfig, TaskManagerCreator
+from .utilities import ServerUrls
+
+PROBE_FILE = "webdriver_probe.json"
+
+
+class DumpWebdriverProbeCommand(BaseCommand):
+    """Copy the probe the test page wrote into the DOM out to a file.
+
+    The page has to run the probe itself: `execute_script` sees the page through
+    Xray vision, where `navigator.webdriver` is still the untouched native
+    getter and the page's own expandos are invisible.
+    """
+
+    def execute(
+        self,
+        webdriver: Firefox,
+        browser_params: BrowserParamsInternal,
+        manager_params: ManagerParamsInternal,
+        extension_socket: ClientSocket,
+    ) -> None:
+        # Some probes are deliberately asynchronous (a frame's load event, a
+        # macrotask), so wait for the page to say it is finished rather than
+        # guessing how long that takes.
+        WebDriverWait(webdriver, 30).until(
+            lambda d: d.find_element(By.TAG_NAME, "html").get_attribute(
+                "data-probe-complete"
+            )
+        )
+        probe = webdriver.find_element(By.ID, "probe").get_attribute("textContent")
+        assert probe is not None
+        (manager_params.data_directory / PROBE_FILE).write_text(probe)
+
+
+def _probe(
+    task_manager_creator: TaskManagerCreator,
+    params: FullConfig,
+    server: ServerUrls,
+    data_directory: Path,
+    spoof_webdriver: bool,
+    page: str = "/webdriver_spoof.html",
+) -> dict:
+    """Visit a probe page in a single browser and return what the page saw."""
+    manager_params, browser_params = params
+    data_directory.mkdir(parents=True, exist_ok=True)
+    manager_params.data_directory = data_directory
+    manager_params.log_path = data_directory / "openwpm.log"
+    manager_params.num_browsers = 1
+    browser_params = browser_params[:1]
+    browser_params[0].spoof_webdriver = spoof_webdriver
+
+    manager, _ = task_manager_creator((manager_params, browser_params))
+    sequence = CommandSequence(server.base + page)
+    sequence.get()
+    sequence.append_command(DumpWebdriverProbeCommand())
+    manager.execute_command_sequence(sequence)
+    manager.close()
+    return json.loads((data_directory / PROBE_FILE).read_text())
+
+
+def test_spoof_webdriver_is_invisible_to_the_page(
+    task_manager_creator: TaskManagerCreator,
+    default_params: FullConfig,
+    server: ServerUrls,
+    tmp_path: Path,
+) -> None:
+    baseline = _probe(
+        task_manager_creator,
+        default_params,
+        server,
+        tmp_path / "baseline",
+        spoof_webdriver=False,
+    )
+    spoofed = _probe(
+        task_manager_creator,
+        default_params,
+        server,
+        tmp_path / "spoofed",
+        spoof_webdriver=True,
+    )
+
+    # Selenium's tell, and the one thing the spoof is allowed to change.
+    assert baseline["value"] is True
+    assert baseline["staticFrameValue"] is True
+    assert spoofed["value"] is False
+    assert spoofed["staticFrameValue"] is False
+
+    # Everything else about the property is indistinguishable from native: the
+    # accessor still stringifies as native code under its native name, carries
+    # no setter, keeps its descriptor flags, and stays in place in the
+    # prototype's property order. The `navigator` instance gains no own
+    # property, which is what rules out the `Object.defineProperty(navigator,
+    # ...)` approach (see https://github.com/openwpm/OpenWPM/pull/526).
+    assert baseline["getterName"] == "get webdriver"
+    assert "[native code]" in baseline["getterSource"]
+    assert baseline["ownOnInstance"] is False
+    assert baseline["hasSetter"] is False
+
+    for key in (
+        "getterName",
+        "getterSource",
+        "ownOnInstance",
+        "hasSetter",
+        "enumerable",
+        "configurable",
+        "prototypeKeys",
+        # A replaced accessor diverges from native on both of these, so they
+        # are the probes that would catch a regression back to patching the
+        # page rather than the automation flag.
+        "getterOnWrongReceiver",
+        "getterOwnKeys",
+    ):
+        assert spoofed[key] == baseline[key], key
+
+
+# Realms the page can reach other than the top-level document. Every one is
+# spoofed, including the two that #526 and the stealth instrument's D10 notes
+# describe as escapes: on Firefox 155 a pop-up opened with `window.open("")` and
+# a frame appended and read in the same task are both covered.
+REACHED_REALMS = [
+    "syncAppendedIframe",
+    "syncAppendedIframeAboutBlank",
+    "indexedFrameAccess",
+    "popupEmpty",
+    "popupAboutBlank",
+    "frameNavigatorPrototypeGetter",
+    "srcdocOnLoad",
+    "srcdocAfterTimeout",
+]
+
+
+def test_spoof_webdriver_reaches_other_realms(
+    task_manager_creator: TaskManagerCreator,
+    default_params: FullConfig,
+    server: ServerUrls,
+    tmp_path: Path,
+) -> None:
+    """Every realm the page can reach is patched, including ones no content
+    script can cover.
+
+    The hard case is a srcdoc frame read in the same task as the appendChild
+    that created it. That read does not reach the srcdoc document; it reaches
+    the frame's uncommitted initial about:blank, which Firefox deliberately
+    never injects content scripts into (bug 1415539). It is observable from the
+    parent regardless, which is why the spoof is installed from a privileged
+    actor observing content-document-global-created rather than from a content
+    script.
+    """
+    page = "/webdriver_spoof_escapes.html"
+    baseline = _probe(
+        task_manager_creator,
+        default_params,
+        server,
+        tmp_path / "escapes-baseline",
+        spoof_webdriver=False,
+        page=page,
+    )
+    spoofed = _probe(
+        task_manager_creator,
+        default_params,
+        server,
+        tmp_path / "escapes-spoofed",
+        spoof_webdriver=True,
+        page=page,
+    )
+
+    # Every probe must actually have reached a realm, or it proves nothing.
+    for key in REACHED_REALMS + ["srcdocSyncAfterAppend"]:
+        assert baseline[key] is True, (key, baseline[key])
+
+    for key in REACHED_REALMS:
+        assert spoofed[key] is False, (key, spoofed[key])
+
+    # The case no content script can reach: this read lands on the frame's
+    # uncommitted initial about:blank (bug 1415539), not on the srcdoc
+    # document. The actor covers it because it observes every window global.
+    assert spoofed["srcdocSyncAfterAppend"] is False


### PR DESCRIPTION
## What this is

`navigator.webdriver` reads as `false` in **every realm** the page can reach. New `BrowserParams.spoof_webdriver`, default `True`.

This is deliberately the smallest useful slice of #1154. `navigator.webdriver` is the one detection vector in that PR's D1–D10 suite that is independent of instrumentation — it is true whether or not OpenWPM instruments anything, because Selenium sets it. Splitting it out makes it possible to measure how much of a crawl's differential treatment by sites is attributable to this one flag versus the rest of the stealth instrument's surface.

It also serves a second purpose: it is a complete, reproducible demonstration of what "cover every realm" actually costs on current Firefox. Ported from #526, open since 2019.

The mypy fix that used to ride along here is now #1236.

Closes #526.

## Mechanism

A privileged window actor replaces the page's `Navigator.prototype.webdriver` getter:

```js
const spoofedGetter = Cu.exportFunction(() => false, pageWindow.Object.create(null), {
  defineAs: "get webdriver",
});
Object.defineProperty(navigatorPrototype, "webdriver", { ...descriptor, get: spoofedGetter });
```

The getter is compiled inside the page's compartment, so it reports `[native code]` under the native accessor name. The native descriptor is reused apart from `get`, so nothing else moves. **Nothing in the content realm is hooked** — no patched `HTMLIFrameElement.prototype`, no proxy — so the spoof adds no page-observable surface of its own.

### Why the prototype and not the instance

`Object.defineProperty(navigator, "webdriver", {value: false})` adds an own property the `navigator` instance does not normally have and reorders enumeration — the tell that led #526 to proxy the whole `navigator` object. Replacing the accessor where Firefox defines it avoids both.

### Why an actor and not a content script

An earlier revision of this PR used a content script. It covers almost everything, but **not a frame's uncommitted initial `about:blank`** — the placeholder that exists between `appendChild` and the real document committing. Firefox deliberately never injects content scripts there ([bug 1415539](https://bugzilla.mozilla.org/show_bug.cgi?id=1415539), cited in `ExtensionContent.sys.mjs`), and no configuration changes it: `matchAboutBlank` does not reach it, and `matchOriginAsFallback` *disables* `matchAboutBlank` while requiring a wildcard path glob `<all_urls>` does not provide.

That document is not merely transient — **it is observable**. A page can append a `srcdoc` iframe and read `frame.contentWindow.navigator.webdriver` in the same task and get the uncommitted `about:blank`, uninstrumented. I verified this by reading back the realm the parent actually sees: in both the plain-iframe and srcdoc same-task cases `location.href` is `about:blank`, and only the srcdoc one is unpatched.

The distinction that matters:

> Firefox guarantees that content scripts run **before the document's own scripts**.
> It does not guarantee that a realm is **unreachable from another realm** until its content scripts have run.

Those differ exactly here, and only the second is sufficient for a measurement tool. The actor works below the content-script layer: its child observes `content-document-global-created`, which fires synchronously for every window global, uncommitted ones included.

## What full coverage costs

Documented because the stealth work will hit all of it:

- **`resource:` is the only scheme the system ESM loader accepts** for an actor module. `moz-extension:` and the XPI's own `jar:` URL are both **silently declined** — no error, the actor simply never runs.
- **A `resource:` substitution is per-process.** Registering it only in the parent leaves content processes unable to resolve the module, reported as a bare `Failed to load <uri>`. `bootstrap.js` re-registers it per process.
- **`safeForUntrustedWebProcess: true` is mandatory**, or `registerWindowActor` succeeds, reports nothing, and the actor is never instantiated for web content.
- **Preallocated content processes.** Firefox keeps a pool of blank processes and claims one when a navigation needs a new process. Those launched before the extension started never ran the bootstrap, so a page landing in one was unhooked — the source of every intermittent failure while developing this. Observing `process-type-set` and pushing a script when a process is claimed does **not** fix it: that fires in the parent while the process is already loading, and the IPC can lose. Draining the stale pool once at startup does, and preallocation stays enabled for the rest of the crawl.

## Verification

`test_spoof_webdriver_reaches_other_realms` checks every reachable realm against a `spoof_webdriver=False` baseline: `window.open("")`, `window.open("about:blank")`, an iframe appended and read in the same task, `about:blank` and `srcdoc` frames, indexed frame access via `window[n]`, and calling a frame's own `Navigator.prototype` getter directly. All spoofed — including the uncommitted-`about:blank` case no content script can reach.

`test_spoof_webdriver_is_invisible_to_the_page` pins that nothing else moves: `descriptor.get.toString()`, `.name`, the descriptor flags, the absent setter, `hasOwnProperty(navigator, "webdriver")`, and the full `Object.getOwnPropertyNames(Navigator.prototype)` array are byte-identical to baseline.

Both escapes named in the earlier literature are closed on Firefox 155 — #526's `window.open("")` case and the synchronous-iframe race from #1154's D10 notes — measured rather than inherited.

Run green locally against the unbranded Firefox 155 build this repo pins: `test_webdriver_spoof.py` + `test_js_instrument.py` (10), `test_update_script.py` (15), `test_dataclass_validations.py` (8), plus `npm run lint` and `black`/`isort`/`mypy` over all tracked Python files.

## Bonus test: instrumentation reaches srcdoc frames

Chasing the above raised a broader question — do OpenWPM's content scripts reach `srcdoc` frames at all? A gap there would be a silent measurement hole in every crawl, since ad frames and embeds use them heavily. They do: a `<script>` inside the `srcdoc` attribute is captured under `about:srcdoc`, so injection lands before the frame's own code. `TestSrcdocFrameInstrumentation` pins it. This tests pre-existing behaviour rather than anything this PR changes, so it is easy to drop if you would rather it landed separately.

---

# Findings

Investigation notes, kept so they are not lost. Measured on Firefox 155.0.1
(unbranded add-on-devel) and Chromium 152.0.7977.64, Linux x86_64.

## Two loaders, two gates

| | subscript loader | system ESM loader |
|---|---|---|
| gate | `IsTrustedScheme` **or** `(allowUnsafeURL \|\| security.allow_unsafe_subscript_loads)` for `file`/`jar`/`moz-extension` | `IsTrustedScheme` only |
| official bypass | two: a per-call option and the pref | **none** |

`IsTrustedScheme` is `resource:`, `chrome:`, `moz-src:` only
(`dom/security/nsContentSecurityUtils.cpp`). Actors reach it through
`JSActorManager.cpp` calling `ImportESModule` for `esModuleURI`. An
`esModuleURI` of `moz-extension:` or the XPI's own `jar:` URL is **silently**
declined — `JSWindowActorProtocol::Observe` uses `GetActor(..., IgnoreErrors())`,
so the actor simply never instantiates and nothing is logged.

So the `resource://openwpm/` substitution does not bypass that gate, it satisfies
it by aliasing a trusted scheme onto the XPI.

## Why the bootstrap and the pool drain are needed

`SubstitutingProtocolHandler` **does** propagate a substitution to content
processes (`SendSubstitution`, and `CollectSubstitutions` for new ones), and the
shipped webcompat `about-compat` API relies on exactly that: parent-only
`setSubstitution`, then a process script loaded over `resource://webcompat/`.

But propagation is asynchronous with respect to actor registration. Registering
the actor immediately after `setSubstitution` was measured to fail with a bare
`Failed to load resource://openwpm/...`: a content process is asked for the
module before the mapping arrives. webcompat avoids this by doing its setup in
`onStartup()`, long before anything needs the mapping. Having each content
process register the mapping itself, before it hosts a document, is the ordering
guarantee.

Separately, content processes that already exist when the bootstrap is
registered do not run it, so the preallocated pool is replaced rather than
patched by toggling `dom.ipc.processPrelaunch.enabled` once. That pref is
therefore a requirement, enforced as a `ConfigError`.

## Upstream state

- **[bug 1976115](https://bugzilla.mozilla.org/show_bug.cgi?id=1976115)** — move
  `experiment_apis` scripts to `moz-extension:`. Its TODO, and 1974691's, sit
  directly in `CheckAllowedURI`.
- **[bug 1974691](https://bugzilla.mozilla.org/show_bug.cgi?id=1974691)** —
  restrict `moz-extension:` subscript loads to privileged extensions. Rob--W
  notes such loads *"can happen from extension experiments only"*, so the branch
  is already privileged-only in practice and the pref is belt-and-braces.
- **[bug 1771341](https://bugzilla.mozilla.org/show_bug.cgi?id=1771341)** —
  `canUseAPIExperiment()` allows `experiment_apis` when the add-on is privileged
  **or** `AddonSettings.EXPERIMENTS_ENABLED`. **OpenWPM is the second case.** A
  future check keyed on `WebExtensionPolicy::IsPrivileged()` would lock us out;
  one keyed on `canUseAPIExperiment()` would not.

## The one case a content script cannot reach

A frame's *uncommitted initial `about:blank`* — the placeholder between
`appendChild` and the real document committing. Firefox never injects content
scripts there ([bug 1415539](https://bugzilla.mozilla.org/show_bug.cgi?id=1415539)),
and no option changes it. It is observable: a page that appends a `srcdoc` iframe
and reads `frame.contentWindow.navigator.webdriver` in the same task reads that
document, and re-checking the saved document object later shows it is **never**
injected, not merely injected late.

**Chromium 152 behaves identically** on every case measured, so this is not a
Firefox bug or a compat issue; it is
[w3c/webextensions#1009](https://github.com/w3c/webextensions/issues/1009)
territory, where the general form
([#513](https://github.com/w3c/webextensions/issues/513)) is closed and
`opposed:` by all three vendors.

`srcdoc` origin semantics, measured: it inherits the opener's origin and is fully
scriptable. `sandbox="allow-scripts"` makes it opaque and unreachable;
`allow-scripts allow-same-origin` restores same-origin and is **still** never
injected — so the gap is a property of `srcdoc`, not of origin opacity, which
also rules out `match_origin_as_fallback`.

## A narrower mechanism exists for this one flag

`Navigator::Webdriver()` reads Marionette/RemoteAgent state out of `sharedData`,
which the parent can clear — leaving the native getter untouched entirely. It is
deliberately not used here: it can only move that one flag, while the instrument
this is a slice of needs to overwrite arbitrary properties and to run at realm
creation. Matching the native accessor exactly is the part that generalises,
which is why the tests pin property order and wrong-receiver behaviour.

## Tried and rejected

- Parent-only `setSubstitution` without the per-process bootstrap — loses the
  propagation race, measured.
- `matchOriginAsFallback` on a content script — per its documentation it
  *disables* `matchAboutBlank` and needs a wildcard path glob `<all_urls>` does
  not provide.
- `moz-extension:` and `jar:` as `esModuleURI` — silently declined.
- Installing the extension unpacked for a `file:` root — `CheckAllowedURI` gates
  `file:` identically.
- A `process-type-set` observer and an acknowledgement handshake, both of which
  measured unnecessary once the pool is drained.
