### PR TITLE
build(mypy): type-check against the real environment

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,14 +8,29 @@ repos:
     hooks:
       - id: black
         language_version: python3
-  - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v2.3.1
+  - repo: local
     hooks:
+      # mypy runs from the conda env rather than a pre-commit-managed venv, so
+      # it type-checks against the packages the project actually installs and
+      # their bundled type information. Under mirrors-mypy it saw only a
+      # hand-listed subset of dependencies, so every other third-party import
+      # degraded to `Any` -- and that list was a second copy of the dependency
+      # set, free to drift from environment.yaml. Its version now comes from
+      # environment.yaml like every other tool, and `python_version` in
+      # pyproject.toml is kept in step by scripts/update.py.
+      #
+      # `--scripts-are-modules` is inherited from the mirrors-mypy hook
+      # definition and is load-bearing: without it a file with a shebang is
+      # named `__main__`, which the `module = "test.*"` overrides would not
+      # match. `--ignore-missing-imports` is dropped because pyproject.toml
+      # already sets it.
       - id: mypy
-        additional_dependencies:
-          [pytest, types-tabulate, types-PyYAML, types-redis]
-        # We may need to add more and more dependencies here, as pre-commit
-        # runs in an environment without our dependencies
+        name: mypy
+        entry: mypy
+        language: system
+        types_or: [python, pyi]
+        args: [--scripts-are-modules]
+        require_serial: true
   - repo: https://github.com/rhysd/actionlint
     rev: v1.7.11
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ skip = ["venv", "Extension", "firefox-bin"]
 
 [tool.mypy]
 follow_imports = "silent"
-python_version = "3.10"
+python_version = "3.14"
 warn_unused_configs = true
 ignore_missing_imports = true
 disallow_incomplete_defs = true

--- a/scripts/update.py
+++ b/scripts/update.py
@@ -26,10 +26,15 @@ _MAX_RESOLVE_ATTEMPTS = 10
 
 # Mapping: conda package name → (pre-commit repo URL, rev prefix)
 # The prefix is prepended to the conda version to form the pre-commit rev tag.
+#
+# Only tools pre-commit installs itself belong here. mypy is deliberately
+# absent: it runs as a `language: system` hook so it can see the project's real
+# dependencies, which means its version already comes from environment.yaml and
+# there is no rev to pin. What does need syncing for mypy is `python_version`
+# in pyproject.toml — see sync_mypy_python_version.
 _LINTER_MAP: dict[str, tuple[str, str]] = {
     "black": ("https://github.com/psf/black", ""),
     "isort": ("https://github.com/timothycrosley/isort", ""),
-    "mypy": ("https://github.com/pre-commit/mirrors-mypy", "v"),
 }
 
 
@@ -310,6 +315,56 @@ def sync_extension_node_engine(env_name: str = "openwpm") -> None:
     pkg_json.write_text(json.dumps(data, indent=2) + "\n")
 
 
+def sync_mypy_python_version(env_name: str = "openwpm") -> None:
+    """Sync ``[tool.mypy] python_version`` in ``pyproject.toml`` to the conda env.
+
+    mypy checks code against whatever ``python_version`` says, not against the
+    interpreter it happens to run on. Once that setting falls behind the conda
+    env, two things go wrong quietly. The project gets type-checked at an older
+    language level than it actually ships. And mypy rejects newer syntax in the
+    installed third-party stubs it follows -- a local ``mypy openwpm`` dies on
+    somebody else's ``.pyi`` while the pre-commit hook, which runs in an
+    isolated env without those packages, never reaches the file and stays
+    green. Pinning the setting to the conda python keeps the two from drifting
+    after a repin.
+    """
+    pyproject = ROOT / "pyproject.toml"
+
+    print("\n=== Syncing mypy python_version with conda python ===")
+
+    versions = _query_conda_versions(env_name)
+    if "python" not in versions:
+        raise RuntimeError(f"python not found in conda env '{env_name}'.")
+
+    # mypy takes a feature level, not a patch release: 3.14.7 -> "3.14".
+    target = ".".join(versions["python"].split(".")[:2])
+
+    content = pyproject.read_text()
+
+    header = re.search(r"^\[tool\.mypy\][^\S\n]*$", content, re.MULTILINE)
+    if not header:
+        raise RuntimeError("No [tool.mypy] section found in pyproject.toml")
+
+    # The section body runs to the next table header, or to the end of file.
+    rest = content[header.end() :]
+    next_header = re.search(r"^\[", rest, re.MULTILINE)
+    end = header.end() + (next_header.start() if next_header else len(rest))
+    body = content[header.end() : end]
+
+    setting = re.search(r'python_version\s*=\s*"([^"]*)"', body)
+    if not setting:
+        raise RuntimeError("No python_version setting found in [tool.mypy]")
+
+    current = setting.group(1)
+    if current == target:
+        print(f"  python_version: already in sync ({current})")
+        return
+
+    print(f"  python_version: {current} -> {target}")
+    new_body = body[: setting.start(1)] + target + body[setting.end(1) :]
+    pyproject.write_text(content[: header.end()] + new_body + content[end:])
+
+
 _VERSION_RE = re.compile(r"^(\d+)\.(\d+)\.(\d+)$")
 _TAG_RE = re.compile(r"^v?(\d+)\.(\d+)\.(\d+)$")
 
