### PR TITLE
docs: let the page use the full viewport width

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -68,6 +68,15 @@ pygments_style = "sphinx"
 #
 html_theme = "alabaster"
 
+# Alabaster centres a fixed 940px page, which leaves the sidebar floating
+# mid-screen and wraps wide tables (e.g. the requirements matrix in
+# developers/Stealth-Requirements.rst) into a narrow column. Use the whole
+# viewport: the sidebar sits flush left and the body takes the rest.
+html_theme_options = {
+    "page_width": "100%",
+    "sidebar_width": "260px",
+}
+
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".


### PR DESCRIPTION
Alabaster centres a fixed 940px page by default, so the navigation sidebar floats in the middle of the screen and wide content is squeezed into a narrow column. The requirements matrix in `developers/Stealth-Requirements.rst` is the worst case — a wide table wrapped into roughly a third of a modern display.

```python
html_theme_options = {
    "page_width": "100%",
    "sidebar_width": "260px",
}
```

`page_width` and `sidebar_width` are alabaster's own options, confirmed against the installed theme's `theme.conf`. There was no `html_theme_options` block at all before this, so the theme was running entirely on defaults.

The sidebar ends up flush against the left edge and the body takes the remaining width.

One caveat on reviewing this: the effect is most visible on pages that #1154 adds, so the Read the Docs preview for *this* PR shows the change against the current docs only.
