### PR TITLE
ci: extend the concurrency guard to CodeQL

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -21,6 +21,14 @@ on:
   schedule:
     - cron: "33 19 * * 6"
 
+# on PRs only run the latest changes, everything else should run and also run
+# in parallel. no queuing
+concurrency:
+  group: >-
+    ${{ github.workflow }}-${{ github.event_name == 'pull_request'
+    && github.ref || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -10,15 +10,8 @@ on:
   schedule:
     - cron: "0 0 */2 * *"
 
-# A force-push during review supersedes the previous run; without this it keeps
-# running and holding runners.
-#
-# The group is per-ref for pull requests, so a new push replaces the run it
-# supersedes, and per-run for everything else. A shared group would serialize
-# even without cancellation: pushes to master and the nightly schedule both
-# resolve to refs/heads/master, so they would queue behind one another. Merge
-# queue entries must report on their temporary branch and master pushes are the
-# record for the landed commit, so neither may be cancelled or delayed.
+# on PRs only run the latest changes, everything else should run and also run
+# in parallel. no queuing
 concurrency:
   group: >-
     ${{ github.workflow }}-${{ github.event_name == 'pull_request'


### PR DESCRIPTION
#1233 gave `run-tests.yaml` a concurrency group but left CodeQL uncovered, so a
force-push during review still leaves the superseded analysis holding runners.
Same triggers, same block, byte for byte.

Also contracts the comment in both files.
