### PR TITLE
ci: cancel superseded runs on the same pull request

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -10,6 +10,21 @@ on:
   schedule:
     - cron: "0 0 */2 * *"
 
+# A force-push during review supersedes the previous run; without this it keeps
+# running and holding runners.
+#
+# The group is per-ref for pull requests, so a new push replaces the run it
+# supersedes, and per-run for everything else. A shared group would serialize
+# even without cancellation: pushes to master and the nightly schedule both
+# resolve to refs/heads/master, so they would queue behind one another. Merge
+# queue entries must report on their temporary branch and master pushes are the
+# record for the landed commit, so neither may be cancelled or delayed.
+concurrency:
+  group: >-
+    ${{ github.workflow }}-${{ github.event_name == 'pull_request'
+    && github.ref || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   pre-commit:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Every push starts a full matrix — seven test shards plus `demo` and `pre-commit`, and a separate CodeQL run, so roughly ten jobs. Nothing cancels the previous run, so force-pushing a branch during review leaves each superseded generation holding runners until it finishes on its own.

This is not hypothetical. While reviewing the stealth stack today the repo reached **18 queued jobs against 3 in progress**, with three superseded generations of the same two branches (16:05, 16:08, 16:13) still queued behind the push that replaced them. GitHub Actions itself was fully operational; the backlog was entirely self-inflicted.

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
```

## Why the guard on `cancel-in-progress`

Cancellation is restricted to `pull_request` events on purpose:

- **Merge queue** entries must have their checks report on the temporary `gh-readonly-queue/*` branch. Cancelling one would fail the entry rather than speed it up.
- **Pushes to master** are the record for the commit that landed. A cancelled run would leave that commit with no result.
- **Scheduled runs** likewise have no superseding push to replace them.

Only pull request pushes have the property that a later run strictly replaces an earlier one, so only they are safe to cancel.

`actionlint` passes.
