### PR TITLE
ci: bound the demo and pre-commit jobs

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -28,6 +28,7 @@ concurrency:
 jobs:
   pre-commit:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup
@@ -35,6 +36,7 @@ jobs:
 
   demo:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup


### PR DESCRIPTION
Stacked on #1233 — same concern, making CI's time budget coherent rather than arbitrary.

Only `tests` sets `timeout-minutes`. `demo` and `pre-commit` inherit GitHub's default of **360 minutes**, and both are required status checks, so the merge queue blocks on them.

That has two consequences:

1. **A hung job burns six hours.** `demo` drives a real browser; if it wedges, nothing stops it for the rest of the working day.
2. **The queue's timeout cannot be derived.** `check_response_timeout_minutes` should be the maximum time any required check can take, plus an allowance for runner wait. With two of the nine required contexts bounded only by a six-hour default, "the maximum" is six hours, so any queue timeout is a guess.

Ten minutes, against observed runtimes of roughly 2m17s (`demo`) and 2m27s (`pre-commit`) — generous by a factor of four.

## Why this makes the queue timeout principled

The two clocks measure different things and start at different moments:

```
entry created ─── waiting for a runner ─── job starts ─── job runs ─── reports
                  ^^^^^^^^^^^^^^^^^^^^^                   ^^^^^^^^^
                  queue counts this                       both count this
                  timeout-minutes does not
```

`timeout-minutes` bounds *execution*; the merge queue bounds *time to hear back*, which additionally contains the runner wait — unbounded, and inside no job's timeout. With `grouping_strategy: ALLGREEN` the batch waits on the slowest of all nine required contexts at once.

After this change every required check is capped at 30 minutes, so the queue's 60-minute setting is exactly that maximum plus an equal allowance for contention, instead of a number picked to be larger than the worst run anyone happened to observe.

Context: merge queue entries were timing out against the previous 20-minute setting while every underlying run *succeeded* — observed merge-queue durations of 27, 33, 39 and 42 minutes. That setting has been raised to 60 separately, in the ruleset.

`actionlint` passes.