@@ -374,6 +429,9 @@ def main() -> None:
 
     # Sync Extension's engines.node to match the freshly pinned conda env
     sync_extension_node_engine()
+
+    # Sync mypy's python_version to match the freshly pinned conda python
+    sync_mypy_python_version()
 
     # Catch silent VERSION drift relative to the latest release tag
     bump_version_if_behind()

--- a/test/test_update_script.py
+++ b/test/test_update_script.py
@@ -57,6 +57,8 @@ SAMPLE_CONDA_LIST = json.dumps(
 )
 
 
+# mypy is absent on purpose: it is a `language: system` hook, so it carries no
+# rev for sync_precommit_linter_versions to rewrite.
 PRECOMMIT_YAML_TEMPLATE = """\
 repos:
   - repo: https://github.com/timothycrosley/isort
@@ -68,10 +70,12 @@ repos:
     hooks:
       - id: black
         language_version: python3
-  - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: {mypy_rev}
+  - repo: local
     hooks:
       - id: mypy
+        name: mypy
+        entry: mypy
+        language: system
 """
 
 
@@ -91,9 +95,7 @@ def test_versions_from_conda_list_json_invalid_json_raises(update_module):
 def test_sync_updates_outdated_revs(update_module, tmp_path, monkeypatch, capsys):
     precommit = tmp_path / ".pre-commit-config.yaml"
     precommit.write_text(
-        PRECOMMIT_YAML_TEMPLATE.format(
-            isort_rev="1.0.0", black_rev="20.0.0", mypy_rev="v1.0.0"
-        )
+        PRECOMMIT_YAML_TEMPLATE.format(isort_rev="1.0.0", black_rev="20.0.0")
     )
     monkeypatch.setattr(update_module, "ROOT", tmp_path)
     monkeypatch.setattr(
@@ -111,15 +113,12 @@ def test_sync_updates_outdated_revs(update_module, tmp_path, monkeypatch, capsys
     new_content = precommit.read_text()
     assert "rev: 26.1.0" in new_content
     assert "rev: 8.0.1" in new_content
-    assert "rev: v1.19.1" in new_content
     assert "20.0.0" not in new_content
-    assert "v1.0.0" not in new_content
+    assert "1.0.0" not in new_content
 
 
 def test_sync_noop_when_versions_match(update_module, tmp_path, monkeypatch):
-    initial = PRECOMMIT_YAML_TEMPLATE.format(
-        isort_rev="8.0.1", black_rev="26.1.0", mypy_rev="v1.19.1"
-    )
+    initial = PRECOMMIT_YAML_TEMPLATE.format(isort_rev="8.0.1", black_rev="26.1.0")
     precommit = tmp_path / ".pre-commit-config.yaml"
     precommit.write_text(initial)
     mtime_before = precommit.stat().st_mtime_ns
@@ -145,33 +144,27 @@ def test_sync_noop_when_versions_match(update_module, tmp_path, monkeypatch):
 def test_sync_raises_when_linter_missing_from_env(update_module, tmp_path, monkeypatch):
     precommit = tmp_path / ".pre-commit-config.yaml"
     precommit.write_text(
-        PRECOMMIT_YAML_TEMPLATE.format(
-            isort_rev="8.0.1", black_rev="26.1.0", mypy_rev="v1.19.1"
-        )
+        PRECOMMIT_YAML_TEMPLATE.format(isort_rev="8.0.1", black_rev="26.1.0")
     )
     monkeypatch.setattr(update_module, "ROOT", tmp_path)
     monkeypatch.setattr(
         update_module,
         "_query_conda_versions",
-        # mypy intentionally missing
-        lambda env_name="openwpm": {"black": "26.1.0", "isort": "8.0.1"},
+        # isort intentionally missing
+        lambda env_name="openwpm": {"black": "26.1.0", "mypy": "1.19.1"},
     )
 
-    with pytest.raises(RuntimeError, match="mypy"):
+    with pytest.raises(RuntimeError, match="isort"):
         update_module.sync_precommit_linter_versions()
 
 
 def test_sync_raises_when_hook_missing_from_precommit_config(
     update_module, tmp_path, monkeypatch
 ):
-    # File is missing the mypy hook entirely.
+    # File is missing the isort hook entirely.
     precommit = tmp_path / ".pre-commit-config.yaml"
     precommit.write_text("""\
 repos:
-  - repo: https://github.com/timothycrosley/isort
-    rev: 8.0.1
-    hooks:
-      - id: isort
   - repo: https://github.com/psf/black
     rev: 26.1.0
     hooks:
@@ -188,8 +181,120 @@ repos:
         },
     )
 
-    with pytest.raises(RuntimeError, match="mypy"):
+    with pytest.raises(RuntimeError, match="isort"):
         update_module.sync_precommit_linter_versions()
+
+
+def test_mypy_is_not_rev_synced(update_module):
+    """mypy runs as a `language: system` hook, so it has no rev to sync.
+
+    Putting it back in _LINTER_MAP would make sync_precommit_linter_versions
+    raise on the next repin, since the local hook carries no `rev:` line.
+    """
+    assert "mypy" not in update_module._LINTER_MAP
+
+
+PYPROJECT_TEMPLATE = """\
+[tool.black]
+line-length = 88
+
+[tool.mypy]
+follow_imports = "silent"
+python_version = "{python_version}"
+warn_unused_configs = true
+
+[[tool.mypy.overrides]]
+module = "test.*"
+python_version = "1.0"
+
+[tool.coverage.run]
+parallel = true
+"""
+
+
+def _patch_conda_python(update_module, monkeypatch, version):
+    monkeypatch.setattr(
+        update_module,
+        "_query_conda_versions",
+        lambda env_name="openwpm": {"python": version},
+    )
+
+
+def test_sync_mypy_python_version_updates_stale_setting(
+    update_module, tmp_path, monkeypatch
+):
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(PYPROJECT_TEMPLATE.format(python_version="3.10"))
+    monkeypatch.setattr(update_module, "ROOT", tmp_path)
+    _patch_conda_python(update_module, monkeypatch, "3.14.7")
+
+    update_module.sync_mypy_python_version()
+
+    new_content = pyproject.read_text()
+    # The feature level, not the patch release.
+    assert 'python_version = "3.14"' in new_content
+    assert '"3.10"' not in new_content
+    # A python_version in a later table is left alone -- only [tool.mypy] itself
+    # is rewritten.
+    assert 'python_version = "1.0"' in new_content
+
+
+def test_sync_mypy_python_version_noop_when_in_sync(
+    update_module, tmp_path, monkeypatch
+):
+    initial = PYPROJECT_TEMPLATE.format(python_version="3.14")
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(initial)
+    mtime_before = pyproject.stat().st_mtime_ns
+
+    monkeypatch.setattr(update_module, "ROOT", tmp_path)
+    _patch_conda_python(update_module, monkeypatch, "3.14.7")
+
+    update_module.sync_mypy_python_version()
+
+    assert pyproject.read_text() == initial
+    # File should not have been rewritten when nothing changed.
+    assert pyproject.stat().st_mtime_ns == mtime_before
+
+
+def test_sync_mypy_python_version_raises_when_python_missing_from_env(
+    update_module, tmp_path, monkeypatch
+):
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(PYPROJECT_TEMPLATE.format(python_version="3.10"))
+    monkeypatch.setattr(update_module, "ROOT", tmp_path)
+    monkeypatch.setattr(
+        update_module,
+        "_query_conda_versions",
+        lambda env_name="openwpm": {"mypy": "1.19.1"},
+    )
+
+    with pytest.raises(RuntimeError, match="python not found"):
+        update_module.sync_mypy_python_version()
+
+
+def test_sync_mypy_python_version_raises_when_section_missing(
+    update_module, tmp_path, monkeypatch
+):
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text("[tool.black]\nline-length = 88\n")
+    monkeypatch.setattr(update_module, "ROOT", tmp_path)
+    _patch_conda_python(update_module, monkeypatch, "3.14.7")
+
+    with pytest.raises(RuntimeError, match=r"\[tool\.mypy\]"):
+        update_module.sync_mypy_python_version()
+
+
+def test_sync_mypy_python_version_raises_when_setting_missing(
+    update_module, tmp_path, monkeypatch
+):
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text("[tool.mypy]\nwarn_unused_configs = true\n")
+    monkeypatch.setattr(update_module, "ROOT", tmp_path)
+    _patch_conda_python(update_module, monkeypatch, "3.14.7")
+
+    with pytest.raises(RuntimeError, match="python_version"):
+        update_module.sync_mypy_python_version()
 
 
 def test_query_conda_versions_raises_when_conda_missing(update_module, monkeypatch):


### PR DESCRIPTION
## The symptom

`mypy openwpm` died in the conda env on numpy's own `__init__.pyi` — *"Type statement is only supported in Python 3.12 and greater"* — before checking a single OpenWPM file, while CI stayed green. Both halves of that were bugs.

## `python_version` was stale

`[tool.mypy] python_version` said `3.10` while `environment.yaml` pins Python 3.14.7.

mypy applies that setting to the third-party stubs it follows, not just to our own code, so a stale value breaks on any dependency using newer syntax. It also meant the project was being type-checked at an older language level than it actually ships.

Set to `3.14`, and `scripts/update.py` gains `sync_mypy_python_version` so a repin can't leave it behind again — alongside the existing pre-commit-rev and `engines.node` syncs. It rewrites only the `[tool.mypy]` table and fails loud if the section or the setting is missing, matching the convention of the other sync helpers.

## CI missed it because the hook didn't run in this environment

`mirrors-mypy` installs mypy into its own venv, so it saw only the four packages named in `additional_dependencies` and never resolved numpy at all. That list was a second, hand-maintained copy of the dependency set — and the config comment already conceded the treadmill (*"We may need to add more and more dependencies here"*). Everything not on it degraded to `Any`, so the hook was passing largely by not looking.

mypy now runs as a `language: system` hook. The `pre-commit` CI job already sets up the conda env, so no workflow change was needed, and it now type-checks against the packages the project actually installs and their bundled type information.

- **The version is unchanged**: `environment.yaml` pins `mypy=2.3.1`, the same release the removed `rev: v2.3.1` pointed at. It's now pinned in one place instead of two.
- That's also why mypy comes out of `update.py`'s `_LINTER_MAP`: a system hook has no rev to sync, and leaving it there would make the next repin raise. A regression test pins that.
- `--scripts-are-modules` is carried over from the mirrors-mypy hook definition and is load-bearing: without it a file with a shebang is named `__main__`, which the `module = "test.*"` overrides would not match. `test/test_http_instrumentation.py` has one.
- `--ignore-missing-imports`, also inherited, is dropped because `pyproject.toml` already sets it.

## Verification

No new errors surface: mypy in the conda env over all tracked Python files is clean. `test/test_update_script.py` grows from 9 to 15 tests, covering the new sync helper (update, no-op-without-rewriting, missing python, missing section, missing setting) plus a regression test asserting mypy stays out of `_LINTER_MAP`.

Split out of #1230, where it was unrelated noise.
