### PR TITLE
chore(extension): ignore the bundled stealth.js build output

### DIFF
--- a/Extension/.gitignore
+++ b/Extension/.gitignore
@@ -15,3 +15,4 @@ dist
 openwpm.xpi
 bundled/content.js
 bundled/feature.js
+bundled/stealth.js


### PR DESCRIPTION
`Extension/bundled/content.js` and `bundled/feature.js` are already ignored as webpack output. `bundled/stealth.js` is not, because master's webpack config does not emit it — only the stealth instrument branch (#1154) does.

That asymmetry is a trap, and it just cost a CI run.

## How it fails

1. A local extension build on the stealth branch writes `Extension/bundled/stealth.js`. `npm run clean` is `rm -rf build test`, so it does not remove anything under `bundled/`.
2. The file is gitignored on the stealth branch, so nothing complains there.
3. Any commit subsequently made from a **master-based** branch snapshots it, because master has no such ignore rule.
4. CI then fails somewhere that points nowhere near the cause.

## Why the failure is so misleading

The failing step is `Run ./.github/actions/setup`, not `./scripts/ci.sh` — the test suite never starts, so there is no pytest output at all, just a downstream `No files were found with the provided path: coverage.xml`.

Inside setup, `scripts/build-extension.sh` runs `npm ci`, which triggers npm's `prepare` lifecycle → `npm run build && npm run test` → `test:lint` → `eslint .`. `Extension/eslint.config.mjs` ignores generated bundles by explicit allowlist:

```js
ignores: [
  "bundled/feature.js",
  "bundled/content.js",
  "bundled/privileged/sockets/bufferpack.js",
  ...
]
```

`bundled/stealth.js` is absent from that list on master (the stealth branch adds it), so the 211 KB webpacked bundle is linted as ordinary source:

```
✖ 1633 problems (1622 errors, 11 warnings)
```

Every shard of `tests`, plus `demo` and `pre-commit`, fails identically, because they all run the same composite setup. Nothing in the failure output mentions the stray file's origin.

## Fix

Ignore the file on master too, so it cannot be committed from either branch. One line.

This overlaps the entry #1154 already adds to the same file; whichever lands second drops the duplicate.
